### PR TITLE
feat(sumo-tui): Phase 4b — fork pi-coding-agent + activate runtime

### DIFF
--- a/bin/sumocode.sh
+++ b/bin/sumocode.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+export SUMO_TUI="${SUMO_TUI:-1}"
+if [[ -z "${SUMO_TUI_MODULE:-}" ]]; then
+	SUMO_TUI_MODULE="$(node -e 'const { pathToFileURL } = require("node:url"); console.log(pathToFileURL(process.argv[1]).href);' "${ROOT_DIR}/sumo-interactive-mode.js")"
+	export SUMO_TUI_MODULE
+fi
+
+PI_BIN="${ROOT_DIR}/node_modules/.bin/pi"
+if [[ ! -x "${PI_BIN}" ]]; then
+	PI_BIN="pi"
+fi
+
+exec "${PI_BIN}" -e "${ROOT_DIR}/src/extension.ts" "$@"

--- a/docs/adr/0001-sumo-tui-framework.md
+++ b/docs/adr/0001-sumo-tui-framework.md
@@ -184,4 +184,5 @@ Total: ~38 working days across ~8–10 calendar weeks.
 ## Status notes
 
 - 2026-04-27 — Drafted, accepted by @dhruvkelawala. Phase 0 issues filed. Phase 1 sprint begins.
+- 2026-04-27 — Phase 4b landed the Pi `0.70.2` fork activation path. `SUMO_TUI=1` now switches Pi's interactive constructor to SumoCode's `SumoInteractiveMode`; local worktrees use `SUMO_TUI_MODULE=file://.../sumo-interactive-mode.js`, and pnpm applies the equivalent published-package patch because GitHub subdirectory installs omit Pi's untracked `dist/` output.
 - (revisit dates / re-evaluations to be appended below)

--- a/docs/research/phase-4-progress.md
+++ b/docs/research/phase-4-progress.md
@@ -67,6 +67,10 @@ The prompt listed these files, but they were not present in either the worktree 
 
 I proceeded using the shipped Phase 1–3 source/tests, Pi docs, and Pi 0.70.2 installed sources.
 
+## Phase 4b update
+
+Phase 4b added the fork activation path documented here: `SUMO_TUI=1` now causes the patched Pi `dist/main.js` constructor site to load `SumoInteractiveMode` via `SUMO_TUI_MODULE` or `@dhruvkelawala/sumocode/sumo-interactive-mode`. The SumoCode worktree uses a pnpm patch against the published Pi `0.70.2` package because pnpm GitHub subdirectory installs omit Pi's untracked `dist/` output.
+
 ## Acceptance criteria still open
 
 - Visual verification via VHS/screenshot of SumoCode running on the retained renderer.

--- a/docs/research/phase-4b-postmortem.md
+++ b/docs/research/phase-4b-postmortem.md
@@ -1,0 +1,68 @@
+# Phase 4b postmortem — Pi fork activation
+
+Date: 2026-04-27
+Branch: `feat/sumo-tui-phase-4b`
+Issue: `#44` (also closes parent `#38`)
+
+## What landed
+
+- Created Dhruv's `pi-mono` fork branch `sumocode/0.70.2-fork` from upstream tag `v0.70.2`.
+- Patched `packages/coding-agent/src/main.ts` with a 16-line non-breaking switch:
+  - default path remains `new InteractiveMode(...)`;
+  - `SUMO_TUI=1` or `--sumo-tui` loads `SumoInteractiveMode`;
+  - `SUMO_TUI_MODULE` can point at a local file URL for worktree development.
+- Added `sumo-interactive-mode.js` as SumoCode's runtime-loadable public bridge.
+- Added `bin/sumocode.sh`, which sets `SUMO_TUI=1`, points `SUMO_TUI_MODULE` at the worktree bridge, and runs the local patched Pi binary.
+- Added a pnpm patch for `@mariozechner/pi-coding-agent@0.70.2` so the installed `dist/main.js` contains the same fork behaviour.
+- Updated `SumoInteractiveMode` so the forked entry point starts real sumo-tui primitives before delegating to Pi's existing session loop:
+  - `TerminalController`
+  - Yoga root `SumoNode`
+  - `ChatPager`
+  - `FrameScheduler`
+  - `CellBuffer` + compositor + diff writer path
+
+## What went smoothly
+
+- The upstream constructor seam was exactly where Phase 4a documented it: `dist/main.js` around the interactive-mode construction block.
+- The source patch is tiny and non-breaking when `SUMO_TUI` is unset.
+- `SUMO_TUI_MODULE` made worktree development viable without requiring SumoCode to be installed as an npm package.
+- SumoCode's existing unit and integration test suite stayed green.
+
+## What was painful
+
+- pnpm GitHub subdirectory installs did not produce a usable `@mariozechner/pi-coding-agent` package from the monorepo fork because the package `files` list includes `dist/`, but `dist/` is not committed upstream.
+- Adding `prepare` to the fork was explored and rejected:
+  - pnpm requires explicit build-script allowlisting for git-hosted dependencies;
+  - running prepare from a workspace package caused root/package lifecycle confusion;
+  - attempting a root build from prepare risked recursion and excessive install cost.
+- The practical solution is a local pnpm patch against the published `0.70.2` package, with the source-of-truth fork commit retained for audit and future rebases.
+- Upstream `v0.70.2` tests are not fully green in this environment before or after the patch. Failures are in model/default-provider expectations and auth-copy expectations unrelated to the SumoCode switch.
+
+## Current limitations
+
+- `SumoInteractiveMode` is now the live class loaded by the patched Pi binary, and it starts the retained runtime, but the full private `InteractiveMode` event loop is still delegated to upstream Pi.
+- Region-registry-backed extension UI remains available and tested, but it is not yet wired into Pi's private `bindCurrentSessionExtensions()` path in production because that requires a deeper fork of `createExtensionUIContext()` and per-extension caller identity.
+- Visual output is therefore still mostly Pi's existing TUI plus SumoCode's existing extension chrome, with the retained runtime active as the Phase 4b entry point.
+
+## Verification notes
+
+- `npm run check` in the fork passed.
+- `cd packages/coding-agent && npm run build` in the fork passed.
+- `pnpm test` in SumoCode passed: 315 tests.
+- `pnpm test:integration` in SumoCode passed: 11 tests.
+- `pnpm exec tsc --noEmit` passed.
+- `SUMO_TUI_DEBUG=1 PI_STARTUP_BENCHMARK=1 ./bin/sumocode.sh ...` in a pty printed:
+  - `[sumo-tui] SumoInteractiveMode retained runtime started`
+  - `[sumo-tui] SumoInteractiveMode retained runtime stopped`
+
+## Recommendations for Phase 6 no-fork attempt
+
+1. Ask upstream for a public interactive-mode factory hook or renderer injection hook instead of carrying a deeper private fork.
+2. If no public hook exists, keep the source fork patch tiny and move deeper experimentation into SumoCode only.
+3. Treat pnpm's monorepo-subdirectory packaging behaviour as a distribution constraint: either use a published package or keep using a pnpm patch against the published package.
+4. Do not port the full Pi event loop in one step. Port one private seam at a time:
+   - extension UI context factory,
+   - chat container event rendering,
+   - editor focus/input,
+   - session lifecycle.
+5. Keep `SUMO_TUI_MODULE` permanently; it is useful for local worktrees, bisects, and smoke tests.

--- a/docs/research/pi-fork-upgrade.md
+++ b/docs/research/pi-fork-upgrade.md
@@ -1,0 +1,118 @@
+# Pi fork upgrade procedure
+
+Phase 4b pins SumoCode to Pi `0.70.2` plus Dhruv's tiny fork patch on `dhruvkelawala/pi-mono` branch `sumocode/0.70.2-fork`.
+
+The fork patch lives in upstream Pi source at `packages/coding-agent/src/main.ts` and is mirrored into SumoCode's pnpm patch file because pnpm's GitHub subdirectory install packs `packages/coding-agent` without `dist/`.
+
+## Current activation model
+
+- Runtime flag: `SUMO_TUI=1`
+- Optional module override: `SUMO_TUI_MODULE=file:///.../sumo-interactive-mode.js`
+- SumoCode wrapper: `bin/sumocode.sh`
+- Pi fork branch: `https://github.com/dhruvkelawala/pi-mono/tree/sumocode/0.70.2-fork`
+- Fork commit for Phase 4b: `13568394`
+- Local package patch: `patches/@mariozechner__pi-coding-agent@0.70.2.patch`
+
+## Upgrade checklist for Pi 0.71+
+
+1. Create a new fork branch from the upstream release tag:
+
+   ```bash
+   cd /tmp/pi-mono-fork
+   git fetch upstream --tags
+   git checkout v0.71.0
+   git checkout -b sumocode/0.71.0-fork
+   ```
+
+2. Re-apply the minimal constructor patch in `packages/coding-agent/src/main.ts`:
+
+   - Find the interactive constructor site near `new InteractiveMode(runtime, ...)`.
+   - Replace it with `interactiveOptions`, `useSumoTui`, and `loadSumoInteractiveMode(...)`.
+   - Keep the diff under 30 changed lines.
+   - Keep the default path non-breaking when `SUMO_TUI` is unset.
+
+3. Build and check the fork:
+
+   ```bash
+   npm install
+   npm run build
+   npm run check
+   cd packages/coding-agent && npm run build
+   ```
+
+4. Run upstream tests and compare with a clean upstream tag run:
+
+   ```bash
+   ./test.sh
+   ```
+
+   If upstream release tests already fail before the patch, document the exact failures in the PR body and ensure the fork does not add new failures.
+
+5. Commit and push the fork branch:
+
+   ```bash
+   git add packages/coding-agent/src/main.ts
+   git commit -m "feat(coding-agent): load SumoInteractiveMode on demand"
+   git push -u origin sumocode/0.71.0-fork
+   git log --oneline -1
+   ```
+
+6. Regenerate SumoCode's pnpm patch from the published package for the new Pi version:
+
+   ```bash
+   rm -rf /tmp/pi-npm-orig
+   mkdir /tmp/pi-npm-orig
+   cd /tmp/pi-npm-orig
+   npm pack @mariozechner/pi-coding-agent@0.71.0 --silent
+   tar -xzf mariozechner-pi-coding-agent-0.71.0.tgz
+   git diff --no-index --no-prefix \
+     package/dist/main.js \
+     /tmp/pi-mono-fork/packages/coding-agent/dist/main.js \
+     > /tmp/pi-main-dist.patch || true
+   ```
+
+   Convert the patch headers to `a/dist/main.js` and `b/dist/main.js`, then save as:
+
+   ```text
+   patches/@mariozechner__pi-coding-agent@0.71.0.patch
+   ```
+
+7. Update SumoCode `package.json`:
+
+   - `devDependencies.@mariozechner/pi-coding-agent` -> `0.71.0`
+   - `devDependencies.@mariozechner/pi-ai` -> matching Pi version
+   - `devDependencies.@mariozechner/pi-tui` -> matching Pi version
+   - `pnpm.patchedDependencies` key/path -> new patch file
+
+8. Install and verify the patch is present:
+
+   ```bash
+   pnpm install
+   rg "SUMO_TUI_MODULE|loadSumoInteractiveMode" node_modules/@mariozechner/pi-coding-agent/dist/main.js
+   ```
+
+9. Run SumoCode verification:
+
+   ```bash
+   pnpm test
+   pnpm test:integration
+   pnpm exec tsc --noEmit
+   ./scripts/smoke-pi-versions.sh 0.71.0
+   ```
+
+10. Visual smoke:
+
+    ```bash
+    vhs docs/visual/sumo-tui-flex-splash.tape
+    ./bin/sumocode.sh
+    ```
+
+    Check splash centering, footer pinning, clean Ctrl+C, scroll, PgUp/PgDn, Ctrl+P, and streaming sticky-bottom.
+
+## Rebase notes
+
+- Never push to `badlogic/pi-mono`.
+- Do not open upstream PRs for this fork.
+- Keep the fork branch on Dhruv's account.
+- If upstream moves the constructor site, update `docs/research/interactive-mode-map.md` with new line citations before patching.
+- If Pi adds a public renderer injection API, stop and evaluate ADR Q4:C before carrying the fork forward.

--- a/package.json
+++ b/package.json
@@ -16,23 +16,29 @@
     "type": "git",
     "url": "git+https://github.com/dhruvkelawala/sumocode.git"
   },
+  "exports": {
+    "./sumo-interactive-mode": "./sumo-interactive-mode.js"
+  },
+  "bin": {
+    "sumocode": "bin/sumocode.sh"
+  },
   "pi": {
     "extensions": [
       "src/extension.ts"
     ]
   },
   "peerDependencies": {
-    "@mariozechner/pi-coding-agent": "*",
-    "@mariozechner/pi-tui": "*",
+    "@mariozechner/pi-coding-agent": "~0.70.0",
+    "@mariozechner/pi-tui": "~0.70.0",
     "typebox": "*"
   },
   "engines": {
     "node": ">=20"
   },
   "devDependencies": {
-    "@mariozechner/pi-ai": "~0.70.0",
-    "@mariozechner/pi-coding-agent": "~0.70.0",
-    "@mariozechner/pi-tui": "~0.70.0",
+    "@mariozechner/pi-ai": "0.70.2",
+    "@mariozechner/pi-coding-agent": "0.70.2",
+    "@mariozechner/pi-tui": "0.70.2",
     "@types/node": "^25.6.0",
     "node-pty": "^1.1.0",
     "typebox": "1.1.33",
@@ -48,6 +54,12 @@
     "visual": "node scripts/visual.mjs"
   },
   "dependencies": {
+    "@mariozechner/jiti": "^2.6.5",
     "yoga-wasm-web": "^0.3.3"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@mariozechner/pi-coding-agent@0.70.2": "patches/@mariozechner__pi-coding-agent@0.70.2.patch"
+    }
   }
 }

--- a/patches/@mariozechner__pi-coding-agent@0.70.2.patch
+++ b/patches/@mariozechner__pi-coding-agent@0.70.2.patch
@@ -1,0 +1,36 @@
+diff --git a/dist/main.js b/dist/main.js
+index 5cc6978..f047cea 100644
+--- a/dist/main.js
++++ b/dist/main.js
+@@ -545,14 +545,18 @@ export async function main(args, options) {
+                 .join(", ");
+             console.log(chalk.dim(`Model scope: ${modelList} ${chalk.gray("(Ctrl+P to cycle)")}`));
+         }
+-        const interactiveMode = new InteractiveMode(runtime, {
++        const interactiveOptions = {
+             migratedProviders,
+             modelFallbackMessage,
+             initialMessage,
+             initialImages,
+             initialMessages: parsed.messages,
+             verbose: parsed.verbose,
+-        });
++        };
++        const useSumoTui = isTruthyEnvFlag(process.env.SUMO_TUI) || parsed.unknownFlags.has("sumo-tui");
++        const interactiveMode = useSumoTui
++            ? await loadSumoInteractiveMode(runtime, interactiveOptions)
++            : new InteractiveMode(runtime, interactiveOptions);
+         if (startupBenchmark) {
+             await interactiveMode.init();
+             time("interactiveMode.init");
+@@ -586,4 +590,9 @@ export async function main(args, options) {
+         return;
+     }
+ }
++async function loadSumoInteractiveMode(...args) {
++    const specifier = process.env.SUMO_TUI_MODULE ?? "@dhruvkelawala/sumocode/sumo-interactive-mode";
++    const { SumoInteractiveMode } = await import(specifier);
++    return new SumoInteractiveMode(...args);
++}
+ //# sourceMappingURL=main.js.map
+\ No newline at end of file

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,22 +4,30 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@mariozechner/pi-coding-agent@0.70.2':
+    hash: 1c48d442a49fba83c8ff071fce4ac30acdec356678118b4aceb3304d5d02ae3d
+    path: patches/@mariozechner__pi-coding-agent@0.70.2.patch
+
 importers:
 
   .:
     dependencies:
+      '@mariozechner/jiti':
+        specifier: ^2.6.5
+        version: 2.6.5
       yoga-wasm-web:
         specifier: ^0.3.3
         version: 0.3.3
     devDependencies:
       '@mariozechner/pi-ai':
-        specifier: ~0.70.0
+        specifier: 0.70.2
         version: 0.70.2(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-coding-agent':
-        specifier: ~0.70.0
-        version: 0.70.2(ws@8.20.0)(zod@4.3.6)
+        specifier: 0.70.2
+        version: 0.70.2(patch_hash=1c48d442a49fba83c8ff071fce4ac30acdec356678118b4aceb3304d5d02ae3d)(ws@8.20.0)(zod@4.3.6)
       '@mariozechner/pi-tui':
-        specifier: ~0.70.0
+        specifier: 0.70.2
         version: 0.70.2
       '@types/node':
         specifier: ^25.6.0
@@ -2054,7 +2062,7 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.70.2(ws@8.20.0)(zod@4.3.6)':
+  '@mariozechner/pi-coding-agent@0.70.2(patch_hash=1c48d442a49fba83c8ff071fce4ac30acdec356678118b4aceb3304d5d02ae3d)(ws@8.20.0)(zod@4.3.6)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
       '@mariozechner/pi-agent-core': 0.70.2(ws@8.20.0)(zod@4.3.6)

--- a/scripts/smoke-pi-versions.sh
+++ b/scripts/smoke-pi-versions.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSIONS=("${@:-0.70.0 0.70.1 0.70.2}")
+
+for VERSION in ${VERSIONS[*]}; do
+	WORK_DIR="/tmp/sumo-pi-${VERSION}"
+	rm -rf "${WORK_DIR}"
+	mkdir -p "${WORK_DIR}"
+	if [[ "${VERSION}" == "0.70.2" ]]; then
+		PNPM_PATCH=',
+  "pnpm": {
+    "patchedDependencies": {
+      "@mariozechner/pi-coding-agent@0.70.2": "'"${ROOT_DIR}"'/patches/@mariozechner__pi-coding-agent@0.70.2.patch"
+    }
+  }'
+	else
+		PNPM_PATCH=""
+	fi
+	cat >"${WORK_DIR}/package.json" <<JSON
+{
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@mariozechner/pi-coding-agent": "${VERSION}",
+    "@dhruvkelawala/sumocode": "file:${ROOT_DIR}"
+  }${PNPM_PATCH}
+}
+JSON
+	(
+		cd "${WORK_DIR}"
+		pnpm install --silent
+		if [[ "${VERSION}" == "0.70.2" ]]; then
+			rg "SUMO_TUI_MODULE|loadSumoInteractiveMode" node_modules/@mariozechner/pi-coding-agent/dist/main.js >/dev/null
+		else
+			echo "sumocode smoke: ${VERSION} installs; fork activation patch is intentionally pinned to 0.70.2"
+		fi
+		node_modules/.bin/pi --version >"boot.txt" 2>&1
+		printf "pi %s boot: %s\n" "${VERSION}" "$(cat boot.txt)"
+	)
+done

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -30,6 +30,14 @@
 import type { AgentSessionRuntime, InteractiveModeOptions } from "@mariozechner/pi-coding-agent";
 import { InteractiveMode } from "@mariozechner/pi-coding-agent";
 import type { ExtensionUIContext } from "@mariozechner/pi-coding-agent";
+import { SumoNode } from "../layout/node.js";
+import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga, type Yoga } from "../layout/yoga.js";
+import { CellBuffer } from "../render/buffer.js";
+import { composite, type HardwareCursor } from "../render/compositor.js";
+import { diffFrames, type FrameDiffPatch } from "../render/diff.js";
+import { FrameScheduler } from "../runtime/frame-scheduler.js";
+import { TerminalController } from "../runtime/terminal-controller.js";
+import { ChatPager } from "../widgets/chat-pager.js";
 import { SumoExtensionUIAdapter, type SumoExtensionUIAdapterOptions } from "./extension-ui-adapter.js";
 import { createForeignAwareUIContext, type ForeignAwareUIOptions } from "./foreign-extension-warning.js";
 
@@ -45,15 +53,137 @@ export interface CreateExtensionUIContextOptions extends SumoExtensionUIAdapterO
 	readonly foreignExtensions?: ForeignAwareUIOptions;
 }
 
+interface TerminalLike {
+	readonly isTTY?: boolean;
+	readonly columns?: number;
+	readonly rows?: number;
+	write(data: string): unknown;
+}
+
+interface SumoInteractiveRuntimeSnapshot {
+	readonly root: SumoNode;
+	readonly chat: ChatPager;
+	readonly scheduler: FrameScheduler;
+}
+
+function debugLog(message: string): void {
+	if (process.env.SUMO_TUI_DEBUG !== "1") return;
+	console.error(`[sumo-tui] ${message}`);
+}
+
+/**
+ * Minimal retained-runtime owner for Phase 4b.
+ *
+ * The full Pi event-loop port is intentionally incremental: this controller
+ * creates the actual sumo-tui primitives (terminal controller, Yoga root,
+ * ChatPager, frame scheduler, compositor/diff frame path) before delegating the
+ * agent/session loop to upstream Pi. That makes the forked entry point real and
+ * testable while keeping Pi behaviour intact until the remaining private
+ * interactive-mode responsibilities are ported.
+ */
+class SumoInteractiveRuntime {
+	private readonly output: TerminalLike;
+	private readonly terminal: TerminalController;
+	private yoga: Yoga | undefined;
+	private root: SumoNode | undefined;
+	private chat: ChatPager | undefined;
+	private scheduler: FrameScheduler | undefined;
+	private previousFrame: CellBuffer | undefined;
+	private resizeHandler: (() => void) | undefined;
+	private started = false;
+
+	public constructor(output: TerminalLike = process.stdout) {
+		this.output = output;
+		this.terminal = new TerminalController({ output });
+	}
+
+	public async start(): Promise<SumoInteractiveRuntimeSnapshot> {
+		if (this.started && this.root && this.chat && this.scheduler) {
+			return { root: this.root, chat: this.chat, scheduler: this.scheduler };
+		}
+
+		this.yoga = await loadYoga();
+		this.root = new SumoNode(this.yoga.Node.create());
+		this.root.flexDirection = FLEX_DIRECTION_COLUMN;
+		this.chat = ChatPager.create(this.yoga, this.root, {
+			renderControls: {
+				scheduleRender: () => this.scheduler?.requestRender(),
+				setStreamingMode: (enabled) => {
+					if (enabled) this.scheduler?.enterStreamingMode();
+					else this.scheduler?.exitStreamingMode();
+				},
+			},
+		});
+		this.scheduler = new FrameScheduler({ render: () => this.render() });
+		this.resizeHandler = () => this.scheduler?.requestRender();
+		process.stdout.on("resize", this.resizeHandler);
+		this.started = true;
+		debugLog("SumoInteractiveMode retained runtime started");
+		return { root: this.root, chat: this.chat, scheduler: this.scheduler };
+	}
+
+	public requestRender(): void {
+		this.scheduler?.requestRender();
+	}
+
+	public stop(): void {
+		if (!this.started) return;
+		if (this.resizeHandler) process.stdout.off("resize", this.resizeHandler);
+		this.scheduler?.dispose();
+		this.root?.dispose();
+		this.previousFrame = undefined;
+		this.scheduler = undefined;
+		this.chat = undefined;
+		this.root = undefined;
+		this.yoga = undefined;
+		this.resizeHandler = undefined;
+		this.started = false;
+		this.terminal.exitTerminal();
+		debugLog("SumoInteractiveMode retained runtime stopped");
+	}
+
+	public getSnapshot(): SumoInteractiveRuntimeSnapshot | undefined {
+		if (!this.root || !this.chat || !this.scheduler) return undefined;
+		return { root: this.root, chat: this.chat, scheduler: this.scheduler };
+	}
+
+	private render(): void {
+		if (!this.root || !this.output.isTTY) return;
+		const width = Math.max(1, this.output.columns ?? 80);
+		const height = Math.max(1, this.output.rows ?? 24);
+		this.root.width = width;
+		this.root.height = height;
+		this.root.yogaNode.calculateLayout(width, height, DIRECTION_LTR);
+		const nextFrame = new CellBuffer(height, width);
+		const result = composite(this.root, nextFrame);
+		const patches = diffFrames(this.previousFrame, nextFrame);
+		this.writePatches(patches, result.hardwareCursor);
+		this.previousFrame = nextFrame.clone();
+	}
+
+	private writePatches(patches: readonly FrameDiffPatch[], hardwareCursor: HardwareCursor | null): void {
+		if (patches.length === 0 && !hardwareCursor) return;
+		let output = "\x1b[?2026h";
+		for (const patch of patches) {
+			if (patch.type === "scroll") {
+				output += patch.ansi;
+				continue;
+			}
+			output += `\x1b[${patch.row + 1};1H${patch.ansi}\x1b[K`;
+		}
+		if (hardwareCursor) output += `\x1b[${hardwareCursor.row + 1};${hardwareCursor.col + 1}H`;
+		output += "\x1b[?2026l";
+		this.output.write(output);
+	}
+}
+
 /**
  * Small Phase 4 fork boundary for Pi 0.70.x.
  *
  * Pi's CLI constructs `InteractiveMode` directly in
  * `node_modules/.pnpm/@mariozechner+pi-coding-agent@0.70.2.../dist/main.js:548-571`.
- * The real fork patch replaces that constructor call with `new
- * SumoInteractiveMode(...)`; extensions launched via plain `pi -e
- * ./src/extension.ts` still enter upstream Pi until that binary integration is
- * applied.
+ * The fork patch now replaces that constructor call with `new
+ * SumoInteractiveMode(...)` when `SUMO_TUI=1` or `--sumo-tui` is set.
  *
  * Borrowed responsibilities, with source citations:
  * - interactive entrypoint shape (`init`, `run`, `stop`) mirrors
@@ -62,27 +192,34 @@ export interface CreateExtensionUIContextOptions extends SumoExtensionUIAdapterO
  * - extension UI binding seam is the upstream `createExtensionUIContext()`
  *   dispatch table at `interactive-mode.js:1522-1557`.
  * - extension lifecycle bind remains upstream's `bindCurrentSessionExtensions()`
- *   responsibility at `interactive-mode.js:1128-1207`; this class only provides
- *   the retained UI context object used by the fork.
+ *   responsibility at `interactive-mode.js:1128-1207`; this class starts the
+ *   retained runtime and exposes the retained UI context object used by tests
+ *   and the next private-mode port.
  */
 export class SumoInteractiveMode {
-	private readonly upstream: InteractiveMode;
+	private upstream: InteractiveMode | undefined;
+	private readonly retainedRuntime = new SumoInteractiveRuntime();
 	private retainedUIContext: ExtensionUIContext | undefined;
 
-	public constructor(runtimeHost: AgentSessionRuntime, private readonly options: SumoInteractiveModeOptions = {}) {
-		this.upstream = new InteractiveMode(runtimeHost, options);
-	}
+	public constructor(
+		private readonly runtimeHost: AgentSessionRuntime,
+		private readonly options: SumoInteractiveModeOptions = {},
+	) {}
 
 	public async init(): Promise<void> {
-		await this.upstream.init();
+		await this.retainedRuntime.start();
+		await this.ensureUpstream().init();
 	}
 
 	public async run(): Promise<void> {
-		await this.upstream.run();
+		await this.retainedRuntime.start();
+		debugLog("SumoInteractiveMode.run() delegating to Pi session loop");
+		await this.ensureUpstream().run();
 	}
 
 	public stop(): void {
-		this.upstream.stop();
+		this.upstream?.stop();
+		this.retainedRuntime.stop();
 	}
 
 	public createExtensionUIContext(options: CreateExtensionUIContextOptions): ExtensionUIContext {
@@ -97,8 +234,17 @@ export class SumoInteractiveMode {
 		return this.retainedUIContext;
 	}
 
+	public getRetainedRuntimeSnapshot(): SumoInteractiveRuntimeSnapshot | undefined {
+		return this.retainedRuntime.getSnapshot();
+	}
+
 	public isRetainedExtensionUIEnabled(): boolean {
 		return this.options.retainedExtensionUI === true;
+	}
+
+	private ensureUpstream(): InteractiveMode {
+		this.upstream ??= new InteractiveMode(this.runtimeHost, this.options);
+		return this.upstream;
 	}
 }
 

--- a/sumo-interactive-mode.js
+++ b/sumo-interactive-mode.js
@@ -1,0 +1,11 @@
+import { createJiti } from "@mariozechner/jiti";
+
+const jiti = createJiti(import.meta.url, {
+	moduleCache: false,
+	tryNative: false,
+});
+
+const mod = await jiti.import("./src/sumo-tui/pi-compat/sumo-interactive-mode.ts");
+
+export const SumoInteractiveMode = mod.SumoInteractiveMode;
+export const sumoInteractiveMode = mod.sumoInteractiveMode;


### PR DESCRIPTION
## Summary

Closes #44
Closes #38

Phase 4b wires the Pi constructor seam so SumoCode can activate `SumoInteractiveMode` at runtime:

- Added Dhruv's Pi fork branch reference and mirrored runtime patch through pnpm `patchedDependencies` for the published Pi `0.70.2` package.
- Added `bin/sumocode.sh` wrapper that sets `SUMO_TUI=1` and `SUMO_TUI_MODULE=file://.../sumo-interactive-mode.js` before launching the local patched `pi` binary.
- Added `sumo-interactive-mode.js` public bridge for Pi's dynamic import.
- Expanded `SumoInteractiveMode` so the forked entry point starts real sumo-tui primitives before delegating to Pi's current session loop: `TerminalController`, Yoga root, `ChatPager`, `FrameScheduler`, `CellBuffer` compositor/diff path.
- Added fork upgrade docs and Phase 4b postmortem.

## Pi fork

- Fork branch: https://github.com/dhruvkelawala/pi-mono/tree/sumocode/0.70.2-fork
- Fork commit: https://github.com/dhruvkelawala/pi-mono/commit/13568394
- Source patch size against upstream `v0.70.2`: `1 file changed, 14 insertions(+), 2 deletions(-)`
- Patched source file: `packages/coding-agent/src/main.ts`

Patch behaviour:

- Default path is unchanged when `SUMO_TUI` is unset.
- `SUMO_TUI=1` or `--sumo-tui` activates `loadSumoInteractiveMode(...)`.
- `SUMO_TUI_MODULE` optionally overrides the module specifier for local worktrees.

## Packaging note

Direct pnpm GitHub subdirectory installation was tested but is not usable for Pi because `packages/coding-agent/package.json` publishes `dist/`, while upstream does not commit `dist/` to the monorepo. The working distribution path in this PR is therefore:

- keep the source-of-truth fork branch for audit/rebase;
- apply the equivalent patch to published `@mariozechner/pi-coding-agent@0.70.2` via `pnpm.patchedDependencies`.

This is documented in `docs/research/pi-fork-upgrade.md` and `docs/research/phase-4b-postmortem.md`.

## Verification

SumoCode:

```bash
pnpm test
# 48 files, 315 tests passed

pnpm test:integration
# 8 files, 11 tests passed

pnpm exec tsc --noEmit && pnpm build
# passed

./scripts/smoke-pi-versions.sh
# pi 0.70.0 boot: 0.70.0
# pi 0.70.1 boot: 0.70.1
# pi 0.70.2 boot: 0.70.2

vhs docs/visual/sumo-tui-flex-splash.tape
# rendered docs/visual/out/sumo-tui-flex-splash.png
```

Runtime smoke:

```text
SUMO_TUI_DEBUG=1 PI_STARTUP_BENCHMARK=1 ./bin/sumocode.sh ...
[sumo-tui] SumoInteractiveMode retained runtime started
[sumo-tui] SumoInteractiveMode retained runtime stopped
```

Pi fork:

```bash
npm run build
npm run check
cd packages/coding-agent && npm run build
# passed after restoring generated model data to the release-tag snapshot
```

`./test.sh` on the fork exits non-zero with upstream/environment failures unrelated to the SumoCode constructor patch:

- `packages/ai/test/openai-completions-prompt-cache.test.ts` expects a proxy value to be undefined in this environment.
- `packages/coding-agent/test/model-resolver.test.ts` default model expectations drift from current generated model data.
- `packages/coding-agent/test/oauth-selector.test.ts` expects Amazon Bedrock not to be an API-key login provider, while `v0.70.2` source includes it.
- `packages/coding-agent/test/rpc-prompt-response-semantics.test.ts` expects older auth guidance copy.

The same constructor patch path builds and check-passes when `SUMO_TUI` is unset.

## Visuals

- VHS output: `docs/visual/out/sumo-tui-flex-splash.png` (generated locally; ignored by git)

## Follow-up

The forked entry point is now live, but the deepest private Pi `InteractiveMode` responsibilities are still delegated to upstream. The next safe slices are:

1. replace upstream `createExtensionUIContext()` with the retained `SumoExtensionUIAdapter` inside the forked entry point;
2. feed Pi session events into `ChatPager`;
3. move editor focus/input ownership from pi-tui to `PiEditorLeaf`.
