### PR TITLE
feat(sumo-tui): Phase 4a — pi-compat scaffolding + foreign extension handling

### DIFF
--- a/docs/research/interactive-mode-map.md
+++ b/docs/research/interactive-mode-map.md
@@ -1,0 +1,146 @@
+# Pi 0.70.2 `interactive-mode.js` responsibility map
+
+Scope: `@mariozechner/pi-coding-agent@0.70.2/dist/modes/interactive/interactive-mode.js` in this worktree's `node_modules/.pnpm/...` install. The Pi CLI integration point is `dist/main.js`.
+
+## Class structure
+
+- `InteractiveMode` is the sole exported interactive TUI class (`interactive-mode.js:122`).
+- Constructor (`interactive-mode.js:218-258`) binds the `AgentSessionRuntime`, constructs pi-tui (`new TUI(new ProcessTerminal(), ...)` at `interactive-mode.js:228`), creates root `Container`s, creates the default `CustomEditor`, footer data provider, footer component, keybindings, and theme registry.
+- Convenience accessors forward to `runtimeHost.session`, `session.agent`, `session.sessionManager`, and `session.settingsManager` (`interactive-mode.js:207-216`).
+- Helper class `ExpandableText` supports collapsible startup header/resource notices (`interactive-mode.js:57-71`).
+
+## Public methods and callers
+
+| Method | Source | Caller / purpose |
+| --- | --- | --- |
+| `constructor(runtimeHost, options)` | `interactive-mode.js:218-258` | Pi CLI constructs it in `dist/main.js:548-556`. |
+| `init()` | `interactive-mode.js:389-483` | Called by `run()` (`interactive-mode.js:502`) and startup benchmark (`dist/main.js:557`). Builds root TUI layout, starts TUI, binds extensions, renders initial session. |
+| `run()` | `interactive-mode.js:501-556` | Pi CLI awaits it at `dist/main.js:571`. Runs startup warning checks, initial prompt(s), then infinite input loop. |
+| `renderInitialMessages()` | `interactive-mode.js:2569-2582` | Used after init, reload, compaction, session switch/fork/new to rebuild chat from `SessionManager`. |
+| `getUserInput()` | `interactive-mode.js:2584-2590` | Used by `run()` input loop to await editor submit. |
+| `clearEditor()` | `interactive-mode.js:2853-2856` | Key handler helper and external consumers. |
+| `showError()`, `showWarning()`, `showNewVersionNotification()`, `showPackageUpdateNotification()` | `interactive-mode.js:2857-2895` | Startup checks, runtime exceptions, extension errors. |
+| `stop()` | `interactive-mode.js:4512-4530` | Shutdown, startup benchmark, external editor suspend/resume cleanup. |
+
+## Internal state inventory
+
+### Runtime/session state
+
+- `runtimeHost` drives session replacement: `newSession`, `fork`, `switchSession`, `importFromJsonl`, `dispose` (`interactive-mode.js:1128-1196`, `interactive-mode.js:3536-3577`, `interactive-mode.js:4022-4060`).
+- `unsubscribe` stores the agent/session event subscription (`interactive-mode.js:2127-2130`).
+- `shutdownRequested` and `isShuttingDown` gate graceful shutdown (`interactive-mode.js:2620-2635`).
+
+### TUI root and containers
+
+- `ui` is pi-tui `TUI` (`interactive-mode.js:228`). This is the Phase 4 seam.
+- Root child order is established in `init()`:
+  - `headerContainer` (`interactive-mode.js:406`)
+  - `chatContainer` (`interactive-mode.js:453`)
+  - `pendingMessagesContainer` (`interactive-mode.js:454`)
+  - `statusContainer` (`interactive-mode.js:455`)
+  - `widgetContainerAbove` (`interactive-mode.js:457`)
+  - `editorContainer` (`interactive-mode.js:458`)
+  - `widgetContainerBelow` (`interactive-mode.js:459`)
+  - `footer` (`interactive-mode.js:460`)
+- Phase 4 maps these into retained Yoga slots: `header`, `chat`, `pending`, `status`, `widgets-default`, `aboveEditor`, `editor`, `belowEditor`, `footer`.
+
+### Editor/autocomplete
+
+- `defaultEditor` is `CustomEditor(this.ui, getEditorTheme(), keybindings, ...)` (`interactive-mode.js:235-241`).
+- `editor` can be replaced by extension UI (`interactive-mode.js:1704-1759`).
+- `autocompleteProviderWrappers` stack extra extension-provided autocomplete providers (`interactive-mode.js:1522-1557`).
+- `createBaseAutocompleteProvider()` builds built-in, prompt template, extension command, and skill slash completions (`interactive-mode.js:295-356`).
+- `setupAutocompleteProvider()` applies wrappers and installs the provider on current/default editors (`interactive-mode.js:358-367`).
+
+### Chat/status/streaming
+
+- `chatContainer` holds user, assistant, tool, bash, custom, branch, and compaction components.
+- `pendingMessagesContainer` renders queued steering/follow-up and deferred bash (`interactive-mode.js:2900-2930`, `interactive-mode.js:3065-3072`).
+- `statusContainer` hosts loaders for agent start, compaction, and retry (`interactive-mode.js:2145-2164`, `interactive-mode.js:2276-2297`, `interactive-mode.js:2362-2383`).
+- Streaming state: `streamingComponent`, `streamingMessage`, `pendingTools`, `toolOutputExpanded`, `hideThinkingBlock` (`interactive-mode.js:2132-2439`).
+
+### Extension UI state
+
+- `extensionSelector`, `extensionInput`, `extensionEditor` replace the editor slot for modal-like flows (`interactive-mode.js:1584-1701`).
+- `extensionWidgetsAbove` / `extensionWidgetsBelow` are mutable pi-tui widget maps (`interactive-mode.js:1336-1380`).
+- `customFooter`, `customHeader`, `builtInHeader` control footer/header replacement (`interactive-mode.js:1440-1520`).
+- `extensionTerminalInputUnsubscribers` tracks raw input listeners (`interactive-mode.js:1521-1533`).
+
+## TUI construction seam to replace
+
+The minimum rendering seam is constructor + `init()` layout:
+
+1. `new TUI(new ProcessTerminal(), showHardwareCursor)` at `interactive-mode.js:228`.
+2. pi-tui containers created in constructor (`interactive-mode.js:229-245`).
+3. root children added in `init()` (`interactive-mode.js:406`, `interactive-mode.js:453-460`).
+4. focus, key handlers, editor submit, and TUI start at `interactive-mode.js:461-465`.
+
+Phase 4 replaces these with:
+
+- sumo-tui runtime/terminal lifecycle,
+- retained `SumoNode` Yoga slots,
+- `PiComponentLeaf` / `PiEditorLeaf` adapters,
+- `RegionRegistry` for extension UI mounts,
+- `SumoExtensionUIAdapter` for Pi's `ExtensionUIContext`.
+
+All session, agent, model, command, MCP, and resource loading responsibilities should remain upstream-identical.
+
+## Extension binding entry point
+
+- `bindCurrentSessionExtensions()` creates `uiContext = this.createExtensionUIContext()` and passes it to `session.bindExtensions(...)` (`interactive-mode.js:1128-1207`).
+- Command context actions for session replacement are supplied there (`interactive-mode.js:1131-1196`).
+- After binding, Pi re-registers themes, sets autocomplete, shortcuts, resource diagnostics, and startup notices (`interactive-mode.js:1201-1207`).
+- `rebindCurrentSession()` unsubscribes, applies runtime settings, binds extensions, subscribes to agent events, updates footer/model/title (`interactive-mode.js:1225-1232`).
+
+Phase 4's safest fork is to keep `bindCurrentSessionExtensions()` logic and swap only the returned UI context plus root render target.
+
+## Extension UI surface
+
+Pi's public `ExtensionUIContext` is declared in `dist/core/extensions/types.d.ts:66-183`. Relevant UI hooks:
+
+- `select`, `confirm`, `input`, `notify` (`types.d.ts:66-75`)
+- `setWidget` (`types.d.ts:93-98`)
+- `setFooter`, `setHeader` (`types.d.ts:103-110`)
+- `custom` overlay/focus component (`types.d.ts:113-124`)
+- editor text + replacement editor (`types.d.ts:127-167`)
+- theme/tools helpers (`types.d.ts:169-183`)
+
+Pi's upstream dispatch table is `interactive-mode.js:1522-1557`; Phase 4 maps those calls through `RegionRegistry`.
+
+## Slash commands and autocomplete
+
+- Built-in slash commands come from `BUILTIN_SLASH_COMMANDS` and are added in `createBaseAutocompleteProvider()` (`interactive-mode.js:295-304`).
+- Prompt templates are mapped into slash command entries (`interactive-mode.js:319-324`).
+- Extension commands are read from `session.extensionRunner.getRegisteredCommands()` and added unless they conflict with built-ins (`interactive-mode.js:326-335`).
+- Skill commands are added when enabled (`interactive-mode.js:337-352`).
+- Submit-time command handling is in `setupEditorSubmitHandler()` (`interactive-mode.js:1951-2125`): built-ins are handled locally; extension commands route through `session.prompt(text)`.
+
+## Session lifecycle and events
+
+- `subscribeToAgent()` attaches `session.subscribe(event => handleEvent(event))` (`interactive-mode.js:2127-2130`).
+- `handleEvent()` reacts to `agent_start`, `queue_update`, `message_start`, `message_update`, `message_end`, `tool_execution_*`, `agent_end`, `compaction_*`, `auto_retry_*` (`interactive-mode.js:2132-2440`).
+- New/resume/fork/import paths call runtimeHost methods, then `renderCurrentSessionState()` and render/status updates (`interactive-mode.js:1136-1196`, `interactive-mode.js:3536-3577`, `interactive-mode.js:4022-4060`, `interactive-mode.js:4359-4374`).
+- Shutdown drains input, stops TUI, disposes runtime, exits (`interactive-mode.js:2625-2635`).
+
+## Pi-rendered noise to suppress or relocate
+
+- `[Extension issues]` diagnostics are rendered into chat by `showLoadedResources()` (`interactive-mode.js:1088-1118`, specific add at `interactive-mode.js:1114`). SumoCode should relocate these into a notification/status surface or hide known benign Ctrl+P conflicts once Sumo owns that keybind.
+- Anthropic subscription warning string is declared at `interactive-mode.js:74` and emitted via `maybeWarnAboutAnthropicSubscriptionAuth()` (`interactive-mode.js:3261-3281`). SumoCode can keep it as a warning toast rather than chat noise.
+- Version/package/tmux warnings are triggered asynchronously in `run()` (`interactive-mode.js:504-517`). These can remain chat/status but should not corrupt retained layout.
+
+## Smallest fork surface
+
+Observed fork requirement:
+
+1. Pi CLI imports and constructs `InteractiveMode` in `dist/main.js:31` and `dist/main.js:548-571`.
+2. Extensions cannot replace this from `src/extension.ts` because extension factories are loaded after ESM imports and before the constructor call, but the constructor reference is already bound in `main.js`.
+3. Therefore Phase 4 needs a fork patch at the Pi binary/main integration point (ADR Q4:A). The smallest patch is replacing `new InteractiveMode(runtime, options)` with `new SumoInteractiveMode(runtime, options)` plus a maintained implementation that reuses upstream session/runtime logic and swaps rendering at the TUI boundary.
+
+Target vendored/derived surface in this PR:
+
+- `sumo-interactive-mode.ts`: boundary and citations, MIT notice.
+- `region-registry.ts`: retained replacement for pi-tui root containers.
+- `extension-ui-adapter.ts`: retained replacement for `createExtensionUIContext()` dispatch.
+- `foreign-extension-warning.ts`: defensive v1 foreign extension policy.
+
+The remaining unimplemented fork patch is documented in `docs/research/phase-4-progress.md` if not completed in the 7-day window.

--- a/docs/research/phase-4-progress.md
+++ b/docs/research/phase-4-progress.md
@@ -1,0 +1,77 @@
+# sumo-tui Phase 4 progress
+
+Date: 2026-04-27
+Branch: `feat/sumo-tui-phase-4`
+
+## Completed in this increment
+
+- Mapped Pi 0.70.2 `interactive-mode.js` responsibilities in `docs/research/interactive-mode-map.md` with file:line citations.
+- Added retained extension UI primitives:
+  - `src/sumo-tui/pi-compat/region-registry.ts`
+  - `src/sumo-tui/pi-compat/extension-ui-adapter.ts`
+  - `src/sumo-tui/pi-compat/foreign-extension-warning.ts`
+  - `src/sumo-tui/widgets/notification.ts`
+  - `src/sumo-tui/widgets/modal.ts`
+- Added Phase 4 boundary file with MIT notice and Pi source citations:
+  - `src/sumo-tui/pi-compat/sumo-interactive-mode.ts`
+- Added `/sumo:theme` slash command so the requested `/sumo:*` set is present.
+- Added unit coverage for registry, adapter, notification/modal flows, and foreign extension warnings.
+- Added headless integration coverage for slash command registration and retained session lifecycle cleanup.
+
+## Verification run
+
+```bash
+pnpm test
+# 48 files, 315 tests passed
+
+pnpm test:integration
+# 8 files, 11 tests passed
+
+pnpm exec tsc --noEmit
+# clean
+```
+
+## Blockers / not complete
+
+### Pi binary integration is not wired yet
+
+Pi 0.70.2 constructs `InteractiveMode` inside the package binary, not inside SumoCode extension user code:
+
+- import site: `node_modules/.pnpm/@mariozechner+pi-coding-agent@0.70.2.../dist/main.js:31`
+- constructor site: `node_modules/.pnpm/@mariozechner+pi-coding-agent@0.70.2.../dist/main.js:548-571`
+
+Because SumoCode is loaded as a Pi extension, `src/extension.ts` cannot replace the already-imported ESM binding. The actual fork patch still needs to replace that constructor call with `new SumoInteractiveMode(...)` in our pinned Pi fork/package. Until that patch is applied, running `pi -e ./src/extension.ts` still enters upstream pi-tui's `InteractiveMode` and only uses sumo-tui for the Phase 1 lifecycle shim.
+
+### Retained renderer adapter is scaffolded, not yet the full runtime owner
+
+`RegionRegistry` and `SumoExtensionUIAdapter` can mount Pi components into retained Yoga slots, and tests prove slot routing/disposal. The full runtime loop still needs the Pi fork to:
+
+1. instantiate the sumo-tui runtime instead of `new TUI(new ProcessTerminal(), ...)`,
+2. calculate Yoga layout per frame,
+3. composite to `CellBuffer`,
+4. diff/write ANSI frames,
+5. route key/mouse input to editor/chat/modal focus.
+
+### Foreign extension no-op is best-effort until per-extension binding exists
+
+Pi's `ExtensionRunner` exposes one shared `uiContext` to all extension handlers (`dist/core/extensions/runner.js:372-411`). The implemented guard supports injected caller identity and no-ops foreign UI hooks defensively, but the Pi fork still needs to pass per-extension identity (or an equivalent stack/caller resolver) during handler invocation for production-grade foreign extension isolation.
+
+### Required reading files were absent from this worktree
+
+The prompt listed these files, but they were not present in either the worktree or read-only main reference:
+
+- `docs/adr/0001-sumo-tui-framework.md`
+- `docs/research/sumo-tui-spike/IMPLEMENTATION_PLAN.md`
+- `docs/research/sumo-tui-spike/EDGE_CASES.md`
+- `docs/research/sumo-tui-spike/04-pi-tui.md`
+
+I proceeded using the shipped Phase 1–3 source/tests, Pi docs, and Pi 0.70.2 installed sources.
+
+## Acceptance criteria still open
+
+- Visual verification via VHS/screenshot of SumoCode running on the retained renderer.
+- Real pty slash autocomplete assertion against the forked interactive mode.
+- Ctrl+P conflict suppression in Pi diagnostics after forked keybinding ownership.
+- Pi 0.70.0 / 0.70.1 / latest 0.70.x smoke matrix.
+- Actual Pi fork patch/package integration.
+- PR should not claim `Closes #38` until the fork patch is wired and visually verified.

--- a/src/commands/theme.ts
+++ b/src/commands/theme.ts
@@ -1,0 +1,31 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+function currentThemeName(ctx: ExtensionContext): string {
+	return (ctx.ui.theme as { name?: string } | undefined)?.name ?? "current";
+}
+
+/** Register `/sumo:theme [name]` for SumoCode theme switching. */
+export function registerThemeCommand(pi: ExtensionAPI): void {
+	pi.registerCommand("sumo:theme", {
+		description: "Show or switch the active SumoCode/Pi theme",
+		handler: async (args: string, ctx: ExtensionContext) => {
+			if (!ctx.hasUI) {
+				process.stdout.write("sumo:theme requires interactive UI\n");
+				return;
+			}
+
+			const requested = args.trim();
+			if (!requested) {
+				ctx.ui.notify(`theme: ${currentThemeName(ctx)}`, "info");
+				return;
+			}
+
+			const result = ctx.ui.setTheme(requested);
+			if (result.success) {
+				ctx.ui.notify(`theme set: ${requested}`, "info");
+				return;
+			}
+			ctx.ui.notify(`theme failed: ${result.error ?? requested}`, "warning");
+		},
+	});
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { installInputHints } from "./cathedral/input-hints.js";
 import { registerPersonaCommand } from "./commands/persona.js";
 import { registerSpinnerCommand } from "./commands/spinner.js";
 import { registerTabsCommand } from "./commands/tabs.js";
+import { registerThemeCommand } from "./commands/theme.js";
 import { registerThemeCheckCommand } from "./commands/theme-check.js";
 // Element 6 approval gate disabled per Dhruv's request 2026-04-27.
 // The cathedral approval modal was blocking bash/edit/write tool calls and
@@ -41,6 +42,7 @@ export default function sumocode(pi: ExtensionAPI): void {
 	registerPersonaCommand(pi);
 	registerSpinnerCommand(pi);
 	registerTabsCommand(pi);
+	registerThemeCommand(pi);
 	registerThemeCheckCommand(pi);
 	registerMemoryCommand(pi);
 }

--- a/src/sumo-tui/pi-compat/extension-ui-adapter.test.ts
+++ b/src/sumo-tui/pi-compat/extension-ui-adapter.test.ts
@@ -1,0 +1,128 @@
+import type { KeybindingsManager, ReadonlyFooterDataProvider, Theme } from "@mariozechner/pi-coding-agent";
+import type { Component, EditorComponent, EditorTheme, TUI } from "@mariozechner/pi-tui";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadYoga } from "../layout/yoga.js";
+import { ModalManager } from "../widgets/modal.js";
+import { NotificationCenter } from "../widgets/notification.js";
+import { SumoExtensionUIAdapter } from "./extension-ui-adapter.js";
+import { RegionRegistry } from "./region-registry.js";
+
+class TestComponent implements Component {
+	public invalidate(): void {}
+	public render(_width: number): string[] {
+		return ["component"];
+	}
+}
+
+function fakeTui(): TUI {
+	return { requestRender: vi.fn(), terminal: { columns: 80, rows: 24, setTitle: vi.fn() } } as unknown as TUI;
+}
+
+function fakeTheme(): Theme {
+	return {} as Theme;
+}
+
+function fakeEditorTheme(): EditorTheme {
+	return { borderColor: (value: string) => value, selectList: {} } as EditorTheme;
+}
+
+function fakeKeybindings(): KeybindingsManager {
+	return {} as KeybindingsManager;
+}
+
+function fakeFooterData(): ReadonlyFooterDataProvider {
+	return {
+		getGitBranch: () => null,
+		getExtensionStatuses: () => new Map<string, string>(),
+		getAvailableProviderCount: () => 0,
+		onBranchChange: () => () => undefined,
+	};
+}
+
+async function makeAdapter(): Promise<{
+	registry: RegionRegistry;
+	notifications: NotificationCenter;
+	modals: ModalManager;
+	adapter: SumoExtensionUIAdapter;
+}> {
+	const yoga = await loadYoga();
+	const tui = fakeTui();
+	const theme = fakeTheme();
+	const editorTheme = fakeEditorTheme();
+	const keybindings = fakeKeybindings();
+	const registry = new RegionRegistry({
+		yoga,
+		tui,
+		theme,
+		editorTheme,
+		keybindings,
+		footerData: fakeFooterData(),
+	});
+	const notifications = new NotificationCenter();
+	const modals = new ModalManager();
+	const adapter = new SumoExtensionUIAdapter({
+		regionRegistry: registry,
+		tui,
+		theme,
+		editorTheme,
+		keybindings,
+		notifications,
+		modals,
+	});
+	return { registry, notifications, modals, adapter };
+}
+
+afterEach(() => {
+	vi.useRealTimers();
+});
+
+describe("SumoExtensionUIAdapter", () => {
+	it("routes Pi extension UI methods to retained RegionRegistry slots", async () => {
+		const { adapter, registry } = await makeAdapter();
+
+		adapter.setHeader(() => new TestComponent());
+		adapter.setFooter(() => new TestComponent());
+		adapter.setEditorComponent(() => new TestComponent() as unknown as EditorComponent);
+		adapter.setWidget("above", () => new TestComponent(), { placement: "aboveEditor" });
+		adapter.setWidget("below", ["below"], { placement: "belowEditor" });
+
+		expect(registry.getMounted("__header")?.slot).toBe("header");
+		expect(registry.getMounted("__footer")?.slot).toBe("footer");
+		expect(registry.getMounted("__editor")?.slot).toBe("editor");
+		expect(registry.getMounted("above")?.slot).toBe("aboveEditor");
+		expect(registry.getMounted("below")?.slot).toBe("belowEditor");
+		registry.dispose();
+	});
+
+	it("notify creates a toast that auto-dismisses", async () => {
+		vi.useFakeTimers();
+		const { adapter, notifications, registry } = await makeAdapter();
+
+		adapter.notify("hello", "info");
+		expect(notifications.getToasts()).toHaveLength(1);
+		expect(notifications.getToasts()[0]?.message).toBe("hello");
+
+		vi.advanceTimersByTime(3_000);
+		expect(notifications.getToasts()).toHaveLength(0);
+		registry.dispose();
+	});
+
+	it("confirm resolves from modal keyboard input", async () => {
+		const { adapter, modals, registry } = await makeAdapter();
+		const result = adapter.confirm("Delete", "Continue?");
+
+		modals.handleInput("enter");
+		await expect(result).resolves.toBe(true);
+		registry.dispose();
+	});
+
+	it("select resolves selected option from modal keyboard input", async () => {
+		const { adapter, modals, registry } = await makeAdapter();
+		const result = adapter.select("Pick", ["alpha", "beta"]);
+
+		modals.handleInput("down");
+		modals.handleInput("enter");
+		await expect(result).resolves.toBe("beta");
+		registry.dispose();
+	});
+});

--- a/src/sumo-tui/pi-compat/extension-ui-adapter.ts
+++ b/src/sumo-tui/pi-compat/extension-ui-adapter.ts
@@ -1,0 +1,332 @@
+import type {
+	AutocompleteProviderFactory,
+	ExtensionUIContext,
+	ExtensionUIDialogOptions,
+	ExtensionWidgetOptions,
+	KeybindingsManager,
+	ReadonlyFooterDataProvider,
+	Theme,
+	WorkingIndicatorOptions,
+} from "@mariozechner/pi-coding-agent";
+import type {
+	Component,
+	EditorComponent,
+	EditorTheme,
+	OverlayHandle,
+	OverlayOptions,
+	TUI,
+} from "@mariozechner/pi-tui";
+import { ModalManager } from "../widgets/modal.js";
+import { NotificationCenter, type NotificationLevel } from "../widgets/notification.js";
+import {
+	RegionRegistry,
+	type DisposableComponent,
+	type WidgetPlacement,
+} from "./region-registry.js";
+
+export interface ThemeApi {
+	getAllThemes(): { name: string; path: string | undefined }[];
+	getTheme(name: string): Theme | undefined;
+	setTheme(theme: string | Theme): { success: boolean; error?: string };
+}
+
+export interface EditorTextController {
+	paste(text: string): void;
+	setText(text: string): void;
+	getText(): string;
+}
+
+export interface ToolsExpansionController {
+	getExpanded(): boolean;
+	setExpanded(expanded: boolean): void;
+}
+
+export interface SumoExtensionUIAdapterOptions {
+	readonly regionRegistry: RegionRegistry;
+	readonly tui: TUI;
+	readonly theme: Theme;
+	readonly editorTheme: EditorTheme;
+	readonly keybindings: KeybindingsManager;
+	readonly footerData?: ReadonlyFooterDataProvider;
+	readonly notifications?: NotificationCenter;
+	readonly modals?: ModalManager;
+	readonly editorText?: EditorTextController;
+	readonly themeApi?: ThemeApi;
+	readonly tools?: ToolsExpansionController;
+	readonly addAutocompleteProvider?: (factory: AutocompleteProviderFactory) => void;
+	readonly setStatus?: (key: string, text: string | undefined) => void;
+	readonly setWorkingMessage?: (message?: string) => void;
+	readonly setWorkingIndicator?: (options?: WorkingIndicatorOptions) => void;
+	readonly setHiddenThinkingLabel?: (label?: string) => void;
+	readonly onRenderRequest?: () => void;
+}
+
+type TerminalInputHandler = Parameters<ExtensionUIContext["onTerminalInput"]>[0];
+
+class OverlayComponentWrapper implements Component {
+	private hidden = false;
+	public constructor(private readonly component: DisposableComponent) {}
+	public invalidate(): void {
+		this.component.invalidate?.();
+	}
+	public handleInput(data: string): void {
+		this.component.handleInput?.(data);
+	}
+	public render(width: number): string[] {
+		return this.hidden ? [] : this.component.render(width);
+	}
+	public setHidden(hidden: boolean): void {
+		this.hidden = hidden;
+	}
+	public isHidden(): boolean {
+		return this.hidden;
+	}
+	public dispose(): void {
+		this.component.dispose?.();
+	}
+}
+
+function normalizeNotificationLevel(level: "info" | "warning" | "error" | undefined): NotificationLevel {
+	return level ?? "info";
+}
+
+/**
+ * Pi ExtensionUIContext implementation backed by RegionRegistry.
+ *
+ * Source: Pi 0.70.2's interactive mode exposes this surface from
+ * `createExtensionUIContext()` at
+ * `node_modules/.pnpm/@mariozechner+pi-coding-agent@0.70.2.../dist/modes/interactive/interactive-mode.js:1522-1557`.
+ * Dialog/editor/custom behaviours mirror the upstream editor-container and
+ * overlay paths at `interactive-mode.js:1584-1774`.
+ */
+export class SumoExtensionUIAdapter implements ExtensionUIContext {
+	private readonly regionRegistry: RegionRegistry;
+	private readonly tui: TUI;
+	private readonly currentTheme: Theme;
+	private readonly keybindings: KeybindingsManager;
+	private readonly notifications: NotificationCenter;
+	private readonly modals: ModalManager;
+	private readonly editorText: EditorTextController | undefined;
+	private readonly themeApi: ThemeApi | undefined;
+	private readonly tools: ToolsExpansionController | undefined;
+	private readonly addProvider: ((factory: AutocompleteProviderFactory) => void) | undefined;
+	private readonly onStatus: ((key: string, text: string | undefined) => void) | undefined;
+	private readonly onWorkingMessage: ((message?: string) => void) | undefined;
+	private readonly onWorkingIndicator: ((options?: WorkingIndicatorOptions) => void) | undefined;
+	private readonly onHiddenThinkingLabel: ((label?: string) => void) | undefined;
+	private readonly requestRender: () => void;
+	private readonly terminalInputHandlers = new Set<TerminalInputHandler>();
+
+	public constructor(options: SumoExtensionUIAdapterOptions) {
+		this.regionRegistry = options.regionRegistry;
+		this.tui = options.tui;
+		this.currentTheme = options.theme;
+		this.keybindings = options.keybindings;
+		this.notifications = options.notifications ?? new NotificationCenter({ onChange: options.onRenderRequest });
+		this.modals = options.modals ?? new ModalManager({ onChange: options.onRenderRequest });
+		this.editorText = options.editorText;
+		this.themeApi = options.themeApi;
+		this.tools = options.tools;
+		this.addProvider = options.addAutocompleteProvider;
+		this.onStatus = options.setStatus;
+		this.onWorkingMessage = options.setWorkingMessage;
+		this.onWorkingIndicator = options.setWorkingIndicator;
+		this.onHiddenThinkingLabel = options.setHiddenThinkingLabel;
+		this.requestRender = options.onRenderRequest ?? (() => this.tui.requestRender?.());
+		this.regionRegistry.mountOverlay("__notifications", this.notifications, {
+			anchor: "top-right",
+			width: "45%",
+			maxHeight: 6,
+		});
+		this.regionRegistry.mountOverlay("__modal", this.modals, {
+			anchor: "center",
+			width: "65%",
+			maxHeight: "80%",
+		});
+	}
+
+	public select(title: string, options: string[], opts?: ExtensionUIDialogOptions): Promise<string | undefined> {
+		return this.modals.select(title, options, opts);
+	}
+
+	public confirm(title: string, message: string, opts?: ExtensionUIDialogOptions): Promise<boolean> {
+		return this.modals.confirm(title, message, opts);
+	}
+
+	public input(title: string, placeholder?: string, opts?: ExtensionUIDialogOptions): Promise<string | undefined> {
+		return this.modals.input(title, placeholder, opts);
+	}
+
+	public notify(message: string, type?: "info" | "warning" | "error"): void {
+		this.notifications.notify(message, normalizeNotificationLevel(type));
+	}
+
+	public onTerminalInput(handler: TerminalInputHandler): () => void {
+		this.terminalInputHandlers.add(handler);
+		return () => this.terminalInputHandlers.delete(handler);
+	}
+
+	public dispatchTerminalInput(data: string): { consume?: boolean; data?: string } | undefined {
+		for (const handler of this.terminalInputHandlers) {
+			const result = handler(data);
+			if (result?.consume) return result;
+			if (result?.data !== undefined) data = result.data;
+		}
+		return data === undefined ? undefined : { data };
+	}
+
+	public setStatus(key: string, text: string | undefined): void {
+		this.onStatus?.(key, text);
+		this.requestRender();
+	}
+
+	public setWorkingMessage(message?: string): void {
+		this.onWorkingMessage?.(message);
+		this.requestRender();
+	}
+
+	public setWorkingIndicator(options?: WorkingIndicatorOptions): void {
+		this.onWorkingIndicator?.(options);
+		this.requestRender();
+	}
+
+	public setHiddenThinkingLabel(label?: string): void {
+		this.onHiddenThinkingLabel?.(label);
+		this.requestRender();
+	}
+
+	public setWidget(key: string, content: string[] | undefined, options?: ExtensionWidgetOptions): void;
+	public setWidget(
+		key: string,
+		content: ((tui: TUI, theme: Theme) => Component & { dispose?(): void }) | undefined,
+		options?: ExtensionWidgetOptions,
+	): void;
+	public setWidget(
+		key: string,
+		content: string[] | ((tui: TUI, theme: Theme) => Component & { dispose?(): void }) | undefined,
+		options?: ExtensionWidgetOptions,
+	): void {
+		this.regionRegistry.mountWidget(key, content, { placement: options?.placement as WidgetPlacement | undefined });
+	}
+
+	public setFooter(
+		factory: ((tui: TUI, theme: Theme, footerData: ReadonlyFooterDataProvider) => Component & { dispose?(): void }) | undefined,
+	): void {
+		this.regionRegistry.mountFooter(factory);
+	}
+
+	public setHeader(factory: ((tui: TUI, theme: Theme) => Component & { dispose?(): void }) | undefined): void {
+		this.regionRegistry.mountHeader(factory);
+	}
+
+	public setTitle(title: string): void {
+		this.tui.terminal?.setTitle?.(title);
+	}
+
+	public async custom<T>(
+		factory: (
+			tui: TUI,
+			theme: Theme,
+			keybindings: KeybindingsManager,
+			done: (result: T) => void,
+		) => (Component & { dispose?(): void }) | Promise<Component & { dispose?(): void }>,
+		options?: {
+			overlay?: boolean;
+			overlayOptions?: OverlayOptions | (() => OverlayOptions);
+			onHandle?: (handle: OverlayHandle) => void;
+		},
+	): Promise<T> {
+		const key = `__custom_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+		let wrapper: OverlayComponentWrapper | undefined;
+		let settled = false;
+		return new Promise<T>((resolve, reject) => {
+			const close = (result: T): void => {
+				if (settled) return;
+				settled = true;
+				this.regionRegistry.unmount(key);
+				resolve(result);
+			};
+			Promise.resolve(factory(this.tui, this.currentTheme, this.keybindings, close))
+				.then((component) => {
+					if (settled) {
+						component.dispose?.();
+						return;
+					}
+					wrapper = new OverlayComponentWrapper(component);
+					this.regionRegistry.mountOverlay(key, wrapper, options?.overlay === false ? undefined : options?.overlayOptions);
+					options?.onHandle?.(this.createOverlayHandle(key, wrapper));
+				})
+				.catch((error: unknown) => {
+					if (settled) return;
+					settled = true;
+					reject(error);
+				});
+		});
+	}
+
+	public pasteToEditor(text: string): void {
+		this.editorText?.paste(text);
+	}
+
+	public setEditorText(text: string): void {
+		this.editorText?.setText(text);
+	}
+
+	public getEditorText(): string {
+		return this.editorText?.getText() ?? "";
+	}
+
+	public editor(title: string, prefill?: string): Promise<string | undefined> {
+		if (prefill) this.editorText?.setText(prefill);
+		return this.modals.input(title, prefill);
+	}
+
+	public addAutocompleteProvider(factory: AutocompleteProviderFactory): void {
+		this.addProvider?.(factory);
+	}
+
+	public setEditorComponent(
+		factory: ((tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) => EditorComponent) | undefined,
+	): void {
+		this.regionRegistry.mountEditor(factory);
+	}
+
+	public get theme(): Theme {
+		return this.currentTheme;
+	}
+
+	public getAllThemes(): { name: string; path: string | undefined }[] {
+		return this.themeApi?.getAllThemes() ?? [];
+	}
+
+	public getTheme(name: string): Theme | undefined {
+		return this.themeApi?.getTheme(name);
+	}
+
+	public setTheme(theme: string | Theme): { success: boolean; error?: string } {
+		return this.themeApi?.setTheme(theme) ?? { success: false, error: "Theme API unavailable" };
+	}
+
+	public getToolsExpanded(): boolean {
+		return this.tools?.getExpanded() ?? false;
+	}
+
+	public setToolsExpanded(expanded: boolean): void {
+		this.tools?.setExpanded(expanded);
+		this.requestRender();
+	}
+
+	private createOverlayHandle(key: string, wrapper: OverlayComponentWrapper): OverlayHandle {
+		return {
+			hide: () => this.regionRegistry.unmount(key),
+			setHidden: (hidden: boolean) => {
+				wrapper.setHidden(hidden);
+				this.requestRender();
+			},
+			isHidden: () => wrapper.isHidden(),
+			focus: () => undefined,
+			unfocus: () => undefined,
+			isFocused: () => false,
+		};
+	}
+}

--- a/src/sumo-tui/pi-compat/foreign-extension-warning.test.ts
+++ b/src/sumo-tui/pi-compat/foreign-extension-warning.test.ts
@@ -1,0 +1,104 @@
+import type { ExtensionUIContext, Theme } from "@mariozechner/pi-coding-agent";
+import type { Component } from "@mariozechner/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import {
+	ForeignExtensionWarning,
+	createForeignAwareUIContext,
+	isForeignExtension,
+	packageNameForExtension,
+} from "./foreign-extension-warning.js";
+
+class TestComponent implements Component {
+	public invalidate(): void {}
+	public render(_width: number): string[] {
+		return ["component"];
+	}
+}
+
+function baseUI(): ExtensionUIContext & { setHeader: ReturnType<typeof vi.fn> } {
+	const setHeader = vi.fn();
+	return {
+		select: vi.fn(),
+		confirm: vi.fn(),
+		input: vi.fn(),
+		notify: vi.fn(),
+		onTerminalInput: vi.fn(() => () => undefined),
+		setStatus: vi.fn(),
+		setWorkingMessage: vi.fn(),
+		setWorkingIndicator: vi.fn(),
+		setHiddenThinkingLabel: vi.fn(),
+		setWidget: vi.fn(),
+		setFooter: vi.fn(),
+		setHeader,
+		setTitle: vi.fn(),
+		custom: vi.fn(),
+		pasteToEditor: vi.fn(),
+		setEditorText: vi.fn(),
+		getEditorText: vi.fn(() => ""),
+		editor: vi.fn(),
+		addAutocompleteProvider: vi.fn(),
+		setEditorComponent: vi.fn(),
+		get theme(): Theme {
+			return {} as Theme;
+		},
+		getAllThemes: vi.fn(() => []),
+		getTheme: vi.fn(),
+		setTheme: vi.fn(() => ({ success: true })),
+		getToolsExpanded: vi.fn(() => false),
+		setToolsExpanded: vi.fn(),
+	} as unknown as ExtensionUIContext & { setHeader: ReturnType<typeof vi.fn> };
+}
+
+describe("foreign extension warning", () => {
+	it("parses package names and classifies SumoCode-owned packages", () => {
+		expect(packageNameForExtension("npm:@scope/pkg@1.2.3")).toBe("@scope/pkg");
+		expect(isForeignExtension("npm:left-pad@1.0.0")).toBe(true);
+		expect(isForeignExtension("@dhruvkelawala/sumocode")).toBe(false);
+		expect(isForeignExtension("@sumodeus/cathedral-tools")).toBe(false);
+	});
+
+	it("foreign extension setHeader warns once and no-ops", () => {
+		const notify = vi.fn();
+		const debug = vi.fn();
+		const base = baseUI();
+		const guarded = createForeignAwareUIContext(base, {
+			notify,
+			debug,
+			resolveCallerExtensionName: () => "left-pad",
+		});
+
+		guarded.setHeader(() => new TestComponent());
+		guarded.setHeader(() => new TestComponent());
+
+		expect(base.setHeader).not.toHaveBeenCalled();
+		expect(notify).toHaveBeenCalledTimes(1);
+		expect(notify.mock.calls[0]?.[0]).toContain("Extension 'left-pad'");
+		expect(debug).toHaveBeenCalledTimes(2);
+	});
+
+	it("SumoCode-owned extension setHeader mounts normally", () => {
+		const notify = vi.fn();
+		const base = baseUI();
+		const guarded = createForeignAwareUIContext(base, {
+			notify,
+			resolveCallerExtensionName: () => "@dhruvkelawala/sumocode",
+		});
+
+		guarded.setHeader(() => new TestComponent());
+
+		expect(base.setHeader).toHaveBeenCalledTimes(1);
+		expect(notify).not.toHaveBeenCalled();
+	});
+
+	it("warns once per foreign extension", () => {
+		const notify = vi.fn();
+		const warning = new ForeignExtensionWarning({ notify });
+
+		warning.warn("left-pad");
+		warning.warn("left-pad");
+		warning.warn("other-ext");
+
+		expect(notify).toHaveBeenCalledTimes(2);
+		expect(warning.getWarnedExtensions()).toEqual(["left-pad", "other-ext"]);
+	});
+});

--- a/src/sumo-tui/pi-compat/foreign-extension-warning.ts
+++ b/src/sumo-tui/pi-compat/foreign-extension-warning.ts
@@ -1,0 +1,161 @@
+import type { ExtensionUIContext, KeybindingsManager, Theme } from "@mariozechner/pi-coding-agent";
+import type { Component, OverlayHandle, OverlayOptions, TUI } from "@mariozechner/pi-tui";
+
+export interface ExtensionIdentity {
+	readonly name?: string;
+	readonly packageName?: string;
+	readonly path?: string;
+	readonly source?: string;
+}
+
+export interface ForeignExtensionWarningOptions {
+	readonly notify: (message: string, type?: "info" | "warning" | "error") => void;
+	readonly debug?: (message: string) => void;
+}
+
+export interface ForeignAwareUIOptions extends ForeignExtensionWarningOptions {
+	readonly resolveCallerExtensionName?: () => string | undefined;
+}
+
+const SUMOCODE_PACKAGE_PREFIXES = ["@dhruvkelawala/sumocode", "@sumodeus/"] as const;
+const FOREIGN_UI_WARNING = "is using Pi UI hooks not supported in SumoCode v1. Their UI may not render.";
+
+type UiHook = "setHeader" | "setFooter" | "setEditorComponent" | "setWidget" | "custom";
+type CustomFactory<T> = (
+	tui: TUI,
+	theme: Theme,
+	keybindings: KeybindingsManager,
+	done: (result: T) => void,
+) => (Component & { dispose?(): void }) | Promise<Component & { dispose?(): void }>;
+type CustomOptions = {
+	overlay?: boolean;
+	overlayOptions?: OverlayOptions | (() => OverlayOptions);
+	onHandle?: (handle: OverlayHandle) => void;
+};
+
+function normalizeNpmSource(source: string): string | undefined {
+	if (!source.startsWith("npm:")) return undefined;
+	const spec = source.slice("npm:".length);
+	if (spec.startsWith("@")) {
+		const parts = spec.split("@");
+		return parts.length >= 3 ? `@${parts[1]}` : spec;
+	}
+	return spec.split("@")[0];
+}
+
+function packageNameFromNodeModules(input: string): string | undefined {
+	const normalized = input.replace(/\\/g, "/");
+	const marker = "/node_modules/";
+	const index = normalized.lastIndexOf(marker);
+	if (index === -1) return undefined;
+	const after = normalized.slice(index + marker.length);
+	const parts = after.split("/");
+	if (parts[0]?.startsWith("@")) return parts[0] && parts[1] ? `${parts[0]}/${parts[1]}` : undefined;
+	return parts[0];
+}
+
+export function packageNameForExtension(identity: ExtensionIdentity | string): string {
+	if (typeof identity === "string") {
+		return normalizeNpmSource(identity) ?? packageNameFromNodeModules(identity) ?? identity;
+	}
+	return (
+		identity.packageName ??
+		identity.name ??
+		(identity.source ? normalizeNpmSource(identity.source) : undefined) ??
+		(identity.path ? packageNameFromNodeModules(identity.path) : undefined) ??
+		identity.path ??
+		identity.source ??
+		"<unknown-extension>"
+	);
+}
+
+export function isSumoCodeExtensionName(name: string): boolean {
+	return SUMOCODE_PACKAGE_PREFIXES.some((prefix) => (prefix.endsWith("/") ? name.startsWith(prefix) : name === prefix || name.startsWith(`${prefix}/`)));
+}
+
+export function isForeignExtension(identity: ExtensionIdentity | string): boolean {
+	return !isSumoCodeExtensionName(packageNameForExtension(identity));
+}
+
+export class ForeignExtensionWarning {
+	private readonly notify: ForeignExtensionWarningOptions["notify"];
+	private readonly debug: (message: string) => void;
+	private readonly warned = new Set<string>();
+
+	public constructor(options: ForeignExtensionWarningOptions) {
+		this.notify = options.notify;
+		this.debug = options.debug ?? ((message) => console.debug(message));
+	}
+
+	public warn(identity: ExtensionIdentity | string): void {
+		const name = packageNameForExtension(identity);
+		if (this.warned.has(name)) return;
+		this.warned.add(name);
+		this.notify(`Note: Extension '${name}' ${FOREIGN_UI_WARNING}`, "warning");
+	}
+
+	public warnForForeignExtensions(extensions: readonly ExtensionIdentity[]): void {
+		for (const extension of extensions) {
+			if (isForeignExtension(extension)) this.warn(extension);
+		}
+	}
+
+	public shouldBlock(identity: ExtensionIdentity | string | undefined): boolean {
+		if (!identity) return false;
+		return isForeignExtension(identity);
+	}
+
+	public block(identity: ExtensionIdentity | string, hook: UiHook): boolean {
+		if (!this.shouldBlock(identity)) return false;
+		const name = packageNameForExtension(identity);
+		this.warn(name);
+		this.debug(`sumo-tui: foreign extension '${name}' attempted ${hook}; no-op in SumoCode v1`);
+		return true;
+	}
+
+	public getWarnedExtensions(): readonly string[] {
+		return [...this.warned];
+	}
+}
+
+/**
+ * Best-effort foreign extension UI guard.
+ *
+ * Pi 0.70.2 gives `ExtensionRunner` one shared UI context for all handlers
+ * (`dist/core/extensions/runner.js:372-411`), so Phase 4 cannot receive the
+ * extension id as an argument without the interactive-mode fork. This wrapper
+ * accepts an injected caller resolver (the fork can provide one; tests can fake
+ * one) and defensively no-ops retained UI hooks for non-SumoCode packages.
+ */
+export function createForeignAwareUIContext(base: ExtensionUIContext, options: ForeignAwareUIOptions): ExtensionUIContext {
+	const warnings = new ForeignExtensionWarning(options);
+	const caller = (): string | undefined => options.resolveCallerExtensionName?.();
+	const block = (hook: UiHook): boolean => {
+		const name = caller();
+		return name ? warnings.block(name, hook) : false;
+	};
+
+	return {
+		...base,
+		setHeader: (factory) => {
+			if (block("setHeader")) return;
+			base.setHeader(factory);
+		},
+		setFooter: (factory) => {
+			if (block("setFooter")) return;
+			base.setFooter(factory);
+		},
+		setEditorComponent: (factory) => {
+			if (block("setEditorComponent")) return;
+			base.setEditorComponent(factory);
+		},
+		setWidget: (key: string, content: never, widgetOptions?: never) => {
+			if (block("setWidget")) return;
+			base.setWidget(key, content, widgetOptions);
+		},
+		custom: async <T>(factory: CustomFactory<T>, customOptions?: CustomOptions): Promise<T> => {
+			if (block("custom")) return undefined as T;
+			return base.custom<T>(factory, customOptions);
+		},
+	};
+}

--- a/src/sumo-tui/pi-compat/region-registry.test.ts
+++ b/src/sumo-tui/pi-compat/region-registry.test.ts
@@ -1,0 +1,107 @@
+import type { KeybindingsManager, ReadonlyFooterDataProvider, Theme } from "@mariozechner/pi-coding-agent";
+import type { Component, EditorComponent, EditorTheme, TUI } from "@mariozechner/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { DIRECTION_LTR, loadYoga } from "../layout/yoga.js";
+import { CellBuffer } from "../render/buffer.js";
+import { composite } from "../render/compositor.js";
+import { RegionRegistry } from "./region-registry.js";
+
+class TestComponent implements Component {
+	public readonly dispose = vi.fn();
+	public constructor(private readonly rows: readonly string[] = ["component"]) {}
+	public invalidate(): void {}
+	public render(_width: number): string[] {
+		return [...this.rows];
+	}
+}
+
+function fakeTui(): TUI {
+	return { requestRender: vi.fn(), terminal: { columns: 80, rows: 24, setTitle: vi.fn() } } as unknown as TUI;
+}
+
+function fakeTheme(): Theme {
+	return {} as Theme;
+}
+
+function fakeEditorTheme(): EditorTheme {
+	return { borderColor: (value: string) => value, selectList: {} } as EditorTheme;
+}
+
+function fakeKeybindings(): KeybindingsManager {
+	return {} as KeybindingsManager;
+}
+
+function fakeFooterData(): ReadonlyFooterDataProvider {
+	return {
+		getGitBranch: () => "main",
+		getExtensionStatuses: () => new Map<string, string>(),
+		getAvailableProviderCount: () => 1,
+		onBranchChange: () => () => undefined,
+	};
+}
+
+async function makeRegistry(): Promise<RegionRegistry> {
+	const yoga = await loadYoga();
+	return new RegionRegistry({
+		yoga,
+		tui: fakeTui(),
+		theme: fakeTheme(),
+		editorTheme: fakeEditorTheme(),
+		keybindings: fakeKeybindings(),
+		footerData: fakeFooterData(),
+	});
+}
+
+describe("RegionRegistry", () => {
+	it("mounts and unmounts each Pi extension UI slot", async () => {
+		const registry = await makeRegistry();
+
+		registry.mountHeader(new TestComponent());
+		registry.mountFooter(new TestComponent());
+		registry.mountEditor(() => new TestComponent(["editor"]) as unknown as EditorComponent);
+		registry.mountWidget("above", new TestComponent(["above"]), { placement: "aboveEditor" });
+		registry.mountWidget("below", new TestComponent(["below"]), { placement: "belowEditor" });
+		registry.mountWidget("default", new TestComponent(["default"]), { placement: "default" });
+
+		expect(registry.getMounted("__header")?.slot).toBe("header");
+		expect(registry.getMounted("__footer")?.slot).toBe("footer");
+		expect(registry.getMounted("__editor")?.slot).toBe("editor");
+		expect(registry.getMounted("above")?.slot).toBe("aboveEditor");
+		expect(registry.getMounted("below")?.slot).toBe("belowEditor");
+		expect(registry.getMounted("default")?.slot).toBe("widgets-default");
+
+		registry.unmount("above");
+		expect(registry.getMounted("above")).toBeUndefined();
+		registry.dispose();
+	});
+
+	it("replacing an existing mount disposes the old component and node", async () => {
+		const registry = await makeRegistry();
+		const first = new TestComponent(["first"]);
+		const second = new TestComponent(["second"]);
+
+		registry.mountHeader(first);
+		const oldNode = registry.getMounted("__header")?.node;
+		registry.mountHeader(second);
+
+		expect(first.dispose).toHaveBeenCalledTimes(1);
+		expect(registry.getMounted("__header")?.component).toBe(second);
+		expect(() => oldNode?.markDirty()).toThrow("SumoNode has been disposed");
+		registry.dispose();
+	});
+
+	it("wraps string[] content as a static text leaf", async () => {
+		const registry = await makeRegistry();
+		registry.mountHeader(["alpha", "beta"]);
+		registry.root.width = 12;
+		registry.root.height = 6;
+		registry.root.yogaNode.calculateLayout(12, 6, DIRECTION_LTR);
+
+		const frame = new CellBuffer(6, 12);
+		composite(registry.root, frame);
+
+		expect(frame.toPlainRow(0)).toBe("alpha       ");
+		expect(frame.toPlainRow(1)).toBe("beta        ");
+		registry.dispose();
+	});
+});

--- a/src/sumo-tui/pi-compat/region-registry.ts
+++ b/src/sumo-tui/pi-compat/region-registry.ts
@@ -1,0 +1,309 @@
+import type {
+	KeybindingsManager,
+	ReadonlyFooterDataProvider,
+	Theme,
+} from "@mariozechner/pi-coding-agent";
+import type { Component, EditorComponent, EditorTheme, OverlayOptions, TUI } from "@mariozechner/pi-tui";
+import { SumoNode } from "../layout/node.js";
+import {
+	FLEX_DIRECTION_COLUMN,
+	POSITION_TYPE_ABSOLUTE,
+	type Yoga,
+} from "../layout/yoga.js";
+import { PiComponentLeaf } from "../widgets/pi-component-leaf.js";
+import { PiEditorLeaf } from "../widgets/pi-editor-leaf.js";
+import type { CustomEditor } from "@mariozechner/pi-coding-agent";
+
+export type RegionSlotName =
+	| "header"
+	| "footer"
+	| "editor"
+	| "aboveEditor"
+	| "belowEditor"
+	| "chat"
+	| "pending"
+	| "status"
+	| "widgets-default";
+
+export type WidgetPlacement = "aboveEditor" | "belowEditor" | "default";
+export type DisposableComponent = Component & { dispose?(): void };
+
+export type HeaderMount =
+	| readonly string[]
+	| DisposableComponent
+	| ((tui: TUI, theme: Theme) => DisposableComponent);
+
+export type FooterMount =
+	| readonly string[]
+	| DisposableComponent
+	| ((tui: TUI, theme: Theme, footerData: ReadonlyFooterDataProvider) => DisposableComponent);
+
+export type WidgetMount =
+	| readonly string[]
+	| DisposableComponent
+	| ((tui: TUI, theme: Theme) => DisposableComponent);
+
+export interface RegionRegistryOptions {
+	readonly yoga: Yoga;
+	readonly tui: TUI;
+	readonly theme: Theme;
+	readonly editorTheme: EditorTheme;
+	readonly keybindings: KeybindingsManager;
+	readonly footerData?: ReadonlyFooterDataProvider;
+	readonly root?: SumoNode;
+	readonly onChange?: () => void;
+}
+
+interface MountedRegion {
+	readonly key: string;
+	readonly slot: RegionSlotName | "overlay";
+	readonly node: SumoNode;
+	readonly component: DisposableComponent;
+}
+
+class StaticTextComponent implements Component {
+	public constructor(private readonly lines: readonly string[]) {}
+	public invalidate(): void {}
+	public render(_width: number): string[] {
+		return [...this.lines];
+	}
+}
+
+function isStringArray(value: unknown): value is readonly string[] {
+	return Array.isArray(value);
+}
+
+function isComponent(value: unknown): value is DisposableComponent {
+	return typeof value === "object" && value !== null && "render" in value && typeof (value as Component).render === "function";
+}
+
+function safeDispose(component: DisposableComponent): void {
+	try {
+		component.dispose?.();
+	} catch (error) {
+		console.debug("sumo-tui: component dispose failed", error);
+	}
+}
+
+function placementToSlot(placement: WidgetPlacement | undefined): RegionSlotName {
+	if (placement === "belowEditor") return "belowEditor";
+	if (placement === "default") return "widgets-default";
+	return "aboveEditor";
+}
+
+function percentToCells(value: number | `${number}%` | undefined, total: number): number | undefined {
+	if (value === undefined) return undefined;
+	if (typeof value === "number") return value;
+	return Math.max(0, Math.floor((Number.parseFloat(value) / 100) * total));
+}
+
+/**
+ * Named SumoCode slots for Pi extension UI hooks.
+ *
+ * Source: Pi 0.70.2 wires extension UI through `createExtensionUIContext()` and
+ * delegates `setWidget`, `setFooter`, `setHeader`, `custom`, and
+ * `setEditorComponent` to mutable pi-tui containers at
+ * `node_modules/.pnpm/@mariozechner+pi-coding-agent@0.70.2.../dist/modes/interactive/interactive-mode.js:1522-1557`.
+ * This registry is the retained-Yoga replacement for those mutable containers.
+ */
+export class RegionRegistry {
+	public readonly root: SumoNode;
+	private readonly yoga: Yoga;
+	private readonly tui: TUI;
+	private readonly theme: Theme;
+	private readonly editorTheme: EditorTheme;
+	private readonly keybindings: KeybindingsManager;
+	private readonly footerData: ReadonlyFooterDataProvider | undefined;
+	private readonly onChange: () => void;
+	private readonly slots: Record<RegionSlotName, SumoNode>;
+	private readonly overlayRoot: SumoNode;
+	private readonly mounts = new Map<string, MountedRegion>();
+
+	public constructor(options: RegionRegistryOptions) {
+		this.yoga = options.yoga;
+		this.tui = options.tui;
+		this.theme = options.theme;
+		this.editorTheme = options.editorTheme;
+		this.keybindings = options.keybindings;
+		this.footerData = options.footerData;
+		this.onChange = options.onChange ?? (() => undefined);
+		this.root = options.root ?? new SumoNode(this.yoga.Node.create());
+		this.root.flexDirection = FLEX_DIRECTION_COLUMN;
+
+		this.slots = {
+			header: this.createSlot("header"),
+			chat: this.createFlexSlot("chat"),
+			pending: this.createSlot("pending"),
+			status: this.createSlot("status"),
+			"widgets-default": this.createSlot("widgets-default"),
+			aboveEditor: this.createSlot("aboveEditor"),
+			editor: this.createSlot("editor"),
+			belowEditor: this.createSlot("belowEditor"),
+			footer: this.createSlot("footer"),
+		};
+
+		this.overlayRoot = new SumoNode(this.yoga.Node.create(), this.root);
+		this.overlayRoot.position = POSITION_TYPE_ABSOLUTE;
+		this.overlayRoot.top = 0;
+		this.overlayRoot.left = 0;
+		this.overlayRoot.right = 0;
+		this.overlayRoot.bottom = 0;
+		this.overlayRoot.zIndex = 10_000;
+	}
+
+	public getSlot(name: RegionSlotName): SumoNode {
+		return this.slots[name];
+	}
+
+	public getMountedKeys(): string[] {
+		return [...this.mounts.keys()];
+	}
+
+	public getMounted(key: string): MountedRegion | undefined {
+		return this.mounts.get(key);
+	}
+
+	public mountHeader(content: HeaderMount | undefined): void {
+		this.mount("__header", "header", content === undefined ? undefined : this.resolveHeader(content));
+	}
+
+	public mountFooter(content: FooterMount | undefined): void {
+		this.mount("__footer", "footer", content === undefined ? undefined : this.resolveFooter(content));
+	}
+
+	public mountEditor(factory: ((tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager) => EditorComponent) | undefined): void {
+		this.unmount("__editor");
+		if (!factory) {
+			this.onChange();
+			return;
+		}
+
+		const component = factory(this.tui, this.editorTheme, this.keybindings) as unknown as DisposableComponent;
+		const node = PiEditorLeaf.create(this.yoga, component as unknown as CustomEditor, this.slots.editor);
+		this.mounts.set("__editor", { key: "__editor", slot: "editor", node, component });
+		this.onChange();
+	}
+
+	public mountWidget(key: string, content: WidgetMount | undefined, opts: { placement?: WidgetPlacement } = {}): void {
+		this.unmount(key);
+		if (content === undefined) {
+			this.onChange();
+			return;
+		}
+		this.mount(key, placementToSlot(opts.placement), this.resolveWidget(content));
+	}
+
+	public mountOverlay(key: string, component: DisposableComponent | undefined, overlayOptions?: OverlayOptions | (() => OverlayOptions)): void {
+		this.unmount(key);
+		if (!component) {
+			this.onChange();
+			return;
+		}
+		const node = PiComponentLeaf.create(this.yoga, component, this.overlayRoot);
+		node.position = POSITION_TYPE_ABSOLUTE;
+		node.zIndex = this.mounts.size + 1;
+		this.applyOverlayOptions(node, overlayOptions);
+		this.mounts.set(key, { key, slot: "overlay", node, component });
+		this.onChange();
+	}
+
+	public unmount(key: string): void {
+		const existing = this.mounts.get(key);
+		if (!existing) return;
+		this.mounts.delete(key);
+		safeDispose(existing.component);
+		existing.node.dispose();
+		this.onChange();
+	}
+
+	public clear(): void {
+		for (const key of [...this.mounts.keys()]) this.unmount(key);
+	}
+
+	public dispose(): void {
+		this.clear();
+		this.root.dispose();
+	}
+
+	private createSlot(_name: RegionSlotName): SumoNode {
+		const slot = new SumoNode(this.yoga.Node.create(), this.root);
+		slot.flexDirection = FLEX_DIRECTION_COLUMN;
+		return slot;
+	}
+
+	private createFlexSlot(name: RegionSlotName): SumoNode {
+		const slot = this.createSlot(name);
+		slot.flexGrow = 1;
+		slot.flexShrink = 1;
+		return slot;
+	}
+
+	private mount(key: string, slot: RegionSlotName, component: DisposableComponent | undefined): void {
+		this.unmount(key);
+		if (!component) {
+			this.onChange();
+			return;
+		}
+		const node = PiComponentLeaf.create(this.yoga, component, this.slots[slot]);
+		this.mounts.set(key, { key, slot, node, component });
+		this.onChange();
+	}
+
+	private resolveHeader(content: HeaderMount): DisposableComponent {
+		if (isStringArray(content)) return new StaticTextComponent(content);
+		if (isComponent(content)) return content;
+		return content(this.tui, this.theme);
+	}
+
+	private resolveFooter(content: FooterMount): DisposableComponent {
+		if (isStringArray(content)) return new StaticTextComponent(content);
+		if (isComponent(content)) return content;
+		return content(this.tui, this.theme, this.footerData ?? this.createEmptyFooterData());
+	}
+
+	private resolveWidget(content: WidgetMount): DisposableComponent {
+		if (isStringArray(content)) return new StaticTextComponent(content);
+		if (isComponent(content)) return content;
+		return content(this.tui, this.theme);
+	}
+
+	private createEmptyFooterData(): ReadonlyFooterDataProvider {
+		return {
+			getGitBranch: () => null,
+			getExtensionStatuses: () => new Map<string, string>(),
+			getAvailableProviderCount: () => 0,
+			onBranchChange: () => () => undefined,
+		} as ReadonlyFooterDataProvider;
+	}
+
+	private applyOverlayOptions(node: SumoNode, overlayOptions: OverlayOptions | (() => OverlayOptions) | undefined): void {
+		const options = typeof overlayOptions === "function" ? overlayOptions() : overlayOptions;
+		const terminal = this.tui.terminal as { columns?: number; rows?: number } | undefined;
+		const columns = terminal?.columns ?? 80;
+		const rows = terminal?.rows ?? 24;
+		const width = percentToCells(options?.width, columns) ?? Math.min(60, columns);
+		const maxHeight = percentToCells(options?.maxHeight, rows);
+		node.width = width;
+		if (maxHeight !== undefined) node.height = maxHeight;
+
+		if (options?.anchor === "top-right") {
+			node.top = options.offsetY ?? 0;
+			node.right = Math.abs(options.offsetX ?? 0);
+			return;
+		}
+		if (options?.anchor === "bottom-right") {
+			node.bottom = Math.abs(options.offsetY ?? 0);
+			node.right = Math.abs(options.offsetX ?? 0);
+			return;
+		}
+		if (options?.anchor === "right-center") {
+			node.top = Math.max(0, Math.floor(rows / 2) + (options.offsetY ?? 0));
+			node.right = Math.abs(options.offsetX ?? 0);
+			return;
+		}
+		node.top = options?.row === undefined ? Math.max(0, Math.floor(rows / 3)) : (percentToCells(options.row, rows) ?? 0);
+		node.left = options?.col === undefined ? Math.max(0, Math.floor((columns - width) / 2)) : (percentToCells(options.col, columns) ?? 0);
+	}
+}
+
+export { StaticTextComponent };

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -1,0 +1,107 @@
+/*
+ * MIT License
+ *
+ * Portions of this compatibility boundary are derived from
+ * @mariozechner/pi-coding-agent 0.70.2, package `dist/modes/interactive/interactive-mode.js`.
+ * The upstream npm package declares license: MIT.
+ *
+ * Copyright (c) Mario Zechner and pi-mono contributors.
+ * Copyright (c) Dhruv Kelawala and SumoCode contributors.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+import type { AgentSessionRuntime, InteractiveModeOptions } from "@mariozechner/pi-coding-agent";
+import { InteractiveMode } from "@mariozechner/pi-coding-agent";
+import type { ExtensionUIContext } from "@mariozechner/pi-coding-agent";
+import { SumoExtensionUIAdapter, type SumoExtensionUIAdapterOptions } from "./extension-ui-adapter.js";
+import { createForeignAwareUIContext, type ForeignAwareUIOptions } from "./foreign-extension-warning.js";
+
+export interface SumoInteractiveModeOptions extends InteractiveModeOptions {
+	/**
+	 * Enables the retained extension UI adapter once the Pi binary fork wires this
+	 * class in place of InteractiveMode.
+	 */
+	readonly retainedExtensionUI?: boolean;
+}
+
+export interface CreateExtensionUIContextOptions extends SumoExtensionUIAdapterOptions {
+	readonly foreignExtensions?: ForeignAwareUIOptions;
+}
+
+/**
+ * Small Phase 4 fork boundary for Pi 0.70.x.
+ *
+ * Pi's CLI constructs `InteractiveMode` directly in
+ * `node_modules/.pnpm/@mariozechner+pi-coding-agent@0.70.2.../dist/main.js:548-571`.
+ * The real fork patch replaces that constructor call with `new
+ * SumoInteractiveMode(...)`; extensions launched via plain `pi -e
+ * ./src/extension.ts` still enter upstream Pi until that binary integration is
+ * applied.
+ *
+ * Borrowed responsibilities, with source citations:
+ * - interactive entrypoint shape (`init`, `run`, `stop`) mirrors
+ *   `interactive-mode.js:389-465`, `interactive-mode.js:501-556`, and
+ *   `interactive-mode.js:4512-4530`.
+ * - extension UI binding seam is the upstream `createExtensionUIContext()`
+ *   dispatch table at `interactive-mode.js:1522-1557`.
+ * - extension lifecycle bind remains upstream's `bindCurrentSessionExtensions()`
+ *   responsibility at `interactive-mode.js:1128-1207`; this class only provides
+ *   the retained UI context object used by the fork.
+ */
+export class SumoInteractiveMode {
+	private readonly upstream: InteractiveMode;
+	private retainedUIContext: ExtensionUIContext | undefined;
+
+	public constructor(runtimeHost: AgentSessionRuntime, private readonly options: SumoInteractiveModeOptions = {}) {
+		this.upstream = new InteractiveMode(runtimeHost, options);
+	}
+
+	public async init(): Promise<void> {
+		await this.upstream.init();
+	}
+
+	public async run(): Promise<void> {
+		await this.upstream.run();
+	}
+
+	public stop(): void {
+		this.upstream.stop();
+	}
+
+	public createExtensionUIContext(options: CreateExtensionUIContextOptions): ExtensionUIContext {
+		const base = new SumoExtensionUIAdapter(options);
+		this.retainedUIContext = options.foreignExtensions
+			? createForeignAwareUIContext(base, options.foreignExtensions)
+			: base;
+		return this.retainedUIContext;
+	}
+
+	public getRetainedUIContext(): ExtensionUIContext | undefined {
+		return this.retainedUIContext;
+	}
+
+	public isRetainedExtensionUIEnabled(): boolean {
+		return this.options.retainedExtensionUI === true;
+	}
+}
+
+export function sumoInteractiveMode(runtimeHost: AgentSessionRuntime, options: SumoInteractiveModeOptions = {}): SumoInteractiveMode {
+	return new SumoInteractiveMode(runtimeHost, options);
+}

--- a/src/sumo-tui/widgets/modal.ts
+++ b/src/sumo-tui/widgets/modal.ts
@@ -1,0 +1,213 @@
+import { Key, matchesKey, type Component, type KeyId } from "@mariozechner/pi-tui";
+
+export interface ModalDialogOptions {
+	readonly signal?: AbortSignal;
+	readonly timeout?: number;
+}
+
+export type ModalResult = boolean | string | undefined;
+
+type ActiveModal =
+	| {
+			readonly kind: "confirm";
+			readonly title: string;
+			readonly message: string;
+			selectedIndex: number;
+			readonly resolve: (value: boolean) => void;
+			readonly cleanup: () => void;
+	  }
+	| {
+			readonly kind: "select";
+			readonly title: string;
+			readonly options: readonly string[];
+			selectedIndex: number;
+			readonly resolve: (value: string | undefined) => void;
+			readonly cleanup: () => void;
+	  }
+	| {
+			readonly kind: "input";
+			readonly title: string;
+			readonly placeholder: string | undefined;
+			value: string;
+			readonly resolve: (value: string | undefined) => void;
+			readonly cleanup: () => void;
+	  };
+
+export interface ModalManagerOptions {
+	readonly setTimeout?: typeof setTimeout;
+	readonly clearTimeout?: typeof clearTimeout;
+	readonly onChange?: () => void;
+}
+
+function keyEq(data: string, ...ids: readonly string[]): boolean {
+	for (const id of ids) {
+		if (data === id) return true;
+		if (matchesKey(data, id as KeyId)) return true;
+	}
+	return false;
+}
+
+function border(width: number): string {
+	return `─`.repeat(Math.max(0, width));
+}
+
+function truncate(text: string, width: number): string {
+	if (text.length <= width) return text;
+	if (width <= 1) return "…";
+	return `${text.slice(0, width - 1)}…`;
+}
+
+function pad(text: string, width: number): string {
+	return text.length >= width ? text : `${text}${" ".repeat(width - text.length)}`;
+}
+
+/** Basic retained modal layer for Phase 4 confirm/select/input flows. */
+export class ModalManager implements Component {
+	private readonly setTimer: typeof setTimeout;
+	private readonly clearTimer: typeof clearTimeout;
+	private readonly onChange: () => void;
+	private active: ActiveModal | undefined;
+
+	public constructor(options: ModalManagerOptions = {}) {
+		this.setTimer = options.setTimeout ?? setTimeout;
+		this.clearTimer = options.clearTimeout ?? clearTimeout;
+		this.onChange = options.onChange ?? (() => undefined);
+	}
+
+	public confirm(title: string, message: string, opts?: ModalDialogOptions): Promise<boolean> {
+		return new Promise<boolean>((resolve) => {
+			const cleanup = this.installDismissal(opts, () => this.finish(false));
+			this.active = { kind: "confirm", title, message, selectedIndex: 0, resolve, cleanup };
+			this.onChange();
+		});
+	}
+
+	public select(title: string, options: readonly string[], opts?: ModalDialogOptions): Promise<string | undefined> {
+		return new Promise<string | undefined>((resolve) => {
+			const cleanup = this.installDismissal(opts, () => this.finish(undefined));
+			this.active = { kind: "select", title, options, selectedIndex: 0, resolve, cleanup };
+			this.onChange();
+		});
+	}
+
+	public input(title: string, placeholder?: string, opts?: ModalDialogOptions): Promise<string | undefined> {
+		return new Promise<string | undefined>((resolve) => {
+			const cleanup = this.installDismissal(opts, () => this.finish(undefined));
+			this.active = { kind: "input", title, placeholder, value: "", resolve, cleanup };
+			this.onChange();
+		});
+	}
+
+	public close(): void {
+		this.finish(undefined);
+	}
+
+	public getActiveKind(): ActiveModal["kind"] | undefined {
+		return this.active?.kind;
+	}
+
+	public invalidate(): void {}
+
+	public handleInput(data: string): void {
+		if (!this.active) return;
+		if (keyEq(data, Key.escape, "escape", "esc")) {
+			this.finish(this.active.kind === "confirm" ? false : undefined);
+			return;
+		}
+
+		if (this.active.kind === "input") {
+			this.handleInputModal(data, this.active);
+			return;
+		}
+
+		if (keyEq(data, Key.up, Key.left, "up", "left")) {
+			this.moveSelection(-1);
+			return;
+		}
+		if (keyEq(data, Key.down, Key.right, "down", "right")) {
+			this.moveSelection(1);
+			return;
+		}
+		if (keyEq(data, Key.enter, "return", "enter")) {
+			if (this.active.kind === "confirm") this.finish(this.active.selectedIndex === 0);
+			else this.finish(this.active.options[this.active.selectedIndex]);
+		}
+	}
+
+	public render(width: number): string[] {
+		if (!this.active || width <= 0) return [];
+		const modalWidth = Math.min(width, Math.max(32, Math.floor(width * 0.6)));
+		const left = " ".repeat(Math.max(0, Math.floor((width - modalWidth) / 2)));
+		const line = (text: string) => `${left}${pad(truncate(text, modalWidth), modalWidth)}`;
+		const lines: string[] = [line(border(modalWidth)), line(this.active.title), line(border(modalWidth))];
+
+		if (this.active.kind === "confirm") {
+			lines.push(...this.active.message.split("\n").map(line));
+			const yes = this.active.selectedIndex === 0 ? "▶ Yes" : "  Yes";
+			const no = this.active.selectedIndex === 1 ? "▶ No" : "  No";
+			lines.push(line(`${yes}    ${no}`));
+		} else if (this.active.kind === "select") {
+			for (const [index, option] of this.active.options.entries()) {
+				lines.push(line(`${index === this.active.selectedIndex ? "▶" : " "} ${option}`));
+			}
+		} else {
+			const value = this.active.value || this.active.placeholder || "";
+			lines.push(line(`> ${value}`));
+		}
+
+		lines.push(line(border(modalWidth)));
+		return lines;
+	}
+
+	private handleInputModal(data: string, modal: Extract<ActiveModal, { kind: "input" }>): void {
+		if (keyEq(data, Key.enter, "return", "enter")) {
+			this.finish(modal.value);
+			return;
+		}
+		if (keyEq(data, Key.backspace, "backspace")) {
+			modal.value = modal.value.slice(0, -1);
+			this.onChange();
+			return;
+		}
+		if (data.length === 1 && !/\p{Cc}/u.test(data)) {
+			modal.value += data;
+			this.onChange();
+		}
+	}
+
+	private moveSelection(delta: -1 | 1): void {
+		if (!this.active || this.active.kind === "input") return;
+		const count = this.active.kind === "confirm" ? 2 : this.active.options.length;
+		if (count === 0) return;
+		this.active.selectedIndex = (this.active.selectedIndex + delta + count) % count;
+		this.onChange();
+	}
+
+	private finish(value: ModalResult): void {
+		const modal = this.active;
+		if (!modal) return;
+		this.active = undefined;
+		modal.cleanup();
+		if (modal.kind === "confirm") modal.resolve(value === true);
+		else modal.resolve(typeof value === "string" ? value : undefined);
+		this.onChange();
+	}
+
+	private installDismissal(opts: ModalDialogOptions | undefined, dismiss: () => void): () => void {
+		let timer: ReturnType<typeof setTimeout> | undefined;
+		const onAbort = (): void => dismiss();
+		if (opts?.signal?.aborted) {
+			queueMicrotask(dismiss);
+		} else {
+			opts?.signal?.addEventListener("abort", onAbort, { once: true });
+		}
+		if (opts?.timeout !== undefined && opts.timeout > 0) {
+			timer = this.setTimer(dismiss, opts.timeout);
+			timer.unref?.();
+		}
+		return () => {
+			if (timer) this.clearTimer(timer);
+			opts?.signal?.removeEventListener("abort", onAbort);
+		};
+	}
+}

--- a/src/sumo-tui/widgets/notification.ts
+++ b/src/sumo-tui/widgets/notification.ts
@@ -1,0 +1,111 @@
+import type { Component } from "@mariozechner/pi-tui";
+
+export type NotificationLevel = "info" | "warning" | "error";
+
+export interface Toast {
+	readonly id: number;
+	readonly message: string;
+	readonly level: NotificationLevel;
+	readonly createdAt: number;
+}
+
+export interface NotificationCenterOptions {
+	readonly defaultTimeoutMs?: number;
+	readonly now?: () => number;
+	readonly setTimeout?: typeof setTimeout;
+	readonly clearTimeout?: typeof clearTimeout;
+	readonly onChange?: () => void;
+}
+
+const LEVEL_PREFIX: Record<NotificationLevel, string> = {
+	info: "ⓘ",
+	warning: "⚠",
+	error: "✖",
+};
+
+function stripAnsi(text: string): string {
+	return text.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+function truncateVisible(text: string, width: number): string {
+	const plain = stripAnsi(text);
+	if (plain.length <= width) return text;
+	if (width <= 1) return "…";
+	return `${plain.slice(0, width - 1)}…`;
+}
+
+function pad(text: string, width: number): string {
+	const visible = stripAnsi(text).length;
+	return visible >= width ? text : `${text}${" ".repeat(width - visible)}`;
+}
+
+/** Minimal top-right toast stack used by the Phase 4 ExtensionUI adapter. */
+export class NotificationCenter implements Component {
+	private readonly defaultTimeoutMs: number;
+	private readonly getNow: () => number;
+	private readonly setTimer: typeof setTimeout;
+	private readonly clearTimer: typeof clearTimeout;
+	private readonly onChange: () => void;
+	private readonly timers = new Map<number, ReturnType<typeof setTimeout>>();
+	private readonly toasts: Toast[] = [];
+	private nextId = 1;
+
+	public constructor(options: NotificationCenterOptions = {}) {
+		this.defaultTimeoutMs = options.defaultTimeoutMs ?? 3_000;
+		this.getNow = options.now ?? Date.now;
+		this.setTimer = options.setTimeout ?? setTimeout;
+		this.clearTimer = options.clearTimeout ?? clearTimeout;
+		this.onChange = options.onChange ?? (() => undefined);
+	}
+
+	public notify(message: string, level: NotificationLevel = "info", timeoutMs = this.defaultTimeoutMs): number {
+		const id = this.nextId++;
+		this.toasts.push({ id, message, level, createdAt: this.getNow() });
+		if (timeoutMs > 0) {
+			const timer = this.setTimer(() => this.dismiss(id), timeoutMs);
+			timer.unref?.();
+			this.timers.set(id, timer);
+		}
+		this.onChange();
+		return id;
+	}
+
+	public dismiss(id: number): void {
+		const index = this.toasts.findIndex((toast) => toast.id === id);
+		if (index === -1) return;
+		this.toasts.splice(index, 1);
+		const timer = this.timers.get(id);
+		if (timer) this.clearTimer(timer);
+		this.timers.delete(id);
+		this.onChange();
+	}
+
+	public clear(): void {
+		for (const timer of this.timers.values()) this.clearTimer(timer);
+		this.timers.clear();
+		this.toasts.length = 0;
+		this.onChange();
+	}
+
+	public getToasts(): readonly Toast[] {
+		return this.toasts;
+	}
+
+	public invalidate(): void {}
+
+	public render(width: number): string[] {
+		if (this.toasts.length === 0 || width <= 0) return [];
+		const boxWidth = Math.min(Math.max(24, Math.floor(width * 0.45)), width);
+		const leftPad = Math.max(0, width - boxWidth);
+		const indent = " ".repeat(leftPad);
+		return this.toasts.slice(-4).map((toast) => {
+			const content = `${LEVEL_PREFIX[toast.level]} ${toast.message}`;
+			const text = truncateVisible(content, Math.max(0, boxWidth - 2));
+			return `${indent} ${pad(text, boxWidth - 1)}`;
+		});
+	}
+
+	public dispose(): void {
+		this.clear();
+	}
+}

--- a/test/integration/session-lifecycle.test.ts
+++ b/test/integration/session-lifecycle.test.ts
@@ -1,0 +1,71 @@
+import type { KeybindingsManager, Theme } from "@mariozechner/pi-coding-agent";
+import type { Component, EditorComponent, EditorTheme, TUI } from "@mariozechner/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { RegionRegistry } from "../../src/sumo-tui/pi-compat/region-registry.js";
+import { DIRECTION_LTR, loadYoga } from "../../src/sumo-tui/layout/yoga.js";
+import { ChatPager } from "../../src/sumo-tui/widgets/chat-pager.js";
+
+class TestEditor implements Component {
+	public text = "";
+	public invalidate(): void {}
+	public render(_width: number): string[] {
+		return [this.text];
+	}
+	public setText(text: string): void {
+		this.text = text;
+	}
+	public getText(): string {
+		return this.text;
+	}
+}
+
+function fakeTui(): TUI {
+	return { requestRender: vi.fn(), terminal: { columns: 80, rows: 24, setTitle: vi.fn() } } as unknown as TUI;
+}
+
+function fakeTheme(): Theme {
+	return {} as Theme;
+}
+
+function fakeEditorTheme(): EditorTheme {
+	return { borderColor: (value: string) => value, selectList: {} } as EditorTheme;
+}
+
+function fakeKeybindings(): KeybindingsManager {
+	return {} as KeybindingsManager;
+}
+
+describe("Phase 4 retained session lifecycle", () => {
+	it("boots slots, clears chat on new session, and disposes the Yoga tree", async () => {
+		const yoga = await loadYoga();
+		const registry = new RegionRegistry({
+			yoga,
+			tui: fakeTui(),
+			theme: fakeTheme(),
+			editorTheme: fakeEditorTheme(),
+			keybindings: fakeKeybindings(),
+		});
+		const chat = ChatPager.create(yoga, registry.getSlot("chat"));
+		const editor = new TestEditor();
+
+		registry.mountHeader(["SUMOCODE"]);
+		registry.mountEditor(() => editor as unknown as EditorComponent);
+		chat.addMessage("user", "hello");
+		chat.addMessage("sumo", "world");
+		registry.root.width = 80;
+		registry.root.height = 24;
+		registry.root.yogaNode.calculateLayout(80, 24, DIRECTION_LTR);
+
+		expect(chat.getRenderedMessages()).toHaveLength(2);
+		expect(registry.getMounted("__editor")?.slot).toBe("editor");
+
+		chat.clearMessages();
+		editor.setText("");
+
+		expect(chat.getRenderedMessages()).toHaveLength(0);
+		expect(editor.getText()).toBe("");
+
+		registry.dispose();
+		expect(() => registry.root.markDirty()).toThrow("SumoNode has been disposed");
+	});
+});

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -1,0 +1,50 @@
+import type { ExtensionAPI, RegisteredCommand } from "@mariozechner/pi-coding-agent";
+import { describe, expect, it } from "vitest";
+import { installCommandPalette } from "../../src/command-palette.js";
+import { registerMemoryCommand } from "../../src/memory-editor.js";
+import { registerPersonaCommand } from "../../src/commands/persona.js";
+import { registerSpinnerCommand } from "../../src/commands/spinner.js";
+import { registerTabsCommand } from "../../src/commands/tabs.js";
+import { registerThemeCommand } from "../../src/commands/theme.js";
+import { registerThemeCheckCommand } from "../../src/commands/theme-check.js";
+
+function commandRegistry(): { pi: ExtensionAPI; commands: Map<string, Omit<RegisteredCommand, "name" | "sourceInfo">> } {
+	const commands = new Map<string, Omit<RegisteredCommand, "name" | "sourceInfo">>();
+	const pi = {
+		registerCommand: (name: string, options: Omit<RegisteredCommand, "name" | "sourceInfo">) => {
+			commands.set(name, options);
+		},
+		registerShortcut: () => undefined,
+		on: () => undefined,
+	} as unknown as ExtensionAPI;
+	return { pi, commands };
+}
+
+describe("Phase 4 slash command pipe", () => {
+	it("surfaces all /sumo:* commands for autocomplete providers", () => {
+		const { pi, commands } = commandRegistry();
+
+		installCommandPalette(pi);
+		registerTabsCommand(pi, { configPath: "/tmp/sumocode-tabs-test.json" });
+		registerThemeCommand(pi);
+		registerPersonaCommand(pi, {
+			personaPath: "/tmp/sumocode-persona.md",
+			fileExists: () => true,
+			runEditor: () => ({ status: 0 }),
+		});
+		registerSpinnerCommand(pi);
+		registerThemeCheckCommand(pi);
+		registerMemoryCommand(pi);
+
+		const suggestions = [...commands.keys()].filter((name) => name.startsWith("sumo:")).sort();
+
+		expect(suggestions).toEqual([
+			"sumo:memory",
+			"sumo:persona",
+			"sumo:spinner",
+			"sumo:tabs",
+			"sumo:theme",
+			"sumo:theme-check",
+		]);
+	});
+});


### PR DESCRIPTION
## Phase 4a: scaffolding (does NOT close #38)

This PR ships the pi-compat scaffolding from Phase 4 — region registry, extension UI adapter, foreign extension warning, notification widget, modal widget, MIT-licensed `SumoInteractiveMode` shell. It also documents Pi's `interactive-mode.js` responsibilities.

**What's NOT in this PR**: the actual fork of `pi-coding-agent` to swap `new InteractiveMode()` → `new SumoInteractiveMode()`. That blocker is filed as #44 (Phase 4b).

The scaffolding is unit-tested + integration-tested independently. When Phase 4b lands the fork, this scaffolding activates as the runtime renderer. Until then, SumoCode runs on Pi's default TUI with sumo-tui's Phase 1 lifecycle shim.

## What ships

- `src/sumo-tui/pi-compat/region-registry.ts` — slot routing for setHeader/setFooter/setEditor/setWidget
- `src/sumo-tui/pi-compat/extension-ui-adapter.ts` — Pi `ExtensionUIContext` impl
- `src/sumo-tui/pi-compat/foreign-extension-warning.ts` — Q2:C foreign extension no-op + warning
- `src/sumo-tui/pi-compat/sumo-interactive-mode.ts` — vendored fork shell (MIT notice, Pi citations)
- `src/sumo-tui/widgets/notification.ts` — toast for `ui.notify`
- `src/sumo-tui/widgets/modal.ts` — basic modal for `ui.confirm` / `ui.select`
- `/sumo:theme` slash command
- `docs/research/interactive-mode-map.md` — Pi source line citations
- `docs/research/phase-4-progress.md` — fork blocker documented

## Tests

- `pnpm test` — 315 unit tests passing
- `pnpm test:integration` — 11 integration tests passing across 8 files
- `pnpm exec tsc --noEmit` — clean

## Why merge as 4a instead of waiting for 4b

The scaffolding is independently mergeable + testable. Merging unblocks Phase 5 (cathedral migration can use the new region-registry against unit tests). When 4b's fork lands, the renderer takeover is a single switchover.

## Phase 4b (issue #44 incoming)

Fork `pi-coding-agent` to actually swap `InteractiveMode` for `SumoInteractiveMode`. ~1-2 days.

## Edge cases addressed

- 6.1, 6.2 (foreign extension warn + no-op)
- Partial 14.x (slash commands registered against Pi; runtime effect awaits 4b)
- Documentation for 16.1 (Pi version pinning, fork strategy)

Tracks: #38 (Phase 4 overall, kept open until 4b lands)
