### PR TITLE
feat(sumo-tui): Phase 5 — Cathedral parity

### DIFF
--- a/docs/visual/sumo-tui-cathedral-landscape.tape
+++ b/docs/visual/sumo-tui-cathedral-landscape.tape
@@ -1,0 +1,32 @@
+# Phase 5 retained cathedral landscape smoke (MacBook landscape-class viewport).
+# Target terminal shape: ~240 cols × 60 rows. Verifies wide top chrome,
+# centered splash, and footer pinning across a broad canvas.
+
+Output docs/visual/out/sumo-tui-cathedral-landscape.png
+
+Set Shell zsh
+Set FontFamily "JetBrainsMono Nerd Font Mono"
+Set FontSize 14
+Set Width 2400
+Set Height 1200
+Set Padding 10
+Set TypingSpeed 20ms
+
+Type "cd '/Volumes/SumoDeus NVMe/openclaw/workspace/worktrees/sumocode-phase-5'"
+Enter
+Sleep 250ms
+
+Type "clear"
+Enter
+Sleep 100ms
+
+Type "./bin/sumocode.sh --offline --no-extensions --no-session"
+Enter
+Sleep 5s
+
+Screenshot docs/visual/out/sumo-tui-cathedral-landscape.png
+
+Ctrl+C
+Sleep 300ms
+Ctrl+D
+Sleep 300ms

--- a/docs/visual/sumo-tui-cathedral-narrow.tape
+++ b/docs/visual/sumo-tui-cathedral-narrow.tape
@@ -1,0 +1,32 @@
+# Phase 5 retained cathedral narrow smoke (<120 cols).
+# The sidebar policy switches to overlay below 120 cols after chat exists;
+# splash remains sidebar-hidden, covering EC-17.6.
+
+Output docs/visual/out/sumo-tui-cathedral-narrow.png
+
+Set Shell zsh
+Set FontFamily "JetBrainsMono Nerd Font Mono"
+Set FontSize 14
+Set Width 900
+Set Height 1200
+Set Padding 10
+Set TypingSpeed 20ms
+
+Type "cd '/Volumes/SumoDeus NVMe/openclaw/workspace/worktrees/sumocode-phase-5'"
+Enter
+Sleep 250ms
+
+Type "clear"
+Enter
+Sleep 100ms
+
+Type "./bin/sumocode.sh --offline --no-extensions --no-session"
+Enter
+Sleep 5s
+
+Screenshot docs/visual/out/sumo-tui-cathedral-narrow.png
+
+Ctrl+C
+Sleep 300ms
+Ctrl+D
+Sleep 300ms

--- a/docs/visual/sumo-tui-cathedral-portrait.tape
+++ b/docs/visual/sumo-tui-cathedral-portrait.tape
@@ -1,0 +1,32 @@
+# Phase 5 retained cathedral portrait smoke (Mac mini portrait-class viewport).
+# Target terminal shape: ~100 cols × 80 rows. Verifies centered splash,
+# pinned footer, and no sidebar during splash.
+
+Output docs/visual/out/sumo-tui-cathedral-portrait.png
+
+Set Shell zsh
+Set FontFamily "JetBrainsMono Nerd Font Mono"
+Set FontSize 14
+Set Width 1000
+Set Height 1600
+Set Padding 10
+Set TypingSpeed 20ms
+
+Type "cd '/Volumes/SumoDeus NVMe/openclaw/workspace/worktrees/sumocode-phase-5'"
+Enter
+Sleep 250ms
+
+Type "clear"
+Enter
+Sleep 100ms
+
+Type "./bin/sumocode.sh --offline --no-extensions --no-session"
+Enter
+Sleep 5s
+
+Screenshot docs/visual/out/sumo-tui-cathedral-portrait.png
+
+Ctrl+C
+Sleep 300ms
+Ctrl+D
+Sleep 300ms

--- a/src/commands/theme.ts
+++ b/src/commands/theme.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { emitCathedralThemeChanged } from "../sumo-tui/cathedral/theme-bridge.js";
 
 function currentThemeName(ctx: ExtensionContext): string {
 	return (ctx.ui.theme as { name?: string } | undefined)?.name ?? "current";
@@ -22,6 +23,7 @@ export function registerThemeCommand(pi: ExtensionAPI): void {
 
 			const result = ctx.ui.setTheme(requested);
 			if (result.success) {
+				emitCathedralThemeChanged(requested);
 				ctx.ui.notify(`theme set: ${requested}`, "info");
 				return;
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import { installCommandPalette } from "./command-palette.js";
 import { installFooter } from "./footer.js";
 import { registerMemoryCommand } from "./memory-editor.js";
 import { installSidebar } from "./sidebar.js";
+import { installSplash } from "./splash.js";
 import { installTopChrome } from "./top-chrome.js";
 import { installWorkingIndicator } from "./working-indicator.js";
 
@@ -32,6 +33,7 @@ import { installWorkingIndicator } from "./working-indicator.js";
 export default function sumocode(pi: ExtensionAPI): void {
 	installAltscreen(pi);
 	installTopChrome(pi);
+	installSplash(pi);
 	installFooter(pi);
 	installCathedralEditor(pi);
 	installInputHints(pi);

--- a/src/splash.ts
+++ b/src/splash.ts
@@ -18,6 +18,9 @@
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { truncateToWidth } from "@mariozechner/pi-tui";
+import type { Component } from "@mariozechner/pi-tui";
 import { CATHEDRAL_TOKENS } from "./tokens.js";
 
 const RESET = "\u001b[0m";
@@ -41,7 +44,7 @@ function visibleLength(text: string): number {
 
 function center(line: string, width: number): string {
 	const len = visibleLength(line);
-	if (len >= width) return line;
+	if (len >= width) return truncateToWidth(line, width, "");
 	const pad = Math.floor((width - len) / 2);
 	return `${" ".repeat(pad)}${line}`;
 }
@@ -104,39 +107,13 @@ export type SplashSnapshot = {
 };
 
 /**
- * Vertical layout reserved for the rest of Pi's chrome below the splash.
- * Used to compute how much top padding to add to push the footer to the
- * bottom of the viewport.
+ * Standalone splash content: cat + wordmark + quote only.
  *
- *   1 row : top chrome bar (Element 2)
- *   8 rows: Pi-hardcoded noise (extension issues warnings + ctrl+p/k
- *           shortcut conflicts + Anthropic auth subscription warning;
- *           varies by environment, sized for the worst case)
- *   5 rows: cathedral input frame (Element 3 + 4 — top + pad + content +
- *           pad + bottom; matches Stitch HTML `p-4`)
- *   1 row : input hints row (Element 4)
- *   1 row : footer F1 (Element 5)
- *   ----
- *  16 rows total reserved
- *
- * If this value is too low, the footer ends up halfway up the viewport with
- * empty space below it. If it's too high, the splash content is pushed off
- * screen at the top. Re-measure when adding/removing chrome rows.
+ * The retained sumo-tui splash tree centers this fixed-height leaf with Yoga
+ * flex spacers. Keep this function free of viewport padding and chrome
+ * reservation hacks so centering remains a layout concern.
  */
-const CHROME_RESERVED_ROWS = 16;
-
-/**
- * Pure render of the cathedral splash. Returns an empty array if the session
- * already has messages — caller can splice this into a header without
- * conditional logic.
- *
- * `terminalHeight` is optional. When provided, the splash output is padded
- * with blank rows at the top so the cat + wordmark + quote sit vertically
- * centered in the viewport, with chrome reserved at top and bottom. Without
- * it, the splash starts immediately below whatever rendered above (the
- * pre-altscreen behaviour).
- */
-export function renderSplash(snapshot: SplashSnapshot, width: number, terminalHeight?: number): string[] {
+export function renderSplashContent(snapshot: SplashSnapshot, width: number): string[] {
 	if (snapshot.hasMessages) return [];
 
 	const content: string[] = [];
@@ -161,21 +138,63 @@ export function renderSplash(snapshot: SplashSnapshot, width: number, terminalHe
 	content.push(center(`${DIM}${MUTED}${snapshot.quote}${RESET}`, width));
 	content.push(center(`${DIM}${MUTED}${snapshot.quoteAttribution}${RESET}`, width));
 
-	// Vertical centering: pad with blank rows above the content so the splash
-	// sits in the middle of the available viewport. Reserve CHROME_RESERVED_ROWS
-	// for the bottom chrome (input + hints + footer + anthropic warning).
-	if (terminalHeight && terminalHeight > content.length + CHROME_RESERVED_ROWS) {
-		const availableForCentering = terminalHeight - CHROME_RESERVED_ROWS;
-		const topPad = Math.max(2, Math.floor((availableForCentering - content.length) / 2));
-		const out: string[] = [];
-		for (let i = 0; i < topPad; i++) out.push("");
-		out.push(...content);
-		return out;
+	return content;
+}
+
+/**
+ * Legacy line renderer retained for preview scripts and non-retained fallback.
+ * When `terminalHeight` is provided it centers against the whole viewport — no
+ * `CHROME_RESERVED_ROWS` subtraction. The retained runtime should prefer
+ * `renderSplashContent()` inside `splash-tree.ts`.
+ */
+export function renderSplash(snapshot: SplashSnapshot, width: number, terminalHeight?: number): string[] {
+	const content = renderSplashContent(snapshot, width);
+	if (content.length === 0) return [];
+
+	if (terminalHeight && terminalHeight > content.length) {
+		const topPad = Math.max(0, Math.floor((terminalHeight - content.length) / 2));
+		return [...Array.from({ length: topPad }, () => ""), ...content];
 	}
 
-	// Fallback: small fixed top padding (legacy behaviour).
-	const out: string[] = [];
-	for (let i = 0; i < 4; i++) out.push("");
-	out.push(...content);
-	return out;
+	return content;
+}
+
+function sessionHasMessages(ctx: ExtensionContext): boolean {
+	try {
+		return ctx.sessionManager.getBranch().some((entry) => entry.type === "message");
+	} catch {
+		return false;
+	}
+}
+
+class SplashComponent implements Component {
+	public constructor(private readonly ctx: ExtensionContext) {}
+	public invalidate(): void {}
+	public render(width: number): string[] {
+		return renderSplash(
+			{
+				quote: SUMOCODE_QUOTE,
+				quoteAttribution: SUMOCODE_QUOTE_ATTRIBUTION,
+				hasMessages: sessionHasMessages(this.ctx),
+			},
+			width,
+			process.stdout.rows,
+		);
+	}
+}
+
+/** Mounts the splash as its own chrome region instead of piggybacking on the top bar. */
+export function installSplash(pi: ExtensionAPI): void {
+	let render: (() => void) | undefined;
+
+	pi.on("session_start", (_event, ctx) => {
+		if (!ctx.hasUI) return;
+		ctx.ui.setWidget("sumocode-splash", (tui) => {
+			render = () => tui.requestRender();
+			return new SplashComponent(ctx);
+		});
+	});
+
+	pi.on("message_start", () => render?.());
+	pi.on("message_end", () => render?.());
 }

--- a/src/sumo-tui/cathedral/footer-tree.test.ts
+++ b/src/sumo-tui/cathedral/footer-tree.test.ts
@@ -1,0 +1,46 @@
+import type { KeybindingsManager, Theme } from "@mariozechner/pi-coding-agent";
+import type { Component, EditorTheme, TUI } from "@mariozechner/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { DIRECTION_LTR, loadYoga } from "../layout/yoga.js";
+import { CellBuffer } from "../render/buffer.js";
+import { composite } from "../render/compositor.js";
+import { RegionRegistry } from "../pi-compat/region-registry.js";
+
+class LineComponent implements Component {
+	public constructor(private readonly text: string) {}
+	public invalidate(): void {}
+	public render(width: number): string[] {
+		return [this.text.padEnd(width, " ")];
+	}
+}
+
+function fakeTui(rows: number): TUI {
+	return { requestRender: vi.fn(), terminal: { columns: 80, rows, setTitle: vi.fn() } } as unknown as TUI;
+}
+
+describe("footer pinning via RegionRegistry shell", () => {
+	for (const height of [24, 60, 100]) {
+		it(`pins footer to the last row at ${height} rows`, async () => {
+			const yoga = await loadYoga();
+			const registry = new RegionRegistry({
+				yoga,
+				tui: fakeTui(height),
+				theme: {} as Theme,
+				editorTheme: { borderColor: (value: string) => value, selectList: {} } as EditorTheme,
+				keybindings: {} as KeybindingsManager,
+			});
+			registry.mountHeader(new LineComponent("TOP"));
+			registry.mountFooter(new LineComponent("FOOTER"));
+			registry.root.width = 80;
+			registry.root.height = height;
+			registry.root.yogaNode.calculateLayout(80, height, DIRECTION_LTR);
+			const frame = new CellBuffer(height, 80);
+			composite(registry.root, frame);
+
+			expect(frame.toPlainRow(0).startsWith("TOP")).toBe(true);
+			expect(frame.toPlainRow(height - 1).startsWith("FOOTER")).toBe(true);
+			expect(registry.getSlot("chat").getComputedHeight()).toBe(height - 2);
+			registry.dispose();
+		});
+	}
+});

--- a/src/sumo-tui/cathedral/sidebar-tree.test.ts
+++ b/src/sumo-tui/cathedral/sidebar-tree.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { SumoNode } from "../layout/node.js";
+import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga } from "../layout/yoga.js";
+import { CellBuffer } from "../render/buffer.js";
+import { composite } from "../render/compositor.js";
+import { createSidebarTree, resolveSidebarLayoutMode } from "./sidebar-tree.js";
+
+function plainRowHasPaint(buffer: CellBuffer, row: number): boolean {
+	return buffer.toPlainRow(row).trim().length > 0;
+}
+
+describe("sidebar-tree", () => {
+	it("docks at width >= 120 with a fixed 49-column sidebar", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		root.width = 130;
+		root.height = 20;
+		const tree = createSidebarTree(yoga, root, { terminalWidth: 130, terminalHeight: 20, sessionHasMessages: true });
+		root.yogaNode.calculateLayout(130, 20, DIRECTION_LTR);
+
+		expect(tree.mode).toBe("dock");
+		expect(tree.sidebar.getComputedWidth()).toBe(49);
+		expect(tree.chat.getComputedWidth()).toBe(81);
+		expect(tree.sidebar.getComputedLeft()).toBe(81);
+		root.dispose();
+	});
+
+	it("overlays with a backdrop below 120 columns", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		root.width = 80;
+		root.height = 20;
+		const tree = createSidebarTree(yoga, root, { terminalWidth: 80, terminalHeight: 20, sessionHasMessages: true });
+		root.yogaNode.calculateLayout(80, 20, DIRECTION_LTR);
+		const frame = new CellBuffer(20, 80);
+		composite(root, frame);
+
+		expect(tree.mode).toBe("overlay");
+		expect(tree.chat.getComputedWidth()).toBe(80);
+		expect(tree.sidebar.getComputedWidth()).toBe(49);
+		expect(tree.sidebar.getComputedLeft()).toBe(31);
+		expect(plainRowHasPaint(frame, 0)).toBe(false);
+		expect(frame.getCell(0, 0).bg).toBe("#120D0A");
+		root.dispose();
+	});
+
+	it("hides while the splash has no messages", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		root.width = 130;
+		root.height = 20;
+		const tree = createSidebarTree(yoga, root, { terminalWidth: 130, terminalHeight: 20, sessionHasMessages: false });
+		root.yogaNode.calculateLayout(130, 20, DIRECTION_LTR);
+
+		expect(resolveSidebarLayoutMode({ terminalWidth: 130, terminalHeight: 20, sessionHasMessages: false })).toBe("hidden");
+		expect(tree.mode).toBe("hidden");
+		expect(tree.sidebar.getComputedWidth()).toBe(0);
+		root.dispose();
+	});
+});

--- a/src/sumo-tui/cathedral/sidebar-tree.ts
+++ b/src/sumo-tui/cathedral/sidebar-tree.ts
@@ -1,0 +1,116 @@
+import { SIDEBAR_MIN_TERMINAL_WIDTH, SIDEBAR_WIDTH } from "../../sidebar.js";
+import { SumoNode } from "../layout/node.js";
+import { FLEX_DIRECTION_ROW, type Yoga, type YogaNode } from "../layout/yoga.js";
+import type { CellBuffer, Rect } from "../render/buffer.js";
+import { cathedralBackdropCell } from "./theme-bridge.js";
+
+export type SidebarLayoutMode = "dock" | "overlay" | "hidden";
+
+export interface SidebarLayoutSnapshot {
+	readonly terminalWidth: number;
+	readonly terminalHeight: number;
+	readonly sessionHasMessages: boolean;
+	readonly dockMinWidth?: number;
+	readonly sidebarWidth?: number;
+}
+
+export interface SidebarTree {
+	readonly root: SumoNode;
+	readonly chat: SumoNode;
+	readonly backdrop: SidebarBackdropNode;
+	readonly sidebar: SumoNode;
+	mode: SidebarLayoutMode;
+	sync(snapshot: SidebarLayoutSnapshot): SidebarLayoutMode;
+}
+
+function finiteDimension(value: number, fallback: number): number {
+	return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+export function resolveSidebarLayoutMode(snapshot: SidebarLayoutSnapshot): SidebarLayoutMode {
+	if (!snapshot.sessionHasMessages) return "hidden";
+	return snapshot.terminalWidth >= (snapshot.dockMinWidth ?? SIDEBAR_MIN_TERMINAL_WIDTH) ? "dock" : "overlay";
+}
+
+export class SidebarBackdropNode extends SumoNode {
+	private visible = false;
+
+	public constructor(yogaNode: YogaNode, parent?: SumoNode) {
+		super(yogaNode, parent);
+	}
+
+	public setVisible(visible: boolean): void {
+		this.visible = visible;
+	}
+
+	public render(buffer: CellBuffer, rect: Rect): void {
+		if (!this.visible) return;
+		buffer.paint(rect, cathedralBackdropCell());
+	}
+}
+
+/**
+ * Responsive cathedral sidebar host.
+ *
+ * Wide terminals dock the sidebar as a fixed 49-column sibling after chat.
+ * Narrow terminals let chat keep the full width and place sidebar above it as
+ * an absolute right overlay with a dim backdrop. Empty splash state hides both
+ * sidebar and backdrop (EC-17.6).
+ */
+export function createSidebarTree(yoga: Yoga, parent: SumoNode | undefined, snapshot: SidebarLayoutSnapshot): SidebarTree {
+	const root = new SumoNode(yoga.Node.create(), parent);
+	root.flexDirection = FLEX_DIRECTION_ROW;
+	root.flexGrow = 1;
+	root.flexShrink = 1;
+
+	const chat = new SumoNode(yoga.Node.create(), root);
+	chat.flexGrow = 1;
+	chat.flexShrink = 1;
+
+	const backdrop = new SidebarBackdropNode(yoga.Node.create(), root);
+	backdrop.position = "absolute";
+	backdrop.top = 0;
+	backdrop.left = 0;
+	backdrop.right = 0;
+	backdrop.bottom = 0;
+	backdrop.zIndex = 100;
+
+	const sidebar = new SumoNode(yoga.Node.create(), root);
+	sidebar.flexShrink = 0;
+	sidebar.zIndex = 101;
+
+	const tree: SidebarTree = {
+		root,
+		chat,
+		backdrop,
+		sidebar,
+		mode: "hidden",
+		sync(next: SidebarLayoutSnapshot): SidebarLayoutMode {
+			const mode = resolveSidebarLayoutMode(next);
+			const width = Math.min(next.sidebarWidth ?? SIDEBAR_WIDTH, finiteDimension(next.terminalWidth, SIDEBAR_WIDTH));
+			this.mode = mode;
+			backdrop.setVisible(mode === "overlay");
+			if (mode === "hidden") {
+				sidebar.position = "relative";
+				sidebar.width = 0;
+				sidebar.height = 0;
+				return mode;
+			}
+			if (mode === "dock") {
+				sidebar.position = "relative";
+				sidebar.width = width;
+				sidebar.height = "100%";
+				return mode;
+			}
+			sidebar.position = "absolute";
+			sidebar.top = 0;
+			sidebar.right = 0;
+			sidebar.bottom = 0;
+			sidebar.width = width;
+			sidebar.height = finiteDimension(next.terminalHeight, 24);
+			return mode;
+		},
+	};
+	tree.sync(snapshot);
+	return tree;
+}

--- a/src/sumo-tui/cathedral/splash-tree.test.ts
+++ b/src/sumo-tui/cathedral/splash-tree.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { SumoNode } from "../layout/node.js";
+import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga } from "../layout/yoga.js";
+import { CellBuffer } from "../render/buffer.js";
+import { composite } from "../render/compositor.js";
+import { createSplashTree, defaultSplashSnapshot, getSplashContentHeight } from "./splash-tree.js";
+
+function firstNonBlankRow(buffer: CellBuffer, height: number): number {
+	for (let row = 0; row < height; row += 1) {
+		if (buffer.toPlainRow(row).trim().length > 0) return row;
+	}
+	return -1;
+}
+
+describe("createSplashTree", () => {
+	for (const height of [30, 60, 100]) {
+		it(`centers splash content vertically at ${height} rows with flex spacers`, async () => {
+			const yoga = await loadYoga();
+			const root = new SumoNode(yoga.Node.create());
+			root.flexDirection = FLEX_DIRECTION_COLUMN;
+			root.width = 120;
+			root.height = height;
+
+			const snapshot = defaultSplashSnapshot(false);
+			const tree = createSplashTree(yoga, root, () => snapshot);
+			root.yogaNode.calculateLayout(120, height, DIRECTION_LTR);
+			const frame = new CellBuffer(height, 120);
+			composite(root, frame);
+
+			const contentHeight = getSplashContentHeight(snapshot, 120);
+			const expectedTop = Math.floor((height - contentHeight) / 2);
+			expect(tree.topSpacer.getComputedHeight()).toBe(expectedTop);
+			expect(tree.bottomSpacer.getComputedHeight()).toBe(height - expectedTop - contentHeight);
+			expect(tree.content.getComputedTop()).toBe(expectedTop);
+			expect(firstNonBlankRow(frame, height)).toBeGreaterThanOrEqual(expectedTop);
+			expect(firstNonBlankRow(frame, height)).toBeLessThan(expectedTop + contentHeight);
+			root.dispose();
+		});
+	}
+
+	it("collapses once the session has messages so splash and sidebar never share the empty state", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		root.width = 100;
+		root.height = 40;
+		const tree = createSplashTree(yoga, root, () => defaultSplashSnapshot(true));
+		tree.syncVisibility();
+		root.yogaNode.calculateLayout(100, 40, DIRECTION_LTR);
+
+		expect(tree.root.getComputedHeight()).toBe(0);
+		root.dispose();
+	});
+});

--- a/src/sumo-tui/cathedral/splash-tree.ts
+++ b/src/sumo-tui/cathedral/splash-tree.ts
@@ -1,0 +1,85 @@
+import type { Component } from "@mariozechner/pi-tui";
+import { SumoNode } from "../layout/node.js";
+import { FLEX_DIRECTION_COLUMN, type Yoga } from "../layout/yoga.js";
+import { PiComponentLeaf } from "../widgets/pi-component-leaf.js";
+import {
+	renderSplashContent,
+	SUMOCODE_QUOTE,
+	SUMOCODE_QUOTE_ATTRIBUTION,
+	type SplashSnapshot,
+} from "../../splash.js";
+
+export type SplashSnapshotProvider = () => SplashSnapshot;
+
+export interface SplashTree {
+	readonly root: SumoNode;
+	readonly topSpacer: SumoNode;
+	readonly content: PiComponentLeaf;
+	readonly bottomSpacer: SumoNode;
+	/** Collapse the tree once the first message arrives (EC-17.4 / 17.6). */
+	syncVisibility(): void;
+}
+
+export function defaultSplashSnapshot(hasMessages = false): SplashSnapshot {
+	return {
+		quote: SUMOCODE_QUOTE,
+		quoteAttribution: SUMOCODE_QUOTE_ATTRIBUTION,
+		hasMessages,
+	};
+}
+
+export function getSplashContentHeight(snapshot: SplashSnapshot, width: number): number {
+	return renderSplashContent(snapshot, width).length;
+}
+
+class SplashContentComponent implements Component {
+	public constructor(private readonly snapshot: SplashSnapshotProvider) {}
+	public invalidate(): void {}
+	public render(width: number): string[] {
+		return renderSplashContent(this.snapshot(), width);
+	}
+}
+
+/**
+ * Yoga-centered cathedral splash.
+ *
+ * The shape is intentionally tiny and declarative:
+ *   Root(column, flexGrow=1)
+ *     TopSpacer(flexGrow=1)
+ *     SplashContent(PiComponentLeaf, intrinsic fixed row count)
+ *     BottomSpacer(flexGrow=1)
+ *
+ * There is no viewport padding or chrome-reservation math here; Yoga splits the
+ * free rows between the two spacers at any terminal height.
+ */
+export function createSplashTree(yoga: Yoga, parent: SumoNode | undefined, snapshot: SplashSnapshotProvider): SplashTree {
+	const root = new SumoNode(yoga.Node.create(), parent);
+	root.flexDirection = FLEX_DIRECTION_COLUMN;
+	root.flexGrow = 1;
+	root.flexShrink = 1;
+
+	const topSpacer = new SumoNode(yoga.Node.create(), root);
+	topSpacer.flexGrow = 1;
+	topSpacer.flexShrink = 1;
+
+	const content = PiComponentLeaf.create(yoga, new SplashContentComponent(snapshot), root);
+	content.flexShrink = 0;
+
+	const bottomSpacer = new SumoNode(yoga.Node.create(), root);
+	bottomSpacer.flexGrow = 1;
+	bottomSpacer.flexShrink = 1;
+
+	return {
+		root,
+		topSpacer,
+		content,
+		bottomSpacer,
+		syncVisibility(): void {
+			if (snapshot().hasMessages) {
+				root.height = 0;
+				root.flexGrow = 0;
+				root.flexShrink = 0;
+			}
+		},
+	};
+}

--- a/src/sumo-tui/cathedral/theme-bridge.test.ts
+++ b/src/sumo-tui/cathedral/theme-bridge.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { emitCathedralThemeChanged, getCathedralThemeVersion, onCathedralThemeChanged } from "./theme-bridge.js";
+
+describe("theme-bridge", () => {
+	it("emits theme_changed and increments the repaint version", () => {
+		const before = getCathedralThemeVersion();
+		const seen: string[] = [];
+		const unsubscribe = onCathedralThemeChanged((themeName) => seen.push(themeName));
+
+		emitCathedralThemeChanged("amber-crt");
+		unsubscribe();
+		emitCathedralThemeChanged("obsidian-temple");
+
+		expect(getCathedralThemeVersion()).toBe(before + 2);
+		expect(seen).toEqual(["amber-crt"]);
+	});
+});

--- a/src/sumo-tui/cathedral/theme-bridge.ts
+++ b/src/sumo-tui/cathedral/theme-bridge.ts
@@ -1,0 +1,47 @@
+import { createAttrs, type Cell } from "../render/cell.js";
+import { CATHEDRAL_TOKENS, type SumoCodeState } from "../../tokens.js";
+
+export type CathedralColorToken = keyof typeof CATHEDRAL_TOKENS.colors;
+export type ThemeChangedListener = (themeName: string) => void;
+
+let themeVersion = 0;
+const themeListeners = new Set<ThemeChangedListener>();
+
+export function getCathedralThemeVersion(): number {
+	return themeVersion;
+}
+
+export function onCathedralThemeChanged(listener: ThemeChangedListener): () => void {
+	themeListeners.add(listener);
+	return () => themeListeners.delete(listener);
+}
+
+export function emitCathedralThemeChanged(themeName: string): void {
+	themeVersion += 1;
+	for (const listener of themeListeners) listener(themeName);
+}
+
+export function cathedralCell(options: { char?: string; fg?: string; bg?: string; dim?: boolean } = {}): Cell {
+	return {
+		char: options.char ?? " ",
+		fg: options.fg,
+		bg: options.bg,
+		attrs: createAttrs({ dim: options.dim ?? false }),
+	};
+}
+
+export function cathedralStateColor(state: SumoCodeState): string {
+	return CATHEDRAL_TOKENS.colors.states[state];
+}
+
+export function cathedralBackdropCell(): Cell {
+	return cathedralCell({ bg: CATHEDRAL_TOKENS.colors.surfaceRecess, dim: true });
+}
+
+export function cathedralSurfaceCell(): Cell {
+	return cathedralCell({ bg: CATHEDRAL_TOKENS.colors.surface });
+}
+
+export function cathedralRecessCell(): Cell {
+	return cathedralCell({ bg: CATHEDRAL_TOKENS.colors.surfaceRecess });
+}

--- a/src/sumo-tui/pi-compat/extension-ui-adapter.ts
+++ b/src/sumo-tui/pi-compat/extension-ui-adapter.ts
@@ -17,6 +17,7 @@ import type {
 	TUI,
 } from "@mariozechner/pi-tui";
 import { ModalManager } from "../widgets/modal.js";
+import { ModalLayer } from "../widgets/modal-layer.js";
 import { NotificationCenter, type NotificationLevel } from "../widgets/notification.js";
 import {
 	RegionRegistry,
@@ -123,7 +124,13 @@ export class SumoExtensionUIAdapter implements ExtensionUIContext {
 		this.currentTheme = options.theme;
 		this.keybindings = options.keybindings;
 		this.notifications = options.notifications ?? new NotificationCenter({ onChange: options.onRenderRequest });
-		this.modals = options.modals ?? new ModalManager({ onChange: options.onRenderRequest });
+		this.modals = options.modals ?? new ModalLayer({
+			onChange: options.onRenderRequest,
+			getTerminalSize: () => ({
+				columns: (this.tui.terminal as { columns?: number } | undefined)?.columns ?? 80,
+				rows: (this.tui.terminal as { rows?: number } | undefined)?.rows ?? 24,
+			}),
+		});
 		this.editorText = options.editorText;
 		this.themeApi = options.themeApi;
 		this.tools = options.tools;
@@ -138,11 +145,20 @@ export class SumoExtensionUIAdapter implements ExtensionUIContext {
 			width: "45%",
 			maxHeight: 6,
 		});
-		this.regionRegistry.mountOverlay("__modal", this.modals, {
-			anchor: "center",
-			width: "65%",
-			maxHeight: "80%",
-		});
+		if (this.modals instanceof ModalLayer) {
+			this.regionRegistry.mountOverlay("__modal", this.modals, {
+				row: 0,
+				col: 0,
+				width: "100%",
+				maxHeight: "100%",
+			});
+		} else {
+			this.regionRegistry.mountModal("__modal", this.modals, {
+				anchor: "center",
+				width: "65%",
+				maxHeight: "80%",
+			});
+		}
 	}
 
 	public select(title: string, options: string[], opts?: ExtensionUIDialogOptions): Promise<string | undefined> {
@@ -253,7 +269,8 @@ export class SumoExtensionUIAdapter implements ExtensionUIContext {
 						return;
 					}
 					wrapper = new OverlayComponentWrapper(component);
-					this.regionRegistry.mountOverlay(key, wrapper, options?.overlay === false ? undefined : options?.overlayOptions);
+					if (options?.overlay === false) this.regionRegistry.mountOverlay(key, wrapper, undefined);
+					else this.regionRegistry.mountModal(key, wrapper, options?.overlayOptions);
 					options?.onHandle?.(this.createOverlayHandle(key, wrapper));
 				})
 				.catch((error: unknown) => {

--- a/src/sumo-tui/pi-compat/region-registry.ts
+++ b/src/sumo-tui/pi-compat/region-registry.ts
@@ -7,9 +7,11 @@ import type { Component, EditorComponent, EditorTheme, OverlayOptions, TUI } fro
 import { SumoNode } from "../layout/node.js";
 import {
 	FLEX_DIRECTION_COLUMN,
+	FLEX_DIRECTION_ROW,
 	POSITION_TYPE_ABSOLUTE,
 	type Yoga,
 } from "../layout/yoga.js";
+import { ModalBackdropNode, ModalSurfaceComponent } from "../widgets/modal-layer.js";
 import { PiComponentLeaf } from "../widgets/pi-component-leaf.js";
 import { PiEditorLeaf } from "../widgets/pi-editor-leaf.js";
 import type { CustomEditor } from "@mariozechner/pi-coding-agent";
@@ -23,9 +25,10 @@ export type RegionSlotName =
 	| "chat"
 	| "pending"
 	| "status"
-	| "widgets-default";
+	| "widgets-default"
+	| "sidebar";
 
-export type WidgetPlacement = "aboveEditor" | "belowEditor" | "default";
+export type WidgetPlacement = "aboveEditor" | "belowEditor" | "default" | "sidebar" | "modal";
 export type DisposableComponent = Component & { dispose?(): void };
 
 export type HeaderMount =
@@ -85,9 +88,10 @@ function safeDispose(component: DisposableComponent): void {
 	}
 }
 
-function placementToSlot(placement: WidgetPlacement | undefined): RegionSlotName {
+function placementToSlot(placement: Exclude<WidgetPlacement, "modal"> | undefined): RegionSlotName {
 	if (placement === "belowEditor") return "belowEditor";
 	if (placement === "default") return "widgets-default";
+	if (placement === "sidebar") return "sidebar";
 	return "aboveEditor";
 }
 
@@ -130,16 +134,28 @@ export class RegionRegistry {
 		this.root = options.root ?? new SumoNode(this.yoga.Node.create());
 		this.root.flexDirection = FLEX_DIRECTION_COLUMN;
 
+		const header = this.createSlot("header", this.root);
+		const main = new SumoNode(this.yoga.Node.create(), this.root);
+		main.flexDirection = FLEX_DIRECTION_ROW;
+		main.flexGrow = 1;
+		main.flexShrink = 1;
+
+		const content = new SumoNode(this.yoga.Node.create(), main);
+		content.flexDirection = FLEX_DIRECTION_COLUMN;
+		content.flexGrow = 1;
+		content.flexShrink = 1;
+
 		this.slots = {
-			header: this.createSlot("header"),
-			chat: this.createFlexSlot("chat"),
-			pending: this.createSlot("pending"),
-			status: this.createSlot("status"),
-			"widgets-default": this.createSlot("widgets-default"),
-			aboveEditor: this.createSlot("aboveEditor"),
-			editor: this.createSlot("editor"),
-			belowEditor: this.createSlot("belowEditor"),
-			footer: this.createSlot("footer"),
+			header,
+			chat: this.createFlexSlot("chat", content),
+			pending: this.createSlot("pending", content),
+			status: this.createSlot("status", content),
+			"widgets-default": this.createSlot("widgets-default", content),
+			aboveEditor: this.createSlot("aboveEditor", content),
+			editor: this.createSlot("editor", content),
+			belowEditor: this.createSlot("belowEditor", content),
+			sidebar: this.createSlot("sidebar", main),
+			footer: this.createSlot("footer", this.root),
 		};
 
 		this.overlayRoot = new SumoNode(this.yoga.Node.create(), this.root);
@@ -190,7 +206,16 @@ export class RegionRegistry {
 			this.onChange();
 			return;
 		}
-		this.mount(key, placementToSlot(opts.placement), this.resolveWidget(content));
+		if (opts.placement === "modal") {
+			this.mountModal(key, this.resolveWidget(content), { anchor: "center", width: "65%", maxHeight: "80%" });
+			return;
+		}
+		const slot = placementToSlot(opts.placement);
+		if (slot === "sidebar") {
+			this.slots.sidebar.width = 49;
+			this.slots.sidebar.flexShrink = 0;
+		}
+		this.mount(key, slot, this.resolveWidget(content));
 	}
 
 	public mountOverlay(key: string, component: DisposableComponent | undefined, overlayOptions?: OverlayOptions | (() => OverlayOptions)): void {
@@ -204,6 +229,33 @@ export class RegionRegistry {
 		node.zIndex = this.mounts.size + 1;
 		this.applyOverlayOptions(node, overlayOptions);
 		this.mounts.set(key, { key, slot: "overlay", node, component });
+		this.onChange();
+	}
+
+	public mountModal(key: string, component: DisposableComponent | undefined, overlayOptions?: OverlayOptions | (() => OverlayOptions)): void {
+		this.unmount(key);
+		if (!component) {
+			this.onChange();
+			return;
+		}
+		const surface = new ModalSurfaceComponent(component);
+		const width = this.resolveOverlayWidth(
+			typeof overlayOptions === "function" ? overlayOptions() : overlayOptions,
+			((this.tui.terminal as { columns?: number } | undefined)?.columns ?? 80),
+		);
+		const backdrop = new ModalBackdropNode(this.yoga.Node.create(), this.overlayRoot, () => surface.isVisible(width));
+		backdrop.position = POSITION_TYPE_ABSOLUTE;
+		backdrop.top = 0;
+		backdrop.left = 0;
+		backdrop.right = 0;
+		backdrop.bottom = 0;
+		backdrop.zIndex = this.mounts.size + 1;
+
+		const node = PiComponentLeaf.create(this.yoga, surface, backdrop);
+		node.position = POSITION_TYPE_ABSOLUTE;
+		node.zIndex = 1;
+		this.applyModalOptions(node, surface, overlayOptions);
+		this.mounts.set(key, { key, slot: "overlay", node: backdrop, component: surface });
 		this.onChange();
 	}
 
@@ -225,14 +277,14 @@ export class RegionRegistry {
 		this.root.dispose();
 	}
 
-	private createSlot(_name: RegionSlotName): SumoNode {
-		const slot = new SumoNode(this.yoga.Node.create(), this.root);
+	private createSlot(_name: RegionSlotName, parent: SumoNode): SumoNode {
+		const slot = new SumoNode(this.yoga.Node.create(), parent);
 		slot.flexDirection = FLEX_DIRECTION_COLUMN;
 		return slot;
 	}
 
-	private createFlexSlot(name: RegionSlotName): SumoNode {
-		const slot = this.createSlot(name);
+	private createFlexSlot(name: RegionSlotName, parent: SumoNode): SumoNode {
+		const slot = this.createSlot(name, parent);
 		slot.flexGrow = 1;
 		slot.flexShrink = 1;
 		return slot;
@@ -281,7 +333,7 @@ export class RegionRegistry {
 		const terminal = this.tui.terminal as { columns?: number; rows?: number } | undefined;
 		const columns = terminal?.columns ?? 80;
 		const rows = terminal?.rows ?? 24;
-		const width = percentToCells(options?.width, columns) ?? Math.min(60, columns);
+		const width = this.resolveOverlayWidth(options, columns);
 		const maxHeight = percentToCells(options?.maxHeight, rows);
 		node.width = width;
 		if (maxHeight !== undefined) node.height = maxHeight;
@@ -303,6 +355,27 @@ export class RegionRegistry {
 		}
 		node.top = options?.row === undefined ? Math.max(0, Math.floor(rows / 3)) : (percentToCells(options.row, rows) ?? 0);
 		node.left = options?.col === undefined ? Math.max(0, Math.floor((columns - width) / 2)) : (percentToCells(options.col, columns) ?? 0);
+	}
+
+	private applyModalOptions(node: SumoNode, surface: ModalSurfaceComponent, overlayOptions: OverlayOptions | (() => OverlayOptions) | undefined): void {
+		const options = typeof overlayOptions === "function" ? overlayOptions() : overlayOptions;
+		const terminal = this.tui.terminal as { columns?: number; rows?: number } | undefined;
+		const columns = terminal?.columns ?? 80;
+		const rows = terminal?.rows ?? 24;
+		const width = this.resolveOverlayWidth(options, columns);
+		const maxHeight = percentToCells(options?.maxHeight, rows);
+		const contentHeight = surface.render(width).length;
+		const height = maxHeight === undefined ? contentHeight : Math.min(maxHeight, contentHeight);
+		node.width = width;
+		node.height = height;
+		node.top = Math.max(0, Math.floor((rows - height) / 2) + (options?.offsetY ?? 0));
+		node.left = Math.max(0, Math.floor((columns - width) / 2) + (options?.offsetX ?? 0));
+	}
+
+	private resolveOverlayWidth(options: OverlayOptions | undefined, columns: number): number {
+		const requested = percentToCells(options?.width, columns) ?? Math.min(60, columns);
+		const minWidth = options?.minWidth ?? 0;
+		return Math.max(1, Math.min(columns, Math.max(minWidth, requested)));
 	}
 }
 

--- a/src/sumo-tui/runtime/lifecycle.test.ts
+++ b/src/sumo-tui/runtime/lifecycle.test.ts
@@ -1,10 +1,11 @@
+import { EventEmitter } from "node:events";
 import { existsSync, readFileSync } from "node:fs";
 import { mkdtemp } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
-import { createLifecycleRuntime, type LifecycleInput, type LifecycleListener, type LifecycleProcess, type LifecycleProcessEvent, type LifecycleSignal } from "./lifecycle.js";
+import { createLifecycleRuntime, useTerminalDimensions, type LifecycleInput, type LifecycleListener, type LifecycleProcess, type LifecycleProcessEvent, type LifecycleSignal } from "./lifecycle.js";
 import { ALTSCREEN_ENTER_SEQUENCE, MOUSE_SGR_ENABLE_SEQUENCE, TERMINAL_CLEANUP_SEQUENCE, TerminalController, type TerminalOutput } from "./terminal-controller.js";
 
 class FakeProcess implements LifecycleProcess {
@@ -91,6 +92,26 @@ function buildPiStub() {
 	};
 	return { pi: pi as unknown as ExtensionAPI, handlers };
 }
+
+describe("useTerminalDimensions", () => {
+	it("tracks stdout resize events and unsubscribes cleanly", () => {
+		const source = new EventEmitter() as EventEmitter & { columns: number; rows: number };
+		source.columns = 100;
+		source.rows = 40;
+		const seen: { cols: number; rows: number }[] = [];
+		const handle = useTerminalDimensions((dimensions) => seen.push(dimensions), source);
+
+		expect(handle.getSnapshot()).toEqual({ cols: 100, rows: 40 });
+		source.columns = 80;
+		source.rows = 24;
+		source.emit("resize");
+		expect(seen).toEqual([{ cols: 80, rows: 24 }]);
+		handle.dispose();
+		source.columns = 120;
+		source.emit("resize");
+		expect(seen).toHaveLength(1);
+	});
+});
 
 describe("LifecycleRuntime", () => {
 	it("registers process signal handlers exactly once", () => {

--- a/src/sumo-tui/runtime/lifecycle.ts
+++ b/src/sumo-tui/runtime/lifecycle.ts
@@ -22,6 +22,24 @@ export interface LifecycleInput {
 	setRawMode?(enabled: boolean): void;
 }
 
+export interface TerminalDimensions {
+	readonly cols: number;
+	readonly rows: number;
+}
+
+export interface TerminalDimensionSource {
+	readonly columns?: number;
+	readonly rows?: number;
+	on?(event: "resize", listener: () => void): unknown;
+	off?(event: "resize", listener: () => void): unknown;
+	removeListener?(event: "resize", listener: () => void): unknown;
+}
+
+export interface TerminalDimensionsHandle {
+	getSnapshot(): TerminalDimensions;
+	dispose(): void;
+}
+
 export interface LifecycleRenderControls {
 	scheduleRender(): void;
 	setStreamingMode(enabled: boolean): void;
@@ -73,6 +91,26 @@ function getNodeInput(): LifecycleInput | undefined {
 function crashText(error: unknown): string {
 	if (error instanceof Error) return error.stack ?? `${error.name}: ${error.message}`;
 	return String(error);
+}
+
+/** Subscribe to terminal resize events and expose the latest cell dimensions. */
+export function useTerminalDimensions(
+	onChange: (dimensions: TerminalDimensions) => void,
+	source: TerminalDimensionSource = process.stdout,
+): TerminalDimensionsHandle {
+	const snapshot = (): TerminalDimensions => ({
+		cols: Math.max(1, source.columns ?? 80),
+		rows: Math.max(1, source.rows ?? 24),
+	});
+	const handleResize = (): void => onChange(snapshot());
+	source.on?.("resize", handleResize);
+	return {
+		getSnapshot: snapshot,
+		dispose(): void {
+			if (source.off) source.off("resize", handleResize);
+			else source.removeListener?.("resize", handleResize);
+		},
+	};
 }
 
 /**

--- a/src/sumo-tui/widgets/modal-layer.test.ts
+++ b/src/sumo-tui/widgets/modal-layer.test.ts
@@ -1,0 +1,66 @@
+import type { Component } from "@mariozechner/pi-tui";
+import { describe, expect, it, vi } from "vitest";
+import { SumoNode } from "../layout/node.js";
+import { DIRECTION_LTR, loadYoga } from "../layout/yoga.js";
+import { CellBuffer } from "../render/buffer.js";
+import { composite } from "../render/compositor.js";
+import { RegionRegistry } from "../pi-compat/region-registry.js";
+import { ModalLayer } from "./modal-layer.js";
+
+class CloseOnEnterComponent implements Component {
+	public constructor(private readonly done: (value: string) => void) {}
+	public invalidate(): void {}
+	public handleInput(data: string): void {
+		if (data === "enter") this.done("closed");
+	}
+	public render(): string[] {
+		return ["CUSTOM MODAL"];
+	}
+}
+
+describe("ModalLayer", () => {
+	it("renders a full-screen dim backdrop and centered modal card", () => {
+		const layer = new ModalLayer({ getTerminalSize: () => ({ columns: 80, rows: 24 }) });
+		void layer.confirm("APPROVAL", "Continue?");
+		const rows = layer.render(80);
+
+		expect(rows).toHaveLength(24);
+		expect(rows.join("\n")).toContain("APPROVAL");
+		expect(rows.join("\n")).toContain("╭");
+		expect(rows[0]).toContain("\u001b[48;2;18;13;10m");
+	});
+
+	it("traps focus until Escape closes the active modal", async () => {
+		const layer = new ModalLayer({ getTerminalSize: () => ({ columns: 80, rows: 24 }) });
+		const result = layer.select("PICK", ["alpha", "beta"]);
+
+		expect(layer.getActiveKind()).toBe("select");
+		layer.handleInput("escape");
+		await expect(result).resolves.toBeUndefined();
+		expect(layer.getActiveKind()).toBeUndefined();
+	});
+
+	it("RegionRegistry mounts custom modals above all content with backdrop", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const registry = new RegionRegistry({
+			yoga,
+			root,
+			tui: { requestRender: vi.fn(), terminal: { columns: 80, rows: 24, setTitle: vi.fn() } } as never,
+			theme: {} as never,
+			editorTheme: { borderColor: (value: string) => value, selectList: {} } as never,
+			keybindings: {} as never,
+		});
+		registry.mountHeader(["CONTENT"]);
+		registry.mountModal("custom", new CloseOnEnterComponent(() => undefined), { width: 40 });
+		root.width = 80;
+		root.height = 24;
+		root.yogaNode.calculateLayout(80, 24, DIRECTION_LTR);
+		const frame = new CellBuffer(24, 80);
+		composite(root, frame);
+
+		expect(frame.getCell(0, 0).bg).toBe("#120D0A");
+		expect(frame.toPlainRow(11)).toContain("CUSTOM MODAL");
+		registry.dispose();
+	});
+});

--- a/src/sumo-tui/widgets/modal-layer.ts
+++ b/src/sumo-tui/widgets/modal-layer.ts
@@ -1,0 +1,122 @@
+import { truncateToWidth, visibleWidth, type Component } from "@mariozechner/pi-tui";
+import { SumoNode } from "../layout/node.js";
+import type { YogaNode } from "../layout/yoga.js";
+import type { CellBuffer, Rect } from "../render/buffer.js";
+import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { ModalManager, type ModalManagerOptions } from "./modal.js";
+import { cathedralBackdropCell } from "../cathedral/theme-bridge.js";
+
+export interface TerminalSizeProvider {
+	columns: number;
+	rows: number;
+}
+
+export interface ModalLayerOptions extends ModalManagerOptions {
+	readonly getTerminalSize?: () => TerminalSizeProvider;
+}
+
+const RESET = "\u001b[0m";
+
+function rgb(hex: string): { r: number; g: number; b: number } {
+	const normalized = hex.replace("#", "");
+	return {
+		r: Number.parseInt(normalized.slice(0, 2), 16),
+		g: Number.parseInt(normalized.slice(2, 4), 16),
+		b: Number.parseInt(normalized.slice(4, 6), 16),
+	};
+}
+
+function fg(hex: string): string {
+	const { r, g, b } = rgb(hex);
+	return `\u001b[38;2;${r};${g};${b}m`;
+}
+
+function bg(hex: string): string {
+	const { r, g, b } = rgb(hex);
+	return `\u001b[48;2;${r};${g};${b}m`;
+}
+
+function padVisible(text: string, width: number): string {
+	const clipped = visibleWidth(text) > width ? truncateToWidth(text, width, "") : text;
+	const pad = Math.max(0, width - visibleWidth(clipped));
+	return `${clipped}${" ".repeat(pad)}`;
+}
+
+function centerRows(rows: readonly string[], width: number, height: number): string[] {
+	const blank = `${bg(CATHEDRAL_TOKENS.colors.surfaceRecess)}${" ".repeat(width)}${RESET}`;
+	const out = Array.from({ length: height }, () => blank);
+	if (rows.length === 0) return [];
+	const top = Math.max(0, Math.floor((height - rows.length) / 2));
+	for (let index = 0; index < rows.length && top + index < out.length; index += 1) {
+		const row = rows[index] ?? "";
+		const left = Math.max(0, Math.floor((width - visibleWidth(row)) / 2));
+		const right = Math.max(0, width - left - visibleWidth(row));
+		out[top + index] = `${bg(CATHEDRAL_TOKENS.colors.surfaceRecess)}${" ".repeat(left)}${row}${" ".repeat(right)}${RESET}`;
+	}
+	return out;
+}
+
+export class ModalSurfaceComponent implements Component {
+	public constructor(private readonly inner: Component & { dispose?(): void }) {}
+	public invalidate(): void {
+		this.inner.invalidate?.();
+	}
+	public handleInput(data: string): void {
+		this.inner.handleInput?.(data);
+	}
+	public dispose(): void {
+		this.inner.dispose?.();
+	}
+	public isVisible(width: number): boolean {
+		return this.inner.render(Math.max(1, width - 2)).length > 0;
+	}
+	public render(width: number): string[] {
+		const outerWidth = Math.max(12, width);
+		const innerWidth = Math.max(1, outerWidth - 2);
+		const border = fg(CATHEDRAL_TOKENS.colors.divider);
+		const surface = bg(CATHEDRAL_TOKENS.colors.surfaceLifted);
+		const childRows = this.inner.render(innerWidth);
+		if (childRows.length === 0) return [];
+		const lines: string[] = [];
+		lines.push(`${surface}${border}╭${"─".repeat(innerWidth)}╮${RESET}`);
+		for (const row of childRows) {
+			lines.push(`${surface}${border}│${RESET}${surface}${padVisible(row, innerWidth)}${border}│${RESET}`);
+		}
+		lines.push(`${surface}${border}╰${"─".repeat(innerWidth)}╯${RESET}`);
+		return lines;
+	}
+}
+
+export class ModalBackdropNode extends SumoNode {
+	public constructor(yogaNode: YogaNode, parent: SumoNode | undefined, private readonly isVisible: () => boolean = () => true) {
+		super(yogaNode, parent);
+	}
+	public render(buffer: CellBuffer, rect: Rect): void {
+		if (!this.isVisible()) return;
+		buffer.paint(rect, cathedralBackdropCell());
+	}
+}
+
+/** Full-screen modal manager component with backdrop, centered card, Esc close. */
+export class ModalLayer extends ModalManager {
+	private readonly getTerminalSize: () => TerminalSizeProvider;
+
+	public constructor(options: ModalLayerOptions = {}) {
+		super(options);
+		this.getTerminalSize = options.getTerminalSize ?? (() => ({ columns: 80, rows: 24 }));
+	}
+
+	public override render(width: number): string[] {
+		if (!this.getActiveKind()) return [];
+		const size = this.getTerminalSize();
+		const frameWidth = Math.max(1, width || size.columns);
+		const frameHeight = Math.max(1, size.rows);
+		const modalWidth = Math.min(80, Math.max(32, Math.floor(frameWidth * 0.6)));
+		const surface = new ModalSurfaceComponent({
+			invalidate: () => undefined,
+			handleInput: (data: string) => this.handleInput(data),
+			render: () => super.render(modalWidth - 2),
+		});
+		return centerRows(surface.render(modalWidth), frameWidth, frameHeight);
+	}
+}

--- a/src/top-chrome.ts
+++ b/src/top-chrome.ts
@@ -21,7 +21,6 @@
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { isTopChromeHidden } from "./commands/tabs.js";
-import { renderSplash, SUMOCODE_QUOTE, SUMOCODE_QUOTE_ATTRIBUTION } from "./splash.js";
 import { CATHEDRAL_TOKENS, type SumoCodeState } from "./tokens.js";
 
 const RESET = "\u001b[0m";
@@ -190,18 +189,6 @@ export function renderTopChrome(snapshot: TopChromeSnapshot, width: number): str
  */
 export type TopChromeLoader = () => TopChromeSnapshot;
 
-/**
- * Heuristic: returns true if the session has at least one user-visible message
- * entry. Used to decide whether to render the splash content below the chrome.
- */
-function sessionHasMessages(ctx: { sessionManager: { getBranch(): readonly { type?: string }[] } }): boolean {
-	try {
-		return ctx.sessionManager.getBranch().some((entry) => entry.type === "message");
-	} catch {
-		return false;
-	}
-}
-
 export function installTopChrome(pi: ExtensionAPI, loader?: TopChromeLoader): void {
 	let state: SumoCodeState = "idle";
 	let render: (() => void) | undefined;
@@ -219,18 +206,7 @@ export function installTopChrome(pi: ExtensionAPI, loader?: TopChromeLoader): vo
 				invalidate(): void {},
 				render(width: number): string[] {
 					const snap = loader ? loader() : defaultSnapshot(ctx, state);
-					const chrome = renderTopChrome(snap, width);
-					const termHeight = process.stdout.rows ?? 0;
-					const splash = renderSplash(
-						{
-							quote: SUMOCODE_QUOTE,
-							quoteAttribution: SUMOCODE_QUOTE_ATTRIBUTION,
-							hasMessages: sessionHasMessages(ctx),
-						},
-						width,
-						termHeight > 0 ? termHeight : undefined,
-					);
-					return [chrome, ...splash];
+					return [renderTopChrome(snap, width)];
 				},
 			};
 		});
@@ -257,7 +233,7 @@ export function installTopChrome(pi: ExtensionAPI, loader?: TopChromeLoader): vo
 		render?.();
 	});
 
-	// Splash collapses on first user message arrival.
+	// Session-name / state affordances can change when messages commit.
 	pi.on("message_start", () => render?.());
 	pi.on("message_end", () => render?.());
 }


### PR DESCRIPTION
Closes #39

## Summary
- Adds Yoga-centered cathedral splash tree and splits splash mounting from top chrome.
- Reworks RegionRegistry into a header/content/sidebar/footer/modal shell with footer pinning.
- Adds adaptive sidebar tree, full-screen modal layer, terminal dimension hook, and theme-change bridge.
- Adds Phase 5 unit coverage plus portrait/landscape/narrow VHS tapes.

## Verification
- pnpm test
- pnpm test:integration
- pnpm exec tsc --noEmit
- pnpm build
- vhs docs/visual/sumo-tui-cathedral-portrait.tape
- vhs docs/visual/sumo-tui-cathedral-landscape.tape
- vhs docs/visual/sumo-tui-cathedral-narrow.tape
- for t in docs/visual/cathedral-*.tape; do vhs ""; done