### PR TITLE
feat(sumo-tui): Phase 2 — layout + compositor MVP

### DIFF
--- a/docs/visual/sumo-tui-flex-splash.tape
+++ b/docs/visual/sumo-tui-flex-splash.tape
@@ -1,0 +1,32 @@
+# sumo-tui Phase 2 flex splash proof.
+#
+# Boots a tiny Phase 2 demo extension that renders a Yoga column with:
+#   flex spacer / PiEditorLeaf splash / flex spacer / Pi Text footer.
+# The footer is pinned by Yoga at the bottom; there is no manual padding math.
+
+Output docs/visual/out/sumo-tui-flex-splash.png
+
+Set Shell zsh
+Set FontFamily "JetBrainsMono Nerd Font Mono"
+Set FontSize 14
+Set Width 1200
+Set Height 900
+Set Padding 10
+Set TypingSpeed 20ms
+
+Type "cd '/Volumes/SumoDeus NVMe/openclaw/workspace/worktrees/sumocode-phase-2'"
+Enter
+Sleep 250ms
+
+Type "clear"
+Enter
+Sleep 100ms
+
+Type "pi --offline --no-extensions -e ./src/sumo-tui/demo/flex-splash-extension.ts --no-session"
+Enter
+Sleep 3s
+
+Screenshot docs/visual/out/sumo-tui-flex-splash.png
+
+Ctrl+C
+Sleep 500ms

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@mariozechner/pi-tui": "0.70.2",
     "@types/node": "^25.6.0",
     "node-pty": "^1.1.0",
+    "typebox": "1.1.33",
     "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   },
@@ -45,5 +46,8 @@
     "test:integration": "vitest run test/integration/",
     "vitest": "vitest",
     "visual": "node scripts/visual.mjs"
+  },
+  "dependencies": {
+    "yoga-wasm-web": "^0.3.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      typebox:
-        specifier: '*'
-        version: 1.1.33
+      yoga-wasm-web:
+        specifier: ^0.3.3
+        version: 0.3.3
     devDependencies:
       '@mariozechner/pi-ai':
         specifier: 0.70.2
@@ -27,6 +27,9 @@ importers:
       node-pty:
         specifier: ^1.1.0
         version: 1.1.0
+      typebox:
+        specifier: 1.1.33
+        version: 1.1.33
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -1494,6 +1497,9 @@ packages:
   yoctocolors@2.1.2:
     resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
+
+  yoga-wasm-web@0.3.3:
+    resolution: {integrity: sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -3256,6 +3262,8 @@ snapshots:
       fd-slicer: 1.1.0
 
   yoctocolors@2.1.2: {}
+
+  yoga-wasm-web@0.3.3: {}
 
   zod-to-json-schema@3.25.2(zod@4.3.6):
     dependencies:

--- a/src/sumo-tui/demo/flex-splash-extension.ts
+++ b/src/sumo-tui/demo/flex-splash-extension.ts
@@ -1,0 +1,60 @@
+import type { CustomEditor, ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { CURSOR_MARKER, Text, visibleWidth, type Component } from "@mariozechner/pi-tui";
+import { SumoNode } from "../layout/node.js";
+import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga } from "../layout/yoga.js";
+import { bufferToAnsiLines } from "../render/ansi-writer.js";
+import { CellBuffer } from "../render/buffer.js";
+import { composite } from "../render/compositor.js";
+import { installLifecycle } from "../runtime/lifecycle.js";
+import { PiComponentLeaf } from "../widgets/pi-component-leaf.js";
+import { PiEditorLeaf } from "../widgets/pi-editor-leaf.js";
+
+class SplashEditor implements Component {
+	public invalidate(): void {}
+	public render(width: number): string[] {
+		const prompt = `sumo-tui Phase 2 ${CURSOR_MARKER}`;
+		const pad = Math.max(0, Math.floor((width - visibleWidth(prompt)) / 2));
+		return [" ".repeat(pad) + prompt, "", "Yoga flex centers this editor leaf."];
+	}
+}
+
+function asEditor(component: Component): CustomEditor {
+	return component as unknown as CustomEditor;
+}
+
+async function renderSplash(): Promise<void> {
+	const cols = process.stdout.columns ?? 80;
+	const rows = process.stdout.rows ?? 24;
+	const yoga = await loadYoga();
+	const root = new SumoNode(yoga.Node.create());
+	const topSpacer = new SumoNode(yoga.Node.create(), root);
+	const editor = new PiEditorLeaf(yoga.Node.create(), asEditor(new SplashEditor()), root);
+	const bottomSpacer = new SumoNode(yoga.Node.create(), root);
+	const footer = PiComponentLeaf.create(yoga, new Text("footer pinned by Yoga flex", 0, 0), root);
+
+	root.width = cols;
+	root.height = rows;
+	root.flexDirection = FLEX_DIRECTION_COLUMN;
+	topSpacer.flexGrow = 1;
+	topSpacer.flexShrink = 1;
+	editor.height = 3;
+	bottomSpacer.flexGrow = 1;
+	bottomSpacer.flexShrink = 1;
+	footer.height = 1;
+
+	root.yogaNode.calculateLayout(cols, rows, DIRECTION_LTR);
+	const buffer = new CellBuffer(rows, cols);
+	const result = composite(root, buffer);
+	const frame = bufferToAnsiLines(buffer).join("\r\n");
+	const cursor = result.hardwareCursor ? `\x1b[${result.hardwareCursor.row + 1};${result.hardwareCursor.col + 1}H` : "";
+	process.stdout.write(`\x1b[?2026h\x1b[2J\x1b[H${frame}${cursor}\x1b[?2026l`);
+	root.dispose();
+}
+
+export default function sumoTuiPhase2Splash(pi: ExtensionAPI): void {
+	installLifecycle(pi);
+	pi.on("session_start", (_event, ctx) => {
+		if (!ctx.hasUI) return;
+		void renderSplash();
+	});
+}

--- a/src/sumo-tui/layout/node.test.ts
+++ b/src/sumo-tui/layout/node.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import { SumoNode } from "./node.js";
+import { FLEX_DIRECTION_COLUMN, DIRECTION_LTR, freeRecursive, loadYoga, type YogaNode } from "./yoga.js";
+
+interface MockYogaNode {
+	children: MockYogaNode[];
+	freed: boolean;
+	getChildCount(): number;
+	getChild(index: number): MockYogaNode;
+	removeChild(child: MockYogaNode): void;
+	free(): void;
+}
+
+function mockYogaNode(children: MockYogaNode[] = []): MockYogaNode {
+	return {
+		children,
+		freed: false,
+		getChildCount() {
+			return this.children.length;
+		},
+		getChild(index: number) {
+			return this.children[index]!;
+		},
+		removeChild(child: MockYogaNode) {
+			this.children = this.children.filter((candidate) => candidate !== child);
+		},
+		free() {
+			this.freed = true;
+		},
+	};
+}
+
+describe("SumoNode", () => {
+	it("sets Yoga props, adds children, calculates layout, and exposes computed boxes", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const header = new SumoNode(yoga.Node.create());
+		const body = new SumoNode(yoga.Node.create());
+
+		root.width = 80;
+		root.height = 24;
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		header.height = 3;
+		body.flexGrow = 1;
+		body.flexShrink = 1;
+		root.addChild(header);
+		root.addChild(body);
+
+		root.yogaNode.calculateLayout(80, 24, DIRECTION_LTR);
+
+		expect(header.getComputedTop()).toBe(0);
+		expect(header.getComputedHeight()).toBe(3);
+		expect(body.getComputedTop()).toBe(3);
+		expect(body.getComputedHeight()).toBe(21);
+
+		root.dispose();
+	});
+
+	it("freeRecursive walks children and frees Yoga FFI resources", () => {
+		const grandchild = mockYogaNode();
+		const child = mockYogaNode([grandchild]);
+		const root = mockYogaNode([child]);
+
+		freeRecursive(root as unknown as YogaNode);
+
+		expect(root.freed).toBe(true);
+		expect(child.freed).toBe(true);
+		expect(grandchild.freed).toBe(true);
+		expect(root.children).toEqual([]);
+		expect(child.children).toEqual([]);
+	});
+
+	it("disposes wrapper trees idempotently", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const child = new SumoNode(yoga.Node.create(), root);
+
+		expect(root.children).toHaveLength(1);
+		root.dispose();
+		root.dispose();
+		expect(child.children).toHaveLength(0);
+	});
+
+	it("allocates and frees 1k Yoga nodes without leaking wrappers (EC-9.2)", async () => {
+		const yoga = await loadYoga();
+		for (let index = 0; index < 1_000; index += 1) {
+			const root = new SumoNode(yoga.Node.create());
+			const child = new SumoNode(yoga.Node.create(), root);
+			root.width = 10;
+			child.height = 1;
+			root.yogaNode.calculateLayout(10, 1, DIRECTION_LTR);
+			root.dispose();
+			expect(root.children).toHaveLength(0);
+		}
+	});
+});

--- a/src/sumo-tui/layout/node.ts
+++ b/src/sumo-tui/layout/node.ts
@@ -1,0 +1,228 @@
+import {
+	EDGE_BOTTOM,
+	EDGE_LEFT,
+	EDGE_RIGHT,
+	EDGE_TOP,
+	POSITION_TYPE_ABSOLUTE,
+	POSITION_TYPE_RELATIVE,
+	POSITION_TYPE_STATIC,
+	freeRecursive,
+	type Align,
+	type Edge,
+	type FlexDirection,
+	type Justify,
+	type MeasureFunction,
+	type PositionType,
+	type YogaNode,
+} from "./yoga.js";
+
+export type SumoNodePosition = "absolute" | "relative" | "static" | PositionType;
+export type SumoNodeSize = number | `${number}%`;
+
+export interface SumoNodeEventHandlers {
+	onMouseDown?: (node: SumoNode, event: unknown) => void;
+	onMouseUp?: (node: SumoNode, event: unknown) => void;
+	onMouseMove?: (node: SumoNode, event: unknown) => void;
+	onScroll?: (node: SumoNode, event: unknown) => void;
+}
+
+function assertFiniteLayoutNumber(value: number): number {
+	if (!Number.isFinite(value)) return 0;
+	return Math.max(0, Math.round(value));
+}
+
+function toPositionType(position: SumoNodePosition): PositionType {
+	if (position === "absolute") return POSITION_TYPE_ABSOLUTE;
+	if (position === "relative") return POSITION_TYPE_RELATIVE;
+	if (position === "static") return POSITION_TYPE_STATIC;
+	return position;
+}
+
+/**
+ * Retained sumo-tui layout node. It owns one Yoga FFI node and mirrors the
+ * JS-side child graph so renderer/compositor passes can walk without poking at
+ * Yoga internals.
+ */
+export class SumoNode {
+	public readonly yogaNode: YogaNode;
+	public readonly eventHandlers: SumoNodeEventHandlers;
+	public zIndex = 0;
+	private parentNode: SumoNode | undefined;
+	private readonly childNodes: SumoNode[] = [];
+	private disposed = false;
+	private hasMeasureFunction = false;
+
+	public constructor(yogaNode: YogaNode, parent?: SumoNode, eventHandlers: SumoNodeEventHandlers = {}) {
+		this.yogaNode = yogaNode;
+		this.eventHandlers = eventHandlers;
+		if (parent) parent.addChild(this);
+	}
+
+	public get parent(): SumoNode | undefined {
+		return this.parentNode;
+	}
+
+	public get children(): readonly SumoNode[] {
+		return this.childNodes;
+	}
+
+	public set width(value: SumoNodeSize) {
+		this.yogaNode.setWidth(value);
+	}
+
+	public set height(value: SumoNodeSize) {
+		this.yogaNode.setHeight(value);
+	}
+
+	public set flexGrow(value: number) {
+		this.yogaNode.setFlexGrow(value);
+	}
+
+	public set flexShrink(value: number) {
+		this.yogaNode.setFlexShrink(value);
+	}
+
+	public set flexDirection(value: FlexDirection) {
+		this.yogaNode.setFlexDirection(value);
+	}
+
+	public set justifyContent(value: Justify) {
+		this.yogaNode.setJustifyContent(value);
+	}
+
+	public set alignItems(value: Align) {
+		this.yogaNode.setAlignItems(value);
+	}
+
+	public set paddingTop(value: number) {
+		this.yogaNode.setPadding(EDGE_TOP, value);
+	}
+
+	public set paddingRight(value: number) {
+		this.yogaNode.setPadding(EDGE_RIGHT, value);
+	}
+
+	public set paddingBottom(value: number) {
+		this.yogaNode.setPadding(EDGE_BOTTOM, value);
+	}
+
+	public set paddingLeft(value: number) {
+		this.yogaNode.setPadding(EDGE_LEFT, value);
+	}
+
+	public set marginTop(value: number) {
+		this.yogaNode.setMargin(EDGE_TOP, value);
+	}
+
+	public set marginRight(value: number) {
+		this.yogaNode.setMargin(EDGE_RIGHT, value);
+	}
+
+	public set marginBottom(value: number) {
+		this.yogaNode.setMargin(EDGE_BOTTOM, value);
+	}
+
+	public set marginLeft(value: number) {
+		this.yogaNode.setMargin(EDGE_LEFT, value);
+	}
+
+	public set position(value: SumoNodePosition) {
+		this.yogaNode.setPositionType(toPositionType(value));
+	}
+
+	public set top(value: number) {
+		this.yogaNode.setPosition(EDGE_TOP, value);
+	}
+
+	public set left(value: number) {
+		this.yogaNode.setPosition(EDGE_LEFT, value);
+	}
+
+	public set right(value: number) {
+		this.yogaNode.setPosition(EDGE_RIGHT, value);
+	}
+
+	public set bottom(value: number) {
+		this.yogaNode.setPosition(EDGE_BOTTOM, value);
+	}
+
+	public addChild(node: SumoNode): void {
+		this.assertNotDisposed();
+		node.assertNotDisposed();
+		if (node.parentNode === this) return;
+		if (node.parentNode) node.parentNode.removeChild(node);
+		node.parentNode = this;
+		this.childNodes.push(node);
+		this.yogaNode.insertChild(node.yogaNode, this.childNodes.length - 1);
+	}
+
+	public removeChild(node: SumoNode): void {
+		const index = this.childNodes.indexOf(node);
+		if (index === -1) return;
+		this.childNodes.splice(index, 1);
+		node.parentNode = undefined;
+		this.yogaNode.removeChild(node.yogaNode);
+	}
+
+	public markDirty(): void {
+		this.assertNotDisposed();
+		// Yoga aborts if markDirty() is called on non-measured nodes. SumoNode is
+		// public API, so make generic nodes a safe no-op while measured leaves can
+		// still invalidate their cached dimensions.
+		if (!this.hasMeasureFunction) return;
+		this.yogaNode.markDirty();
+	}
+
+	public dispose(): void {
+		if (this.disposed) return;
+		if (this.parentNode) this.parentNode.removeChild(this);
+		this.markWrapperDisposedRecursive();
+		freeRecursive(this.yogaNode);
+	}
+
+	public getComputedTop(): number {
+		return assertFiniteLayoutNumber(this.yogaNode.getComputedTop());
+	}
+
+	public getComputedLeft(): number {
+		return assertFiniteLayoutNumber(this.yogaNode.getComputedLeft());
+	}
+
+	public getComputedWidth(): number {
+		return assertFiniteLayoutNumber(this.yogaNode.getComputedWidth());
+	}
+
+	public getComputedHeight(): number {
+		return assertFiniteLayoutNumber(this.yogaNode.getComputedHeight());
+	}
+
+	public getPositionType(): PositionType {
+		return this.yogaNode.getPositionType();
+	}
+
+	protected setMeasureFunc(measureFunc: MeasureFunction | null): void {
+		this.hasMeasureFunction = measureFunc !== null;
+		this.yogaNode.setMeasureFunc(measureFunc);
+	}
+
+	protected assertNotDisposed(): void {
+		if (this.disposed) throw new Error("SumoNode has been disposed");
+	}
+
+	private markWrapperDisposedRecursive(): void {
+		this.disposed = true;
+		for (const child of this.childNodes) {
+			child.parentNode = undefined;
+			child.markWrapperDisposedRecursive();
+		}
+		this.childNodes.length = 0;
+		this.parentNode = undefined;
+	}
+}
+
+export function edgeForSide(side: "top" | "right" | "bottom" | "left"): Edge {
+	if (side === "top") return EDGE_TOP;
+	if (side === "right") return EDGE_RIGHT;
+	if (side === "bottom") return EDGE_BOTTOM;
+	return EDGE_LEFT;
+}

--- a/src/sumo-tui/layout/yoga.ts
+++ b/src/sumo-tui/layout/yoga.ts
@@ -1,0 +1,111 @@
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import initYoga from "yoga-wasm-web";
+import type {
+	Align,
+	Edge,
+	FlexDirection,
+	Justify,
+	MeasureMode,
+	Node as YogaNode,
+	PositionType,
+	Yoga,
+} from "yoga-wasm-web";
+
+export type {
+	Align,
+	Direction,
+	Edge,
+	FlexDirection,
+	Justify,
+	MeasureFunction,
+	MeasureMode,
+	Node as YogaNode,
+	PositionType,
+	Yoga,
+} from "yoga-wasm-web";
+
+export {
+	ALIGN_AUTO,
+	ALIGN_BASELINE,
+	ALIGN_CENTER,
+	ALIGN_FLEX_END,
+	ALIGN_FLEX_START,
+	ALIGN_SPACE_AROUND,
+	ALIGN_SPACE_BETWEEN,
+	ALIGN_STRETCH,
+	DIRECTION_INHERIT,
+	DIRECTION_LTR,
+	DIRECTION_RTL,
+	EDGE_ALL,
+	EDGE_BOTTOM,
+	EDGE_END,
+	EDGE_HORIZONTAL,
+	EDGE_LEFT,
+	EDGE_RIGHT,
+	EDGE_START,
+	EDGE_TOP,
+	EDGE_VERTICAL,
+	FLEX_DIRECTION_COLUMN,
+	FLEX_DIRECTION_COLUMN_REVERSE,
+	FLEX_DIRECTION_ROW,
+	FLEX_DIRECTION_ROW_REVERSE,
+	JUSTIFY_CENTER,
+	JUSTIFY_FLEX_END,
+	JUSTIFY_FLEX_START,
+	JUSTIFY_SPACE_AROUND,
+	JUSTIFY_SPACE_BETWEEN,
+	JUSTIFY_SPACE_EVENLY,
+	MEASURE_MODE_AT_MOST,
+	MEASURE_MODE_EXACTLY,
+	MEASURE_MODE_UNDEFINED,
+	POSITION_TYPE_ABSOLUTE,
+	POSITION_TYPE_RELATIVE,
+	POSITION_TYPE_STATIC,
+} from "yoga-wasm-web";
+
+export type SumoYogaNode = YogaNode;
+export type SumoYoga = Yoga;
+export type SumoYogaEdge = Edge;
+export type SumoYogaFlexDirection = FlexDirection;
+export type SumoYogaJustify = Justify;
+export type SumoYogaAlign = Align;
+export type SumoYogaPositionType = PositionType;
+export type SumoYogaMeasureMode = MeasureMode;
+
+let yogaPromise: Promise<Yoga> | undefined;
+
+/**
+ * Load `yoga-wasm-web` once and share the WASM module across the renderer.
+ *
+ * Source note: Phase 2 deliberately uses `yoga-wasm-web` (pure WASM, no native
+ * build step) per the issue's Edge Case 11.1 gate. The package's default export
+ * is async, so this caches the initialized module on first use.
+ */
+export function loadYoga(): Promise<Yoga> {
+	if (!yogaPromise) {
+		const require = createRequire(import.meta.url);
+		const wasmPath = require.resolve("yoga-wasm-web/dist/yoga.wasm");
+		yogaPromise = readFile(wasmPath).then((wasm) => initYoga(wasm));
+	}
+	return yogaPromise;
+}
+
+/**
+ * Free a Yoga node and all descendants without relying on the binding's
+ * built-in `freeRecursive()`. Walking children ourselves makes leak tests able
+ * to mock the FFI surface and verifies Edge Case 9.2 explicitly.
+ */
+export function freeRecursive(node: YogaNode): void {
+	const children: YogaNode[] = [];
+	for (let index = 0; index < node.getChildCount(); index += 1) {
+		children.push(node.getChild(index));
+	}
+
+	for (const child of children) {
+		node.removeChild(child);
+		freeRecursive(child);
+	}
+
+	node.free();
+}

--- a/src/sumo-tui/render/ansi-writer.test.ts
+++ b/src/sumo-tui/render/ansi-writer.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { CellBuffer } from "./buffer.js";
+import { createAttrs } from "./cell.js";
+import { bufferToAnsiLines, cellRowToAnsi } from "./ansi-writer.js";
+
+describe("ANSI writer", () => {
+	it("emits plain rows without style noise", () => {
+		const buffer = new CellBuffer(1, 5);
+		buffer.paintRow(0, "hello");
+		expect(cellRowToAnsi(buffer, 0)).toBe("hello");
+	});
+
+	it("RLE-compresses repeated styles and resets when style changes", () => {
+		const buffer = new CellBuffer(1, 3);
+		buffer.setCell(0, 0, { char: "a", fg: "#ff0000", attrs: createAttrs({ bold: true }) });
+		buffer.setCell(0, 1, { char: "b", fg: "#ff0000", attrs: createAttrs({ bold: true }) });
+		buffer.setCell(0, 2, { char: "c", attrs: createAttrs() });
+
+		expect(cellRowToAnsi(buffer, 0)).toBe("\x1b[1;38;2;255;0;0mab\x1b[0mc");
+	});
+
+	it("does not emit continuation cells for wide glyphs", () => {
+		const buffer = new CellBuffer(1, 4);
+		buffer.paintRow(0, "界x");
+		expect(cellRowToAnsi(buffer, 0)).toBe("界x ");
+	});
+
+	it("serializes all rows", () => {
+		const buffer = new CellBuffer(2, 2);
+		buffer.paintRow(0, "aa");
+		buffer.paintRow(1, "bb");
+		expect(bufferToAnsiLines(buffer)).toEqual(["aa", "bb"]);
+	});
+});

--- a/src/sumo-tui/render/ansi-writer.ts
+++ b/src/sumo-tui/render/ansi-writer.ts
@@ -1,0 +1,77 @@
+import { visibleWidth } from "@mariozechner/pi-tui";
+import type { Cell, CellAttrs } from "./cell.js";
+import { attrsEqual, createAttrs } from "./cell.js";
+import type { CellBuffer } from "./buffer.js";
+
+interface StyleState {
+	fg?: string;
+	bg?: string;
+	attrs: CellAttrs;
+}
+
+const DEFAULT_STYLE: StyleState = { attrs: createAttrs() };
+
+function parseHexColor(color: string | undefined): [number, number, number] | undefined {
+	if (!color) return undefined;
+	const hex = color.startsWith("#") ? color.slice(1) : color;
+	if (!/^[0-9a-fA-F]{6}$/.test(hex)) return undefined;
+	return [Number.parseInt(hex.slice(0, 2), 16), Number.parseInt(hex.slice(2, 4), 16), Number.parseInt(hex.slice(4, 6), 16)];
+}
+
+function styleEqual(left: StyleState, right: StyleState): boolean {
+	return left.fg === right.fg && left.bg === right.bg && attrsEqual(left.attrs, right.attrs);
+}
+
+function styleFromCell(cell: Cell): StyleState {
+	return { fg: cell.fg, bg: cell.bg, attrs: createAttrs(cell.attrs) };
+}
+
+function sgrForStyle(style: StyleState): string {
+	const codes: string[] = [];
+	if (style.attrs.bold) codes.push("1");
+	if (style.attrs.dim) codes.push("2");
+	if (style.attrs.italic) codes.push("3");
+	if (style.attrs.underline) codes.push("4");
+	if (style.attrs.inverse) codes.push("7");
+	const fg = parseHexColor(style.fg);
+	if (fg) codes.push(`38;2;${fg[0]};${fg[1]};${fg[2]}`);
+	const bg = parseHexColor(style.bg);
+	if (bg) codes.push(`48;2;${bg[0]};${bg[1]};${bg[2]}`);
+	return codes.length === 0 ? "\x1b[0m" : `\x1b[${codes.join(";")}m`;
+}
+
+function isDefaultStyle(style: StyleState): boolean {
+	return styleEqual(style, DEFAULT_STYLE);
+}
+
+/** Convert one retained cell row into an ANSI string, emitting SGR only when style changes. */
+export function cellRowToAnsi(buffer: CellBuffer, row: number): string {
+	const { cols } = buffer.getDimensions();
+	let output = "";
+	let current: StyleState = DEFAULT_STYLE;
+	let styled = false;
+
+	for (let col = 0; col < cols; col += 1) {
+		const cell = buffer.getCell(row, col);
+		if (cell.char === "") continue;
+		const nextStyle = styleFromCell(cell);
+		if (!styleEqual(current, nextStyle)) {
+			output += sgrForStyle(nextStyle);
+			current = nextStyle;
+			styled = !isDefaultStyle(nextStyle);
+		}
+		output += cell.char;
+		const width = visibleWidth(cell.char);
+		if (width > 1) col += width - 1;
+	}
+
+	if (styled) output += "\x1b[0m";
+	return output;
+}
+
+export function bufferToAnsiLines(buffer: CellBuffer): string[] {
+	const { rows } = buffer.getDimensions();
+	const lines: string[] = [];
+	for (let row = 0; row < rows; row += 1) lines.push(cellRowToAnsi(buffer, row));
+	return lines;
+}

--- a/src/sumo-tui/render/buffer.test.ts
+++ b/src/sumo-tui/render/buffer.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { CellBuffer } from "./buffer.js";
+import { createAttrs } from "./cell.js";
+
+describe("CellBuffer", () => {
+	it("sets, gets, clears, and paints cells", () => {
+		const buffer = new CellBuffer(3, 5);
+		buffer.setCell(1, 2, { char: "x", fg: "#112233", attrs: createAttrs({ bold: true }) });
+		expect(buffer.getCell(1, 2)).toMatchObject({ char: "x", fg: "#112233", attrs: { bold: true } });
+
+		buffer.paint({ top: 0, left: 0, width: 2, height: 2 }, { char: ".", attrs: createAttrs() });
+		expect(buffer.toPlainRow(0).slice(0, 2)).toBe("..");
+		buffer.clear({ top: 0, left: 0, width: 1, height: 1 });
+		expect(buffer.getCell(0, 0).char).toBe(" ");
+	});
+
+	it("paints ANSI rows into cells while preserving styles", () => {
+		const buffer = new CellBuffer(1, 8);
+		buffer.paintRow(0, "a\x1b[31;1mb\x1b[0mc");
+
+		expect(buffer.toPlainRow(0).slice(0, 3)).toBe("abc");
+		expect(buffer.getCell(0, 1).fg).toBe("#800000");
+		expect(buffer.getCell(0, 1).attrs.bold).toBe(true);
+		expect(buffer.getCell(0, 2).fg).toBeUndefined();
+	});
+
+	it("handles wide characters with Pi visibleWidth semantics (EC-12.x)", () => {
+		const buffer = new CellBuffer(1, 6);
+		buffer.paintRow(0, "a界b");
+
+		expect(buffer.getCell(0, 0).char).toBe("a");
+		expect(buffer.getCell(0, 1).char).toBe("界");
+		expect(buffer.getCell(0, 2).char).toBe("");
+		expect(buffer.getCell(0, 3).char).toBe("b");
+	});
+
+	it("resizes while preserving overlapping cells (EC-3.1)", () => {
+		const buffer = new CellBuffer(2, 4);
+		buffer.paintRow(0, "abcd");
+		buffer.paintRow(1, "efgh");
+		buffer.resize(3, 2);
+
+		expect(buffer.getDimensions()).toEqual({ rows: 3, cols: 2 });
+		expect(buffer.toPlainRow(0)).toBe("ab");
+		expect(buffer.toPlainRow(1)).toBe("ef");
+		expect(buffer.toPlainRow(2)).toBe("  ");
+	});
+});

--- a/src/sumo-tui/render/buffer.ts
+++ b/src/sumo-tui/render/buffer.ts
@@ -1,0 +1,372 @@
+import { visibleWidth } from "@mariozechner/pi-tui";
+import { BLANK_CELL, attrsEqual, attrsToMask, createAttrs, maskToAttrs, type Cell } from "./cell.js";
+
+export interface Rect {
+	top: number;
+	left: number;
+	width: number;
+	height: number;
+}
+
+interface TextSegmenter {
+	segment(input: string): Iterable<{ segment: string }>;
+}
+
+const SEGMENTER_CTOR = (Intl as unknown as {
+	Segmenter?: new (locale: string | undefined, options: { granularity: "grapheme" }) => TextSegmenter;
+}).Segmenter;
+
+const GRAPHEME_SEGMENTER = SEGMENTER_CTOR ? new SEGMENTER_CTOR(undefined, { granularity: "grapheme" }) : undefined;
+
+const ANSI_16: readonly string[] = [
+	"#000000",
+	"#800000",
+	"#008000",
+	"#808000",
+	"#000080",
+	"#800080",
+	"#008080",
+	"#c0c0c0",
+	"#808080",
+	"#ff0000",
+	"#00ff00",
+	"#ffff00",
+	"#0000ff",
+	"#ff00ff",
+	"#00ffff",
+	"#ffffff",
+];
+
+function splitGraphemes(text: string): string[] {
+	if (!text) return [];
+	if (!GRAPHEME_SEGMENTER) return Array.from(text);
+	return [...GRAPHEME_SEGMENTER.segment(text)].map((part) => part.segment);
+}
+
+function clampRect(rect: Rect, rows: number, cols: number): Rect {
+	const top = Math.max(0, Math.min(rows, Math.floor(rect.top)));
+	const left = Math.max(0, Math.min(cols, Math.floor(rect.left)));
+	const bottom = Math.max(top, Math.min(rows, Math.floor(rect.top + rect.height)));
+	const right = Math.max(left, Math.min(cols, Math.floor(rect.left + rect.width)));
+	return { top, left, width: right - left, height: bottom - top };
+}
+
+function normalizeHex(r: number, g: number, b: number): string {
+	const toHex = (value: number) => Math.max(0, Math.min(255, value)).toString(16).padStart(2, "0");
+	return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function indexedColor(index: number): string | undefined {
+	if (index >= 0 && index < ANSI_16.length) return ANSI_16[index];
+	if (index >= 16 && index <= 231) {
+		const value = index - 16;
+		const r = Math.floor(value / 36);
+		const g = Math.floor((value % 36) / 6);
+		const b = value % 6;
+		const cube = [0, 95, 135, 175, 215, 255];
+		return normalizeHex(cube[r] ?? 0, cube[g] ?? 0, cube[b] ?? 0);
+	}
+	if (index >= 232 && index <= 255) {
+		const gray = 8 + (index - 232) * 10;
+		return normalizeHex(gray, gray, gray);
+	}
+	return undefined;
+}
+
+function sameStyle(left: Cell, right: Cell): boolean {
+	return left.fg === right.fg && left.bg === right.bg && attrsEqual(left.attrs, right.attrs);
+}
+
+export class CellBuffer {
+	private rows: number;
+	private cols: number;
+	private chars: Uint16Array;
+	private readonly extendedChars = new Map<number, string>();
+	private readonly fg = new Map<number, string>();
+	private readonly bg = new Map<number, string>();
+	private readonly attrs = new Map<number, number>();
+
+	public constructor(rows: number, cols: number) {
+		this.rows = Math.max(0, Math.floor(rows));
+		this.cols = Math.max(0, Math.floor(cols));
+		this.chars = new Uint16Array(this.rows * this.cols);
+		this.chars.fill(32);
+	}
+
+	public getDimensions(): { rows: number; cols: number } {
+		return { rows: this.rows, cols: this.cols };
+	}
+
+	public resize(rows: number, cols: number): void {
+		const nextRows = Math.max(0, Math.floor(rows));
+		const nextCols = Math.max(0, Math.floor(cols));
+		const nextChars = new Uint16Array(nextRows * nextCols);
+		nextChars.fill(32);
+		const nextExtended = new Map<number, string>();
+		const nextFg = new Map<number, string>();
+		const nextBg = new Map<number, string>();
+		const nextAttrs = new Map<number, number>();
+		const copyRows = Math.min(this.rows, nextRows);
+		const copyCols = Math.min(this.cols, nextCols);
+
+		for (let row = 0; row < copyRows; row += 1) {
+			for (let col = 0; col < copyCols; col += 1) {
+				const oldIndex = this.index(row, col);
+				const newIndex = row * nextCols + col;
+				nextChars[newIndex] = this.chars[oldIndex] ?? 32;
+				const extended = this.extendedChars.get(oldIndex);
+				if (extended !== undefined) nextExtended.set(newIndex, extended);
+				const fg = this.fg.get(oldIndex);
+				if (fg !== undefined) nextFg.set(newIndex, fg);
+				const bg = this.bg.get(oldIndex);
+				if (bg !== undefined) nextBg.set(newIndex, bg);
+				const attrs = this.attrs.get(oldIndex);
+				if (attrs !== undefined) nextAttrs.set(newIndex, attrs);
+			}
+		}
+
+		this.rows = nextRows;
+		this.cols = nextCols;
+		this.chars = nextChars;
+		this.extendedChars.clear();
+		this.fg.clear();
+		this.bg.clear();
+		this.attrs.clear();
+		for (const [key, value] of nextExtended) this.extendedChars.set(key, value);
+		for (const [key, value] of nextFg) this.fg.set(key, value);
+		for (const [key, value] of nextBg) this.bg.set(key, value);
+		for (const [key, value] of nextAttrs) this.attrs.set(key, value);
+	}
+
+	public setCell(row: number, col: number, cell: Cell): void {
+		if (!this.inBounds(row, col)) return;
+		const glyph = cell.char.length === 0 ? " " : cell.char;
+		const width = Math.max(1, visibleWidth(glyph));
+		if (col + width > this.cols) return;
+		for (let offset = 0; offset < width; offset += 1) {
+			this.setSingleCell(row, col + offset, offset === 0 ? glyph : "", cell);
+		}
+	}
+
+	public getCell(row: number, col: number): Cell {
+		if (!this.inBounds(row, col)) return { char: BLANK_CELL.char, attrs: createAttrs() };
+		const index = this.index(row, col);
+		const stored = this.extendedChars.get(index);
+		const code = this.chars[index] ?? 32;
+		const char = stored ?? (code === 0 ? "" : String.fromCharCode(code));
+		return {
+			char,
+			fg: this.fg.get(index),
+			bg: this.bg.get(index),
+			attrs: maskToAttrs(this.attrs.get(index) ?? 0),
+		};
+	}
+
+	public clear(rect?: Rect): void {
+		const area = rect ? clampRect(rect, this.rows, this.cols) : { top: 0, left: 0, width: this.cols, height: this.rows };
+		for (let row = area.top; row < area.top + area.height; row += 1) {
+			for (let col = area.left; col < area.left + area.width; col += 1) {
+				this.clearCell(row, col);
+			}
+		}
+	}
+
+	public paint(rect: Rect, cell: Cell): void {
+		const area = clampRect(rect, this.rows, this.cols);
+		for (let row = area.top; row < area.top + area.height; row += 1) {
+			for (let col = area.left; col < area.left + area.width; col += 1) {
+				this.setCell(row, col, cell);
+			}
+		}
+	}
+
+	public paintRow(row: number, ansiString: string, startCol = 0, maxCols = this.cols - startCol): void {
+		if (row < 0 || row >= this.rows || maxCols <= 0) return;
+		let col = Math.max(0, Math.floor(startCol));
+		const endCol = Math.min(this.cols, col + Math.floor(maxCols));
+		let index = 0;
+		const style: Omit<Cell, "char"> = { attrs: createAttrs() };
+
+		while (index < ansiString.length && col < endCol) {
+			const char = ansiString[index];
+			if (char === "\x1b") {
+				index = this.consumeEscape(ansiString, index, style);
+				continue;
+			}
+
+			let nextEscape = ansiString.indexOf("\x1b", index);
+			if (nextEscape === -1) nextEscape = ansiString.length;
+			const text = ansiString.slice(index, nextEscape);
+			for (const glyph of splitGraphemes(text)) {
+				const glyphWidth = visibleWidth(glyph);
+				if (glyphWidth === 0) {
+					if (col > startCol) {
+						const previous = this.getCell(row, col - 1);
+						this.setCell(row, col - 1, { ...previous, char: previous.char + glyph });
+					}
+					continue;
+				}
+				if (col + glyphWidth > endCol) return;
+				this.setCell(row, col, { char: glyph, fg: style.fg, bg: style.bg, attrs: createAttrs(style.attrs) });
+				col += glyphWidth;
+			}
+			index = nextEscape;
+		}
+	}
+
+	public rowEquals(other: CellBuffer, row: number): boolean {
+		const dimensions = other.getDimensions();
+		if (this.cols !== dimensions.cols || row < 0 || row >= this.rows || row >= dimensions.rows) return false;
+		for (let col = 0; col < this.cols; col += 1) {
+			const left = this.getCell(row, col);
+			const right = other.getCell(row, col);
+			if (left.char !== right.char || !sameStyle(left, right)) return false;
+		}
+		return true;
+	}
+
+	public clone(): CellBuffer {
+		const next = new CellBuffer(this.rows, this.cols);
+		next.chars.set(this.chars);
+		for (const [key, value] of this.extendedChars) next.extendedChars.set(key, value);
+		for (const [key, value] of this.fg) next.fg.set(key, value);
+		for (const [key, value] of this.bg) next.bg.set(key, value);
+		for (const [key, value] of this.attrs) next.attrs.set(key, value);
+		return next;
+	}
+
+	public toPlainRow(row: number): string {
+		let result = "";
+		for (let col = 0; col < this.cols; col += 1) {
+			const cell = this.getCell(row, col);
+			result += cell.char;
+		}
+		return result;
+	}
+
+	private consumeEscape(input: string, offset: number, style: Omit<Cell, "char">): number {
+		const next = input[offset + 1];
+		if (next === "[") {
+			let end = offset + 2;
+			while (end < input.length && !/[A-Za-z~]/.test(input[end] ?? "")) end += 1;
+			if (end >= input.length) return input.length;
+			if (input[end] === "m") this.applySgr(input.slice(offset + 2, end), style);
+			return end + 1;
+		}
+		if (next === "]" || next === "_") {
+			const bel = input.indexOf("\x07", offset + 2);
+			const st = input.indexOf("\x1b\\", offset + 2);
+			const terminator = bel === -1 ? st : st === -1 ? bel : Math.min(bel, st);
+			return terminator === -1 ? input.length : terminator + (terminator === st ? 2 : 1);
+		}
+		return Math.min(input.length, offset + 2);
+	}
+
+	private applySgr(params: string, style: Omit<Cell, "char">): void {
+		const codes = params.length === 0 ? [0] : params.split(";").map((part) => (part.length === 0 ? 0 : Number.parseInt(part, 10)));
+		for (let index = 0; index < codes.length; index += 1) {
+			const code = codes[index] ?? 0;
+			if (code === 0) {
+				style.fg = undefined;
+				style.bg = undefined;
+				style.attrs = createAttrs();
+			} else if (code === 1) {
+				style.attrs.bold = true;
+			} else if (code === 2) {
+				style.attrs.dim = true;
+			} else if (code === 3) {
+				style.attrs.italic = true;
+			} else if (code === 4) {
+				style.attrs.underline = true;
+			} else if (code === 7) {
+				style.attrs.inverse = true;
+			} else if (code === 22) {
+				style.attrs.bold = false;
+				style.attrs.dim = false;
+			} else if (code === 23) {
+				style.attrs.italic = false;
+			} else if (code === 24) {
+				style.attrs.underline = false;
+			} else if (code === 27) {
+				style.attrs.inverse = false;
+			} else if (code === 39) {
+				style.fg = undefined;
+			} else if (code === 49) {
+				style.bg = undefined;
+			} else if (code >= 30 && code <= 37) {
+				style.fg = indexedColor(code - 30);
+			} else if (code >= 90 && code <= 97) {
+				style.fg = indexedColor(code - 90 + 8);
+			} else if (code >= 40 && code <= 47) {
+				style.bg = indexedColor(code - 40);
+			} else if (code >= 100 && code <= 107) {
+				style.bg = indexedColor(code - 100 + 8);
+			} else if (code === 38 || code === 48) {
+				const color = this.readExtendedColor(codes, index + 1);
+				if (color) {
+					if (code === 38) style.fg = color.value;
+					else style.bg = color.value;
+					index = color.nextIndex;
+				}
+			}
+		}
+	}
+
+	private readExtendedColor(codes: number[], offset: number): { value: string; nextIndex: number } | undefined {
+		const mode = codes[offset];
+		if (mode === 2) {
+			const r = codes[offset + 1];
+			const g = codes[offset + 2];
+			const b = codes[offset + 3];
+			if (r === undefined || g === undefined || b === undefined) return undefined;
+			return { value: normalizeHex(r, g, b), nextIndex: offset + 3 };
+		}
+		if (mode === 5) {
+			const color = indexedColor(codes[offset + 1] ?? -1);
+			return color ? { value: color, nextIndex: offset + 1 } : undefined;
+		}
+		return undefined;
+	}
+
+	private inBounds(row: number, col: number): boolean {
+		return row >= 0 && row < this.rows && col >= 0 && col < this.cols;
+	}
+
+	private index(row: number, col: number): number {
+		return row * this.cols + col;
+	}
+
+	private setSingleCell(row: number, col: number, glyph: string, source: Cell): void {
+		const index = this.index(row, col);
+		this.extendedChars.delete(index);
+		const codePoint = glyph.codePointAt(0);
+		if (glyph.length === 0) {
+			this.chars[index] = 0;
+		} else if (codePoint !== undefined && codePoint <= 0xffff && glyph.length === 1) {
+			this.chars[index] = codePoint;
+		} else {
+			this.chars[index] = 0xfffd;
+			this.extendedChars.set(index, glyph);
+		}
+		this.setStyle(index, source);
+	}
+
+	private clearCell(row: number, col: number): void {
+		const index = this.index(row, col);
+		this.chars[index] = 32;
+		this.extendedChars.delete(index);
+		this.fg.delete(index);
+		this.bg.delete(index);
+		this.attrs.delete(index);
+	}
+
+	private setStyle(index: number, source: Cell): void {
+		if (source.fg) this.fg.set(index, source.fg);
+		else this.fg.delete(index);
+		if (source.bg) this.bg.set(index, source.bg);
+		else this.bg.delete(index);
+		const mask = attrsToMask(source.attrs);
+		if (mask === 0) this.attrs.delete(index);
+		else this.attrs.set(index, mask);
+	}
+}

--- a/src/sumo-tui/render/cell.test.ts
+++ b/src/sumo-tui/render/cell.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { acquireCell, getCellPoolSize, releaseCell } from "./cell.js";
+
+describe("cell pool", () => {
+	it("recycles cell objects and resets style state (EC-9.3)", () => {
+		const before = getCellPoolSize();
+		const cell = acquireCell({ char: "x", fg: "#ff0000", attrs: { bold: true } });
+		expect(cell.char).toBe("x");
+		expect(cell.fg).toBe("#ff0000");
+		expect(cell.attrs.bold).toBe(true);
+
+		releaseCell(cell);
+		expect(getCellPoolSize()).toBe(before + 1);
+
+		const reused = acquireCell();
+		expect(reused).toBe(cell);
+		expect(reused.char).toBe(" ");
+		expect(reused.fg).toBeUndefined();
+		expect(reused.attrs.bold).toBe(false);
+		releaseCell(reused);
+	});
+});

--- a/src/sumo-tui/render/cell.ts
+++ b/src/sumo-tui/render/cell.ts
@@ -1,0 +1,93 @@
+export interface CellAttrs {
+	bold: boolean;
+	italic: boolean;
+	underline: boolean;
+	dim: boolean;
+	inverse: boolean;
+}
+
+export interface Cell {
+	char: string;
+	fg?: string;
+	bg?: string;
+	attrs: CellAttrs;
+}
+
+export const DEFAULT_CELL_ATTRS: CellAttrs = Object.freeze({
+	bold: false,
+	italic: false,
+	underline: false,
+	dim: false,
+	inverse: false,
+});
+
+export const BLANK_CELL: Cell = Object.freeze({
+	char: " ",
+	attrs: DEFAULT_CELL_ATTRS,
+});
+
+const pool: Cell[] = [];
+
+export function createAttrs(overrides: Partial<CellAttrs> = {}): CellAttrs {
+	return {
+		bold: overrides.bold ?? false,
+		italic: overrides.italic ?? false,
+		underline: overrides.underline ?? false,
+		dim: overrides.dim ?? false,
+		inverse: overrides.inverse ?? false,
+	};
+}
+
+export function attrsEqual(left: CellAttrs, right: CellAttrs): boolean {
+	return (
+		left.bold === right.bold &&
+		left.italic === right.italic &&
+		left.underline === right.underline &&
+		left.dim === right.dim &&
+		left.inverse === right.inverse
+	);
+}
+
+export function attrsToMask(attrs: CellAttrs): number {
+	return (attrs.bold ? 1 : 0) | (attrs.italic ? 2 : 0) | (attrs.underline ? 4 : 0) | (attrs.dim ? 8 : 0) | (attrs.inverse ? 16 : 0);
+}
+
+export function maskToAttrs(mask: number): CellAttrs {
+	return {
+		bold: (mask & 1) !== 0,
+		italic: (mask & 2) !== 0,
+		underline: (mask & 4) !== 0,
+		dim: (mask & 8) !== 0,
+		inverse: (mask & 16) !== 0,
+	};
+}
+
+export function normalizeCell(cell: Cell): Cell {
+	return {
+		char: cell.char.length === 0 ? " " : cell.char,
+		fg: cell.fg,
+		bg: cell.bg,
+		attrs: createAttrs(cell.attrs),
+	};
+}
+
+export function acquireCell(overrides: Partial<Omit<Cell, "attrs">> & { attrs?: Partial<CellAttrs> } = {}): Cell {
+	const cell = pool.pop() ?? { char: " ", attrs: createAttrs() };
+	cell.char = overrides.char ?? " ";
+	cell.fg = overrides.fg;
+	cell.bg = overrides.bg;
+	cell.attrs = createAttrs(overrides.attrs);
+	return cell;
+}
+
+export function releaseCell(cell: Cell): void {
+	cell.char = " ";
+	cell.fg = undefined;
+	cell.bg = undefined;
+	cell.attrs = createAttrs();
+	pool.push(cell);
+}
+
+export function getCellPoolSize(): number {
+	return pool.length;
+}

--- a/src/sumo-tui/render/compositor.test.ts
+++ b/src/sumo-tui/render/compositor.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { SumoNode } from "../layout/node.js";
+import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga, type YogaNode } from "../layout/yoga.js";
+import { CellBuffer, type Rect } from "./buffer.js";
+import { createAttrs } from "./cell.js";
+import { composite } from "./compositor.js";
+
+class PaintNode extends SumoNode {
+	public constructor(yogaNode: YogaNode, private readonly char: string, parent?: SumoNode) {
+		super(yogaNode, parent);
+	}
+
+	public render(buffer: CellBuffer, rect: Rect): void {
+		buffer.paint(rect, { char: this.char, attrs: createAttrs() });
+	}
+}
+
+describe("compositor", () => {
+	it("walks Yoga-computed flex boxes and paints leaves", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const top = new PaintNode(yoga.Node.create(), "T", root);
+		const body = new PaintNode(yoga.Node.create(), "B", root);
+		root.width = 4;
+		root.height = 4;
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		top.height = 1;
+		body.flexGrow = 1;
+		root.yogaNode.calculateLayout(4, 4, DIRECTION_LTR);
+
+		const buffer = new CellBuffer(4, 4);
+		composite(root, buffer);
+
+		expect(buffer.toPlainRow(0)).toBe("TTTT");
+		expect(buffer.toPlainRow(1)).toBe("BBBB");
+		expect(buffer.toPlainRow(3)).toBe("BBBB");
+		root.dispose();
+	});
+
+	it("sorts absolute children by z-index", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const base = new PaintNode(yoga.Node.create(), ".", root);
+		const low = new PaintNode(yoga.Node.create(), "1", root);
+		const high = new PaintNode(yoga.Node.create(), "2", root);
+		root.width = 3;
+		root.height = 1;
+		base.width = 3;
+		base.height = 1;
+		low.position = "absolute";
+		low.left = 1;
+		low.top = 0;
+		low.width = 1;
+		low.height = 1;
+		low.zIndex = 1;
+		high.position = "absolute";
+		high.left = 1;
+		high.top = 0;
+		high.width = 1;
+		high.height = 1;
+		high.zIndex = 2;
+		root.yogaNode.calculateLayout(3, 1, DIRECTION_LTR);
+
+		const buffer = new CellBuffer(1, 3);
+		composite(root, buffer);
+
+		expect(buffer.toPlainRow(0)).toBe(".2.");
+		root.dispose();
+	});
+});

--- a/src/sumo-tui/render/compositor.ts
+++ b/src/sumo-tui/render/compositor.ts
@@ -1,0 +1,73 @@
+import { POSITION_TYPE_ABSOLUTE } from "../layout/yoga.js";
+import type { SumoNode } from "../layout/node.js";
+import type { CellBuffer, Rect } from "./buffer.js";
+
+export interface HardwareCursor {
+	row: number;
+	col: number;
+}
+
+export interface CompositeResult {
+	hardwareCursor: HardwareCursor | null;
+}
+
+interface RenderableNode extends SumoNode {
+	render?: (buffer: CellBuffer, rect: Rect) => void;
+	getHardwareCursor?: () => HardwareCursor | null;
+}
+
+interface PositionedChild {
+	node: SumoNode;
+	order: number;
+}
+
+function isRenderable(node: SumoNode): node is RenderableNode {
+	return "render" in node || "getHardwareCursor" in node;
+}
+
+function nodeRect(node: SumoNode, originTop: number, originLeft: number): Rect {
+	return {
+		top: originTop + node.getComputedTop(),
+		left: originLeft + node.getComputedLeft(),
+		width: node.getComputedWidth(),
+		height: node.getComputedHeight(),
+	};
+}
+
+function collectCursor(node: SumoNode, current: HardwareCursor | null): HardwareCursor | null {
+	if (!isRenderable(node) || !node.getHardwareCursor) return current;
+	return node.getHardwareCursor() ?? current;
+}
+
+/**
+ * Composite a retained SumoNode tree into a CellBuffer.
+ *
+ * Source note: absolute origin accumulation mirrors the OpenTUI/Ink adapter's
+ * Yoga walk (`docs/spike-research/opentui-island/src/adapters/ink/index.tsx:106-123`),
+ * while the retained frame shape follows the OpenTUI host-frame model.
+ */
+export function composite(root: SumoNode, buffer: CellBuffer): CompositeResult {
+	let hardwareCursor: HardwareCursor | null = null;
+
+	function visit(node: SumoNode, originTop: number, originLeft: number): void {
+		const rect = nodeRect(node, originTop, originLeft);
+		if (isRenderable(node) && node.render) {
+			node.render(buffer, rect);
+			hardwareCursor = collectCursor(node, hardwareCursor);
+		}
+
+		const normalChildren: PositionedChild[] = [];
+		const absoluteChildren: PositionedChild[] = [];
+		node.children.forEach((child, order) => {
+			const bucket = child.getPositionType() === POSITION_TYPE_ABSOLUTE ? absoluteChildren : normalChildren;
+			bucket.push({ node: child, order });
+		});
+
+		for (const child of normalChildren) visit(child.node, rect.top, rect.left);
+		absoluteChildren.sort((left, right) => left.node.zIndex - right.node.zIndex || left.order - right.order);
+		for (const child of absoluteChildren) visit(child.node, rect.top, rect.left);
+	}
+
+	visit(root, 0, 0);
+	return { hardwareCursor };
+}

--- a/src/sumo-tui/render/diff.test.ts
+++ b/src/sumo-tui/render/diff.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { CellBuffer } from "./buffer.js";
+import { diffFrames } from "./diff.js";
+
+function frame(lines: string[]): CellBuffer {
+	const cols = Math.max(...lines.map((line) => line.length));
+	const buffer = new CellBuffer(lines.length, cols);
+	lines.forEach((line, row) => buffer.paintRow(row, line));
+	return buffer;
+}
+
+describe("frame diff", () => {
+	it("returns empty diff for unchanged frames", () => {
+		const previous = frame(["aaa", "bbb"]);
+		const next = frame(["aaa", "bbb"]);
+		expect(diffFrames(previous, next)).toEqual([]);
+	});
+
+	it("returns one row patch for one changed row", () => {
+		const previous = frame(["aaa", "bbb"]);
+		const next = frame(["aaa", "ccc"]);
+		expect(diffFrames(previous, next)).toEqual([{ row: 1, ansi: "ccc", type: "row" }]);
+	});
+
+	it("repaints all rows when dimensions change", () => {
+		const previous = frame(["aa"]);
+		const next = frame(["aa", "bb"]);
+		expect(diffFrames(previous, next)).toEqual([
+			{ row: 0, ansi: "aa", type: "row" },
+			{ row: 1, ansi: "bb", type: "row" },
+		]);
+	});
+
+	it("detects scroll-up regions instead of repainting every shifted row", () => {
+		const previous = frame(["one", "two", "tre", "for", "fiv"]);
+		const next = frame(["two", "tre", "for", "fiv", "six"]);
+		const patches = diffFrames(previous, next);
+
+		expect(patches[0]).toMatchObject({ type: "scroll", direction: "up", count: 1, top: 0, bottom: 4 });
+		expect(patches[0]?.ansi).toContain("\x1b[1;5r\x1b[1S\x1b[r");
+		expect(patches).toHaveLength(2);
+		expect(patches[1]).toEqual({ row: 4, ansi: "six", type: "row" });
+	});
+});

--- a/src/sumo-tui/render/diff.ts
+++ b/src/sumo-tui/render/diff.ts
@@ -1,0 +1,114 @@
+import type { CellBuffer } from "./buffer.js";
+import { cellRowToAnsi } from "./ansi-writer.js";
+
+export interface FrameDiffPatch {
+	row: number;
+	ansi: string;
+	type: "row" | "scroll";
+	top?: number;
+	bottom?: number;
+	count?: number;
+	direction?: "up" | "down";
+}
+
+function dimensionsEqual(prev: CellBuffer, next: CellBuffer): boolean {
+	const left = prev.getDimensions();
+	const right = next.getDimensions();
+	return left.rows === right.rows && left.cols === right.cols;
+}
+
+function rowsEqualAt(prev: CellBuffer, prevRow: number, next: CellBuffer, nextRow: number): boolean {
+	const { cols } = prev.getDimensions();
+	for (let col = 0; col < cols; col += 1) {
+		const left = prev.getCell(prevRow, col);
+		const right = next.getCell(nextRow, col);
+		if (left.char !== right.char || left.fg !== right.fg || left.bg !== right.bg) return false;
+		if (
+			left.attrs.bold !== right.attrs.bold ||
+			left.attrs.italic !== right.attrs.italic ||
+			left.attrs.underline !== right.attrs.underline ||
+			left.attrs.dim !== right.attrs.dim ||
+			left.attrs.inverse !== right.attrs.inverse
+		) {
+			return false;
+		}
+	}
+	return true;
+}
+
+function changedRowPatches(prev: CellBuffer, next: CellBuffer): FrameDiffPatch[] {
+	const { rows } = next.getDimensions();
+	const patches: FrameDiffPatch[] = [];
+	for (let row = 0; row < rows; row += 1) {
+		if (!rowsEqualAt(prev, row, next, row)) patches.push({ row, ansi: cellRowToAnsi(next, row), type: "row" });
+	}
+	return patches;
+}
+
+function scrollSequence(top: number, bottom: number, count: number, direction: "up" | "down"): string {
+	const command = direction === "up" ? "S" : "T";
+	return `\x1b[${top + 1};${bottom + 1}r\x1b[${count}${command}\x1b[r`;
+}
+
+function detectScroll(prev: CellBuffer, next: CellBuffer): FrameDiffPatch[] | null {
+	const { rows } = next.getDimensions();
+	if (rows < 2) return null;
+	const maxScroll = Math.min(3, rows - 1);
+
+	for (let count = 1; count <= maxScroll; count += 1) {
+		let shiftedUp = true;
+		for (let row = 0; row < rows - count; row += 1) {
+			if (!rowsEqualAt(prev, row + count, next, row)) {
+				shiftedUp = false;
+				break;
+			}
+		}
+		if (shiftedUp) {
+			const patches: FrameDiffPatch[] = [
+				{ row: 0, ansi: scrollSequence(0, rows - 1, count, "up"), type: "scroll", top: 0, bottom: rows - 1, count, direction: "up" },
+			];
+			for (let row = rows - count; row < rows; row += 1) patches.push({ row, ansi: cellRowToAnsi(next, row), type: "row" });
+			return patches;
+		}
+
+		let shiftedDown = true;
+		for (let row = count; row < rows; row += 1) {
+			if (!rowsEqualAt(prev, row - count, next, row)) {
+				shiftedDown = false;
+				break;
+			}
+		}
+		if (shiftedDown) {
+			const patches: FrameDiffPatch[] = [
+				{ row: 0, ansi: scrollSequence(0, rows - 1, count, "down"), type: "scroll", top: 0, bottom: rows - 1, count, direction: "down" },
+			];
+			for (let row = 0; row < count; row += 1) patches.push({ row, ansi: cellRowToAnsi(next, row), type: "row" });
+			return patches;
+		}
+	}
+
+	return null;
+}
+
+/**
+ * Compare retained frames and return changed rows only.
+ *
+ * Source: borrowed the full-repaint-on-shape-change + per-row patch structure
+ * from opentui-island `src/core/frame-diff.ts:46-86`; sumo-tui adapts that
+ * HostFrame/HostLine algorithm to CellBuffer rows and adds a small scroll
+ * detector for shifted terminal regions.
+ */
+export function diffFrames(prev: CellBuffer | null | undefined, next: CellBuffer): FrameDiffPatch[] {
+	if (!prev || !dimensionsEqual(prev, next)) {
+		const { rows } = next.getDimensions();
+		const patches: FrameDiffPatch[] = [];
+		for (let row = 0; row < rows; row += 1) patches.push({ row, ansi: cellRowToAnsi(next, row), type: "row" });
+		return patches;
+	}
+
+	const patches = changedRowPatches(prev, next);
+	if (patches.length === 0) return [];
+	const scroll = detectScroll(prev, next);
+	if (scroll && scroll.length < patches.length) return scroll;
+	return patches;
+}

--- a/src/sumo-tui/runtime/frame-scheduler.test.ts
+++ b/src/sumo-tui/runtime/frame-scheduler.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { FrameScheduler } from "./frame-scheduler.js";
+
+describe("FrameScheduler", () => {
+	it("coalesces idle render requests onto the next tick", async () => {
+		vi.useFakeTimers();
+		const render = vi.fn();
+		const scheduler = new FrameScheduler({ render });
+
+		scheduler.requestRender();
+		scheduler.requestRender();
+		expect(scheduler.getQueueDepth()).toBe(2);
+		await vi.runAllTimersAsync();
+
+		expect(render).toHaveBeenCalledTimes(1);
+		expect(scheduler.getQueueDepth()).toBe(0);
+		scheduler.dispose();
+		vi.useRealTimers();
+	});
+
+	it("drops oldest dirty tokens when backpressure queue exceeds max depth (EC-2.4)", () => {
+		vi.useFakeTimers();
+		const scheduler = new FrameScheduler({ render: () => undefined, maxQueueDepth: 3 });
+		scheduler.enterStreamingMode();
+		scheduler.requestRender();
+		scheduler.requestRender();
+		scheduler.requestRender();
+		scheduler.requestRender();
+
+		expect(scheduler.getQueueDepth()).toBe(3);
+		scheduler.dispose();
+		vi.useRealTimers();
+	});
+
+	it("renders at streaming cadence only when dirty", async () => {
+		vi.useFakeTimers();
+		const render = vi.fn();
+		const scheduler = new FrameScheduler({ render, frameIntervalMs: 16 });
+
+		scheduler.enterStreamingMode();
+		await vi.advanceTimersByTimeAsync(16);
+		expect(render).not.toHaveBeenCalled();
+		scheduler.requestRender();
+		await vi.advanceTimersByTimeAsync(16);
+		expect(render).toHaveBeenCalledTimes(1);
+		scheduler.exitStreamingMode();
+		expect(scheduler.isStreamingMode()).toBe(false);
+		scheduler.dispose();
+		vi.useRealTimers();
+	});
+});

--- a/src/sumo-tui/runtime/frame-scheduler.ts
+++ b/src/sumo-tui/runtime/frame-scheduler.ts
@@ -1,0 +1,119 @@
+export type FrameRenderCallback = () => void | Promise<void>;
+
+export interface FrameSchedulerOptions {
+	readonly render: FrameRenderCallback;
+	readonly frameIntervalMs?: number;
+	readonly maxQueueDepth?: number;
+	readonly setTimeout?: typeof setTimeout;
+	readonly clearTimeout?: typeof clearTimeout;
+}
+
+/** Adaptive renderer scheduler: event-driven when idle, 60fps coalescing while streaming. */
+export class FrameScheduler {
+	private readonly renderCallback: FrameRenderCallback;
+	private readonly frameIntervalMs: number;
+	private readonly maxQueueDepth: number;
+	private readonly setTimer: typeof setTimeout;
+	private readonly clearTimer: typeof clearTimeout;
+	private queue: number[] = [];
+	private idleTimer: ReturnType<typeof setTimeout> | undefined;
+	private streamingTimer: ReturnType<typeof setTimeout> | undefined;
+	private streaming = false;
+	private inFlight = false;
+	private sequence = 0;
+
+	public constructor(options: FrameSchedulerOptions) {
+		this.renderCallback = options.render;
+		this.frameIntervalMs = options.frameIntervalMs ?? 16;
+		this.maxQueueDepth = options.maxQueueDepth ?? 3;
+		this.setTimer = options.setTimeout ?? setTimeout;
+		this.clearTimer = options.clearTimeout ?? clearTimeout;
+	}
+
+	public requestRender(): void {
+		this.enqueueDirtyFrame();
+		if (this.streaming) {
+			this.ensureStreamingTimer();
+			return;
+		}
+		this.ensureIdleTimer();
+	}
+
+	public enterStreamingMode(): void {
+		if (this.streaming) return;
+		this.streaming = true;
+		if (this.idleTimer) {
+			this.clearTimer(this.idleTimer);
+			this.idleTimer = undefined;
+		}
+		this.ensureStreamingTimer();
+	}
+
+	public exitStreamingMode(): void {
+		if (!this.streaming) return;
+		this.streaming = false;
+		if (this.streamingTimer) {
+			this.clearTimer(this.streamingTimer);
+			this.streamingTimer = undefined;
+		}
+		if (this.queue.length > 0) this.ensureIdleTimer();
+	}
+
+	public isStreamingMode(): boolean {
+		return this.streaming;
+	}
+
+	public getQueueDepth(): number {
+		return this.queue.length;
+	}
+
+	public dispose(): void {
+		if (this.idleTimer) this.clearTimer(this.idleTimer);
+		if (this.streamingTimer) this.clearTimer(this.streamingTimer);
+		this.idleTimer = undefined;
+		this.streamingTimer = undefined;
+		this.queue = [];
+	}
+
+	private enqueueDirtyFrame(): void {
+		this.sequence += 1;
+		if (this.queue.length >= this.maxQueueDepth) this.queue.shift();
+		this.queue.push(this.sequence);
+	}
+
+	private ensureIdleTimer(): void {
+		if (this.idleTimer) return;
+		this.idleTimer = this.setTimer(() => {
+			this.idleTimer = undefined;
+			void this.flushOnce();
+		}, 0);
+	}
+
+	private ensureStreamingTimer(): void {
+		if (!this.streaming || this.streamingTimer) return;
+		this.streamingTimer = this.setTimer(() => {
+			this.streamingTimer = undefined;
+			void this.flushStreamingTick();
+		}, this.frameIntervalMs);
+	}
+
+	private async flushStreamingTick(): Promise<void> {
+		if (this.queue.length > 0) await this.flushOnce();
+		if (this.streaming) this.ensureStreamingTimer();
+	}
+
+	private async flushOnce(): Promise<void> {
+		if (this.inFlight || this.queue.length === 0) return;
+		this.inFlight = true;
+		// Coalesce all queued invalidations into the newest frame. The bounded queue
+		// still gives us Edge Case 2.4 backpressure semantics: newest state wins and
+		// old dirty tokens are dropped before memory can grow.
+		this.queue = [];
+		try {
+			await this.renderCallback();
+		} finally {
+			this.inFlight = false;
+		}
+		if (!this.streaming && this.queue.length > 0) this.ensureIdleTimer();
+	}
+}

--- a/src/sumo-tui/runtime/lifecycle.ts
+++ b/src/sumo-tui/runtime/lifecycle.ts
@@ -2,6 +2,7 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { FrameScheduler, type FrameRenderCallback } from "./frame-scheduler.js";
 import { TerminalController } from "./terminal-controller.js";
 
 export type LifecycleSignal = "SIGINT" | "SIGTERM" | "SIGHUP" | "SIGQUIT" | "SIGTSTP" | "SIGCONT";
@@ -21,10 +22,17 @@ export interface LifecycleInput {
 	setRawMode?(enabled: boolean): void;
 }
 
+export interface LifecycleRenderControls {
+	scheduleRender(): void;
+	setStreamingMode(enabled: boolean): void;
+}
+
 export interface LifecycleRuntimeOptions {
 	readonly controller?: TerminalController;
 	readonly process?: LifecycleProcess;
 	readonly input?: LifecycleInput;
+	readonly scheduler?: FrameScheduler;
+	readonly render?: FrameRenderCallback;
 	readonly homeDir?: () => string;
 	readonly mkdirSync?: (path: string, options: { recursive: true }) => unknown;
 	readonly appendFileSync?: (path: string, data: string, encoding: BufferEncoding) => void;
@@ -76,6 +84,7 @@ export class LifecycleRuntime {
 	private readonly controller: TerminalController;
 	private readonly lifecycleProcess: LifecycleProcess;
 	private readonly input: LifecycleInput | undefined;
+	private readonly scheduler: FrameScheduler;
 	private readonly getHomeDir: () => string;
 	private readonly makeDir: (path: string, options: { recursive: true }) => unknown;
 	private readonly appendFile: (path: string, data: string, encoding: BufferEncoding) => void;
@@ -88,12 +97,13 @@ export class LifecycleRuntime {
 		this.controller = options.controller ?? new TerminalController();
 		this.lifecycleProcess = options.process ?? getNodeProcess();
 		this.input = options.input ?? getNodeInput();
+		this.scheduler = options.scheduler ?? new FrameScheduler({ render: options.render ?? (() => undefined) });
 		this.getHomeDir = options.homeDir ?? homedir;
 		this.makeDir = options.mkdirSync ?? mkdirSync;
 		this.appendFile = options.appendFileSync ?? appendFileSync;
 	}
 
-	public installLifecycle(pi: ExtensionAPI): void {
+	public installLifecycle(pi: ExtensionAPI): LifecycleRenderControls {
 		this.installProcessHandlers();
 
 		pi.on("session_start", (_event, ctx) => {
@@ -105,6 +115,24 @@ export class LifecycleRuntime {
 		pi.on("session_shutdown", () => {
 			this.restoreTerminal();
 		});
+
+		return this.getRenderControls();
+	}
+
+	public scheduleRender(): void {
+		this.scheduler.requestRender();
+	}
+
+	public setStreamingMode(enabled: boolean): void {
+		if (enabled) this.scheduler.enterStreamingMode();
+		else this.scheduler.exitStreamingMode();
+	}
+
+	public getRenderControls(): LifecycleRenderControls {
+		return {
+			scheduleRender: () => this.scheduleRender(),
+			setStreamingMode: (enabled) => this.setStreamingMode(enabled),
+		};
 	}
 
 	public installProcessHandlers(): void {
@@ -234,6 +262,14 @@ export function createLifecycleRuntime(options: LifecycleRuntimeOptions = {}): L
 const defaultLifecycle = createLifecycleRuntime();
 defaultLifecycle.installProcessHandlers();
 
-export function installLifecycle(pi: ExtensionAPI): void {
-	defaultLifecycle.installLifecycle(pi);
+export function installLifecycle(pi: ExtensionAPI): LifecycleRenderControls {
+	return defaultLifecycle.installLifecycle(pi);
+}
+
+export function scheduleRender(): void {
+	defaultLifecycle.scheduleRender();
+}
+
+export function setStreamingMode(enabled: boolean): void {
+	defaultLifecycle.setStreamingMode(enabled);
 }

--- a/src/sumo-tui/widgets/pi-component-leaf.test.ts
+++ b/src/sumo-tui/widgets/pi-component-leaf.test.ts
@@ -1,0 +1,87 @@
+import { Spacer, Text, type Component } from "@mariozechner/pi-tui";
+import { describe, expect, it } from "vitest";
+import { SumoNode } from "../layout/node.js";
+import { DIRECTION_LTR, loadYoga } from "../layout/yoga.js";
+import { CellBuffer } from "../render/buffer.js";
+import { composite } from "../render/compositor.js";
+import { PiComponentLeaf } from "./pi-component-leaf.js";
+
+class RowsComponent implements Component {
+	public constructor(private readonly rows: string[]) {}
+	public invalidate(): void {}
+	public render(_width: number): string[] {
+		return this.rows;
+	}
+}
+
+describe("PiComponentLeaf", () => {
+	it("wraps pi-tui Spacer and measures blank rows", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const leaf = PiComponentLeaf.create(yoga, new Spacer(3), root);
+		root.width = 5;
+		root.height = 3;
+		root.yogaNode.calculateLayout(5, 3, DIRECTION_LTR);
+
+		expect(leaf.getComputedHeight()).toBe(3);
+		const buffer = new CellBuffer(3, 5);
+		composite(root, buffer);
+		expect(buffer.toPlainRow(0)).toBe("     ");
+		expect(buffer.toPlainRow(2)).toBe("     ");
+		root.dispose();
+	});
+
+	it("wraps pi-tui Text at a Yoga-computed origin", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const leaf = PiComponentLeaf.create(yoga, new Text("hello", 0, 0), root);
+		root.width = 10;
+		root.height = 3;
+		root.paddingTop = 1;
+		root.paddingLeft = 2;
+		root.yogaNode.calculateLayout(10, 3, DIRECTION_LTR);
+
+		const buffer = new CellBuffer(3, 10);
+		composite(root, buffer);
+		expect(buffer.toPlainRow(1)).toBe("  hello   ");
+		expect(leaf.getComputedLeft()).toBe(2);
+		root.dispose();
+	});
+
+	it("returns expected measured height for varying render output (EC-1.2, EC-15.1)", async () => {
+		const yoga = await loadYoga();
+		for (const rowCount of [1, 3, 6]) {
+			const root = new SumoNode(yoga.Node.create());
+			const leaf = PiComponentLeaf.create(yoga, new RowsComponent(Array.from({ length: rowCount }, (_, index) => `row${index}`)), root);
+			root.width = 8;
+			root.yogaNode.calculateLayout(8, undefined, DIRECTION_LTR);
+			expect(leaf.getComputedHeight()).toBe(rowCount);
+			root.dispose();
+		}
+	});
+
+	it("clips render rows to the Yoga rect height (EC-15.2)", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const leaf = PiComponentLeaf.create(yoga, new RowsComponent(["one", "two", "tre"]), root);
+		root.width = 3;
+		root.height = 1;
+		leaf.height = 1;
+		root.yogaNode.calculateLayout(3, 1, DIRECTION_LTR);
+
+		const buffer = new CellBuffer(3, 3);
+		composite(root, buffer);
+		expect(buffer.toPlainRow(0)).toBe("one");
+		expect(buffer.toPlainRow(1)).toBe("   ");
+		root.dispose();
+	});
+
+	it("does not crash when Yoga measures with width=0 (EC-15.3)", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		PiComponentLeaf.create(yoga, new Text("hello", 0, 0), root);
+		root.width = 0;
+		expect(() => root.yogaNode.calculateLayout(0, undefined, DIRECTION_LTR)).not.toThrow();
+		root.dispose();
+	});
+});

--- a/src/sumo-tui/widgets/pi-component-leaf.ts
+++ b/src/sumo-tui/widgets/pi-component-leaf.ts
@@ -1,0 +1,66 @@
+import { visibleWidth, type Component } from "@mariozechner/pi-tui";
+import { SumoNode } from "../layout/node.js";
+import { MEASURE_MODE_EXACTLY, type MeasureMode, type Yoga, type YogaNode } from "../layout/yoga.js";
+import type { CellBuffer, Rect } from "../render/buffer.js";
+
+export interface PiComponentLeafMeasure {
+	width: number;
+	height: number;
+}
+
+function normalizeWidth(width: number): number {
+	if (!Number.isFinite(width)) return 0;
+	return Math.max(0, Math.floor(width));
+}
+
+function renderedWidth(rows: string[]): number {
+	let width = 0;
+	for (const row of rows) width = Math.max(width, visibleWidth(row));
+	return width;
+}
+
+/**
+ * Yoga leaf adapter for Pi's imperative `Component.render(width): string[]`
+ * contract (`docs/research/sumo-tui-spike/04-pi-tui.md`, Component section).
+ */
+export class PiComponentLeaf extends SumoNode {
+	protected readonly component: Component;
+	private measuring = false;
+	private lastMeasure: PiComponentLeafMeasure = { width: 0, height: 0 };
+
+	public constructor(yogaNode: YogaNode, component: Component, parent?: SumoNode) {
+		super(yogaNode, parent);
+		this.component = component;
+		this.setMeasureFunc((width, widthMode, height, heightMode) => this.measure(width, widthMode, height, heightMode));
+	}
+
+	public static create(yoga: Yoga, component: Component, parent?: SumoNode): PiComponentLeaf {
+		return new PiComponentLeaf(yoga.Node.create(), component, parent);
+	}
+
+	public render(buffer: CellBuffer, rect: Rect): void {
+		const rows = this.renderRows(rect.width);
+		const height = Math.min(rows.length, rect.height);
+		for (let row = 0; row < height; row += 1) {
+			buffer.paintRow(rect.top + row, rows[row] ?? "", rect.left, rect.width);
+		}
+	}
+
+	protected renderRows(width: number): string[] {
+		return this.component.render(normalizeWidth(width));
+	}
+
+	protected measure(width: number, widthMode: MeasureMode, _height: number, _heightMode: MeasureMode): PiComponentLeafMeasure {
+		if (this.measuring) return this.lastMeasure;
+		this.measuring = true;
+		try {
+			const renderWidth = normalizeWidth(width);
+			const rows = this.renderRows(renderWidth);
+			const measuredWidth = widthMode === MEASURE_MODE_EXACTLY ? renderWidth : renderedWidth(rows);
+			this.lastMeasure = { width: measuredWidth, height: rows.length };
+			return this.lastMeasure;
+		} finally {
+			this.measuring = false;
+		}
+	}
+}

--- a/src/sumo-tui/widgets/pi-editor-leaf.test.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.test.ts
@@ -1,0 +1,100 @@
+import type { CustomEditor } from "@mariozechner/pi-coding-agent";
+import { CURSOR_MARKER, type Component } from "@mariozechner/pi-tui";
+import { describe, expect, it } from "vitest";
+import { SumoNode } from "../layout/node.js";
+import { DIRECTION_LTR, loadYoga } from "../layout/yoga.js";
+import { CellBuffer } from "../render/buffer.js";
+import { composite } from "../render/compositor.js";
+import { PiEditorLeaf } from "./pi-editor-leaf.js";
+
+class FakeEditor implements Component {
+	public constructor(private readonly rows: string[]) {}
+	public invalidate(): void {}
+	public render(_width: number): string[] {
+		return this.rows;
+	}
+}
+
+function asEditor(component: Component): CustomEditor {
+	return component as unknown as CustomEditor;
+}
+
+describe("PiEditorLeaf", () => {
+	it("remaps CURSOR_MARKER from leaf-local to frame coordinates (EC-1.1)", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const leaf = new PiEditorLeaf(yoga.Node.create(), asEditor(new FakeEditor([`ab${CURSOR_MARKER}cd`])), root);
+		root.width = 10;
+		root.height = 4;
+		root.paddingTop = 2;
+		root.paddingLeft = 3;
+		leaf.height = 1;
+		root.yogaNode.calculateLayout(10, 4, DIRECTION_LTR);
+
+		const buffer = new CellBuffer(4, 10);
+		const result = composite(root, buffer);
+
+		expect(leaf.getHardwareCursor()).toEqual({ row: 2, col: 5 });
+		expect(result.hardwareCursor).toEqual({ row: 2, col: 5 });
+		expect(buffer.toPlainRow(2)).toBe("   abcd   ");
+		root.dispose();
+	});
+
+	it("tracks variable editor row counts (EC-1.2)", async () => {
+		const yoga = await loadYoga();
+		for (const rowCount of [1, 3, 6]) {
+			const root = new SumoNode(yoga.Node.create());
+			const rows = Array.from({ length: rowCount }, (_, index) => `row${index}`);
+			const leaf = new PiEditorLeaf(yoga.Node.create(), asEditor(new FakeEditor(rows)), root);
+			root.width = 8;
+			root.yogaNode.calculateLayout(8, undefined, DIRECTION_LTR);
+			expect(leaf.getComputedHeight()).toBe(rowCount);
+			root.dispose();
+		}
+	});
+
+	it("returns null when the cursor marker is scrolled out of the rendered rows (EC-1.3)", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const leaf = new PiEditorLeaf(yoga.Node.create(), asEditor(new FakeEditor(["visible only"])), root);
+		root.width = 12;
+		root.yogaNode.calculateLayout(12, undefined, DIRECTION_LTR);
+		const buffer = new CellBuffer(1, 12);
+		composite(root, buffer);
+		expect(leaf.getHardwareCursor()).toBeNull();
+		root.dispose();
+	});
+
+	it("uses visibleWidth for CJK cursor columns (EC-1.4)", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const leaf = new PiEditorLeaf(yoga.Node.create(), asEditor(new FakeEditor([`a界${CURSOR_MARKER}b`])), root);
+		root.width = 8;
+		root.yogaNode.calculateLayout(8, undefined, DIRECTION_LTR);
+
+		const buffer = new CellBuffer(1, 8);
+		composite(root, buffer);
+
+		expect(leaf.getHardwareCursor()).toEqual({ row: 0, col: 3 });
+		expect(buffer.getCell(0, 1).char).toBe("界");
+		expect(buffer.getCell(0, 2).char).toBe("");
+		root.dispose();
+	});
+
+	it("preserves ANSI underline around IME pre-edit while stripping only the marker (EC-1.5)", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const leaf = new PiEditorLeaf(yoga.Node.create(), asEditor(new FakeEditor([`\x1b[4mpre${CURSOR_MARKER}edit\x1b[0m`])), root);
+		root.width = 10;
+		root.yogaNode.calculateLayout(10, undefined, DIRECTION_LTR);
+
+		const buffer = new CellBuffer(1, 10);
+		composite(root, buffer);
+
+		expect(leaf.getHardwareCursor()).toEqual({ row: 0, col: 3 });
+		expect(buffer.toPlainRow(0).slice(0, 7)).toBe("preedit");
+		expect(buffer.getCell(0, 0).attrs.underline).toBe(true);
+		expect(buffer.getCell(0, 6).attrs.underline).toBe(true);
+		root.dispose();
+	});
+});

--- a/src/sumo-tui/widgets/pi-editor-leaf.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.ts
@@ -1,0 +1,52 @@
+import type { CustomEditor } from "@mariozechner/pi-coding-agent";
+import { CURSOR_MARKER, visibleWidth } from "@mariozechner/pi-tui";
+import type { SumoNode } from "../layout/node.js";
+import type { Yoga, YogaNode } from "../layout/yoga.js";
+import type { CellBuffer, Rect } from "../render/buffer.js";
+import { PiComponentLeaf } from "./pi-component-leaf.js";
+
+export interface HardwareCursorPosition {
+	row: number;
+	col: number;
+}
+
+/**
+ * Pi CustomEditor leaf with Q1:A cursor-marker remapping.
+ *
+ * Source: Pi's own `TUI.extractCursorPosition()` scans for CURSOR_MARKER,
+ * measures `visibleWidth(beforeMarker)`, strips the marker, then positions the
+ * hardware cursor (`node_modules/.pnpm/@mariozechner+pi-tui@0.70.2/.../dist/tui.js:651-674`).
+ * sumo-tui performs the same scan inside the Yoga leaf and offsets by the
+ * leaf's computed frame rect.
+ */
+export class PiEditorLeaf extends PiComponentLeaf {
+	private hardwareCursor: HardwareCursorPosition | null = null;
+
+	public constructor(yogaNode: YogaNode, editor: CustomEditor, parent?: SumoNode) {
+		super(yogaNode, editor, parent);
+	}
+
+	public static override create(yoga: Yoga, editor: CustomEditor, parent?: SumoNode): PiEditorLeaf {
+		return new PiEditorLeaf(yoga.Node.create(), editor, parent);
+	}
+
+	public override render(buffer: CellBuffer, rect: Rect): void {
+		this.hardwareCursor = null;
+		const rows = this.renderRows(rect.width);
+		const height = Math.min(rows.length, rect.height);
+		for (let row = 0; row < height; row += 1) {
+			const raw = rows[row] ?? "";
+			const markerIndex = raw.indexOf(CURSOR_MARKER);
+			const painted = markerIndex === -1 ? raw : raw.slice(0, markerIndex) + raw.slice(markerIndex + CURSOR_MARKER.length);
+			if (markerIndex !== -1) {
+				const markerCol = visibleWidth(raw.slice(0, markerIndex));
+				this.hardwareCursor = { row: rect.top + row, col: rect.left + markerCol };
+			}
+			buffer.paintRow(rect.top + row, painted, rect.left, rect.width);
+		}
+	}
+
+	public getHardwareCursor(): HardwareCursorPosition | null {
+		return this.hardwareCursor;
+	}
+}

--- a/test/integration/cursor-positioning.test.ts
+++ b/test/integration/cursor-positioning.test.ts
@@ -1,0 +1,72 @@
+import type { CustomEditor } from "@mariozechner/pi-coding-agent";
+import { CURSOR_MARKER, type Component } from "@mariozechner/pi-tui";
+import { describe, expect, it } from "vitest";
+import { SumoNode } from "../../src/sumo-tui/layout/node.js";
+import { DIRECTION_LTR, loadYoga } from "../../src/sumo-tui/layout/yoga.js";
+import { CellBuffer } from "../../src/sumo-tui/render/buffer.js";
+import { composite } from "../../src/sumo-tui/render/compositor.js";
+import { PiEditorLeaf } from "../../src/sumo-tui/widgets/pi-editor-leaf.js";
+
+class TypingEditor implements Component {
+	public text = "";
+	public invalidate(): void {}
+	public render(_width: number): string[] {
+		return [`${this.text}${CURSOR_MARKER}`];
+	}
+}
+
+function asEditor(component: Component): CustomEditor {
+	return component as unknown as CustomEditor;
+}
+
+describe("sumo-tui cursor positioning integration", () => {
+	it("keeps PiEditorLeaf hardware cursor exact across 50 typed frames", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const editor = new TypingEditor();
+		const leaf = new PiEditorLeaf(yoga.Node.create(), asEditor(editor), root);
+		root.width = 80;
+		root.height = 4;
+		root.paddingTop = 1;
+		root.paddingLeft = 7;
+		leaf.height = 1;
+
+		for (let index = 0; index < 50; index += 1) {
+			editor.text += "x";
+			leaf.markDirty();
+			root.yogaNode.calculateLayout(80, 4, DIRECTION_LTR);
+			const buffer = new CellBuffer(4, 80);
+			const result = composite(root, buffer);
+			expect(result.hardwareCursor).toEqual({ row: 1, col: 7 + editor.text.length });
+		}
+
+		root.dispose();
+	});
+
+	it("validates Q1:A remap stability over 100 headless runs", async () => {
+		const yoga = await loadYoga();
+		let correctRuns = 0;
+		for (let run = 0; run < 100; run += 1) {
+			const root = new SumoNode(yoga.Node.create());
+			const editor = new TypingEditor();
+			const leaf = new PiEditorLeaf(yoga.Node.create(), asEditor(editor), root);
+			root.width = 80;
+			root.height = 3;
+			root.paddingTop = 1;
+			root.paddingLeft = 2;
+			leaf.height = 1;
+			let runCorrect = true;
+			for (let index = 0; index < 50; index += 1) {
+				editor.text += "a";
+				leaf.markDirty();
+				root.yogaNode.calculateLayout(80, 3, DIRECTION_LTR);
+				const result = composite(root, new CellBuffer(3, 80));
+				if (result.hardwareCursor?.row !== 1 || result.hardwareCursor.col !== 2 + editor.text.length) runCorrect = false;
+			}
+			if (runCorrect) correctRuns += 1;
+			root.dispose();
+		}
+
+		expect(correctRuns).toBeGreaterThanOrEqual(96);
+	});
+});

--- a/test/integration/yoga-flex-layout.test.ts
+++ b/test/integration/yoga-flex-layout.test.ts
@@ -1,0 +1,62 @@
+import { Text } from "@mariozechner/pi-tui";
+import { describe, expect, it } from "vitest";
+import { SumoNode } from "../../src/sumo-tui/layout/node.js";
+import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga, type YogaNode } from "../../src/sumo-tui/layout/yoga.js";
+import { CellBuffer, type Rect } from "../../src/sumo-tui/render/buffer.js";
+import { bufferToAnsiLines } from "../../src/sumo-tui/render/ansi-writer.js";
+import { createAttrs } from "../../src/sumo-tui/render/cell.js";
+import { composite } from "../../src/sumo-tui/render/compositor.js";
+import { PiComponentLeaf } from "../../src/sumo-tui/widgets/pi-component-leaf.js";
+import { PI_BOOT_SEQUENCE, spawnPiPty } from "./spawn-pi-pty.js";
+
+class BodyNode extends SumoNode {
+	public constructor(yogaNode: YogaNode, parent?: SumoNode) {
+		super(yogaNode, parent);
+	}
+
+	public render(buffer: CellBuffer, rect: Rect): void {
+		buffer.paint(rect, { char: "B", attrs: createAttrs() });
+		buffer.paintRow(rect.top, "BODY", rect.left, rect.width);
+	}
+}
+
+describe("sumo-tui Yoga flex layout integration", () => {
+	it("pins footer at bottom and lets body flex without manual padding", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const top = PiComponentLeaf.create(yoga, new Text("TopChrome", 0, 0), root);
+		const body = new BodyNode(yoga.Node.create(), root);
+		const footer = PiComponentLeaf.create(yoga, new Text("Footer", 0, 0), root);
+		root.width = 80;
+		root.height = 24;
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		top.height = 1;
+		body.flexGrow = 1;
+		body.flexShrink = 1;
+		footer.height = 1;
+
+		root.yogaNode.calculateLayout(80, 24, DIRECTION_LTR);
+		const buffer = new CellBuffer(24, 80);
+		composite(root, buffer);
+		const ansi = bufferToAnsiLines(buffer).join("\r\n");
+
+		expect(buffer.toPlainRow(0).startsWith("TopChrome")).toBe(true);
+		expect(buffer.toPlainRow(1).startsWith("BODY")).toBe(true);
+		expect(buffer.toPlainRow(22).startsWith("BBBB")).toBe(true);
+		expect(buffer.toPlainRow(23).startsWith("Footer")).toBe(true);
+		expect(body.getComputedHeight()).toBe(22);
+		expect(ansi).toContain("BODY");
+		root.dispose();
+	});
+
+	it("boots Pi in altscreen so Phase 2 ANSI can be captured by the PTY harness", async () => {
+		const pty = spawnPiPty({ cols: 80, rows: 24 });
+		try {
+			await pty.waitForOutput(PI_BOOT_SEQUENCE, 10_000);
+			expect(pty.getCurrentTerminalState().altscreenActive).toBe(true);
+			expect(pty.getOutput()).toContain(PI_BOOT_SEQUENCE);
+		} finally {
+			pty.cleanup();
+		}
+	});
+});


### PR DESCRIPTION
Closes #36

## Summary
- adds async yoga-wasm-web initialization, SumoNode layout ownership, and recursive Yoga disposal
- adds CellBuffer, ANSI writer/parser, compositor, frame diff with scroll-region detection, and adaptive FrameScheduler
- adds PiComponentLeaf and PiEditorLeaf with CURSOR_MARKER remapping plus a Phase 2 VHS demo extension

## Verification
- pnpm test
- pnpm test:integration
- pnpm exec tsc --noEmit
- pnpm build
- vhs docs/visual/sumo-tui-flex-splash.tape
- cursor-positioning integration passed 100/100 runs