### PR TITLE
refactor(tui): deepen retained TUI architecture

### DIFF
--- a/bin/sumocode.sh
+++ b/bin/sumocode.sh
@@ -5,14 +5,59 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 export SUMO_TUI="${SUMO_TUI:-1}"
-if [[ -z "${SUMO_TUI_MODULE:-}" ]]; then
-	SUMO_TUI_MODULE="$(node -e 'const { pathToFileURL } = require("node:url"); console.log(pathToFileURL(process.argv[1]).href);' "${ROOT_DIR}/sumo-interactive-mode.js")"
-	export SUMO_TUI_MODULE
-fi
 
 PI_BIN="${ROOT_DIR}/node_modules/.bin/pi"
 if [[ ! -x "${PI_BIN}" ]]; then
-	PI_BIN="pi"
+	PI_BIN="$(command -v pi)"
+fi
+
+is_truthy_env_flag() {
+	case "${1:-}" in
+		1|true|TRUE|yes|YES|on|ON) return 0 ;;
+		*) return 1 ;;
+	esac
+}
+
+pi_main_file() {
+	node -e '
+const fs = require("node:fs");
+const path = require("node:path");
+const bin = process.argv[1];
+try {
+	const resolved = fs.realpathSync(bin);
+	const dir = path.dirname(resolved);
+	for (const candidate of [path.join(dir, "main.js"), path.join(dir, "..", "dist", "main.js")]) {
+		if (fs.existsSync(candidate)) {
+			console.log(candidate);
+			process.exit(0);
+		}
+	}
+} catch {}
+process.exit(1);
+' "$1"
+}
+
+pi_has_sumo_tui_patch() {
+	local main_file
+	main_file="$(pi_main_file "$1" 2>/dev/null || true)"
+	[[ -n "${main_file}" ]] && grep -q "loadSumoInteractiveMode" "${main_file}"
+}
+
+if is_truthy_env_flag "${SUMO_TUI}"; then
+	if pi_has_sumo_tui_patch "${PI_BIN}"; then
+		if [[ -z "${SUMO_TUI_MODULE:-}" ]]; then
+			SUMO_TUI_MODULE="$(node -e 'const { pathToFileURL } = require("node:url"); console.log(pathToFileURL(process.argv[1]).href);' "${ROOT_DIR}/sumo-interactive-mode.js")"
+			export SUMO_TUI_MODULE
+		fi
+	else
+		cat >&2 <<EOF
+[sumocode] Selected Pi binary is missing the Sumo retained-TUI patch: ${PI_BIN}
+[sumocode] Falling back to legacy Pi splash so the empty-state remains visible.
+[sumocode] Run 'pnpm install' in ${ROOT_DIR} to use the retained Sumo TUI.
+EOF
+		export SUMO_TUI=0
+		unset SUMO_TUI_MODULE
+	fi
 fi
 
 exec "${PI_BIN}" -e "${ROOT_DIR}/src/extension.ts" "$@"

--- a/bin/sumocode.sh
+++ b/bin/sumocode.sh
@@ -26,7 +26,22 @@ const bin = process.argv[1];
 try {
 	const resolved = fs.realpathSync(bin);
 	const dir = path.dirname(resolved);
-	for (const candidate of [path.join(dir, "main.js"), path.join(dir, "..", "dist", "main.js")]) {
+	const candidates = [path.join(dir, "main.js"), path.join(dir, "..", "dist", "main.js")];
+
+	// pnpm creates a shell shim at node_modules/.bin/pi that execs
+	// ../@mariozechner/pi-coding-agent/dist/cli.js. Resolve that target so we
+	// can inspect the adjacent dist/main.js for the Sumo constructor patch.
+	const source = fs.readFileSync(resolved, "utf8");
+	const marker = "@mariozechner/pi-coding-agent/dist/cli.js";
+	const markerIndex = source.indexOf(marker);
+	const shimTarget = markerIndex >= 0 ? source.slice(0, markerIndex + marker.length).match(/[^\"\s]+@mariozechner\/pi-coding-agent\/dist\/cli\.js$/)?.[0] : undefined;
+	if (shimTarget) {
+		const normalizedShimTarget = shimTarget.replace(/^\$basedir\//, "");
+		const cliPath = path.resolve(dir, normalizedShimTarget);
+		candidates.push(path.join(path.dirname(cliPath), "main.js"));
+	}
+
+	for (const candidate of candidates) {
 		if (fs.existsSync(candidate)) {
 			console.log(candidate);
 			process.exit(0);

--- a/src/cathedral/cathedral-editor.ts
+++ b/src/cathedral/cathedral-editor.ts
@@ -184,12 +184,9 @@ class CathedralEditor extends CustomEditor {
 			return wrapRow(row, width);
 		};
 
-		// p-4 mirror: one blank-recess padding row above + below the content
-		// rows, so the inside of the frame has visible breathing room like the
-		// Stitch HTML mockup.
+		const result: string[] = [renderTopBorder(width, label)];
 		const paddingRow = wrapRow("", width);
-
-		const result: string[] = [renderTopBorder(width, label), paddingRow];
+		if (splash) result.push(paddingRow);
 
 		const lastContentIdx = bottomIdx === -1 ? innerRows.length : bottomIdx;
 		let contentSeen = false;
@@ -197,7 +194,10 @@ class CathedralEditor extends CustomEditor {
 			result.push(renderContent(innerRows[i]!, !contentSeen));
 			contentSeen = true;
 		}
-		result.push(paddingRow);
+		// Keep the roomy mockup padding for the splash empty state, but avoid
+		// adding active-state bottom padding. In active chat, every extra editor
+		// row steals vertical space from chat and makes the shell feel bouncy.
+		if (splash) result.push(paddingRow);
 		result.push(renderBottomBorder(width));
 
 		// Autocomplete rows after Pi's bottom border — passed through as-is

--- a/src/sidebar-placement.test.ts
+++ b/src/sidebar-placement.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	SIDEBAR_MIN_TERMINAL_WIDTH,
+	SIDEBAR_WIDTH,
+	StaticSidebarDock,
+	chooseSidebarAnchor,
+	dockStaticSidebar,
+	installNonCapturingSidebarOverlay,
+} from "./sidebar-placement.js";
+
+const ANSI = /\u001b\[[0-9;]*m/g;
+const stripAnsi = (s: string): string => s.replace(ANSI, "");
+
+function component(lines: string[]): { renderCalls: number[]; node: { render(width: number): string[]; invalidate(): void } } {
+	const renderCalls: number[] = [];
+	return {
+		renderCalls,
+		node: {
+			render(width: number): string[] {
+				renderCalls.push(width);
+				return lines;
+			},
+			invalidate(): void {},
+		},
+	};
+}
+
+describe("sidebar placement", () => {
+	it("chooses portrait-friendly sidebar anchors", () => {
+		expect(chooseSidebarAnchor(80, 140)).toBe("top-right");
+		expect(chooseSidebarAnchor(140, 80)).toBe("right-center");
+		expect(chooseSidebarAnchor(140, 80, "bottom-right")).toBe("bottom-right");
+	});
+
+	it("renders the legacy dock with clipped sidebar height", () => {
+		const left = component(["chat row"]);
+		const right = component(["SIDE 1", "SIDE 2", "SIDE 3"]);
+		const dock = new StaticSidebarDock([left.node], right.node, () => true);
+
+		const lines = dock.render(160).map(stripAnsi);
+
+		expect(left.renderCalls).toEqual([160 - SIDEBAR_WIDTH - 1]);
+		expect(right.renderCalls).toEqual([SIDEBAR_WIDTH]);
+		expect(lines).toHaveLength(1);
+		expect(lines[0]).toContain("chat row");
+		expect(lines[0]).toContain("SIDE 1");
+		expect(lines[0]).not.toContain("SIDE 2");
+	});
+
+	it("hides the legacy dock below the wide-layout threshold or before messages", () => {
+		const left = component(["main"]);
+		const right = component(["side"]);
+
+		expect(new StaticSidebarDock([left.node], right.node, () => false).render(160).map(stripAnsi)).toEqual(["main"]);
+		expect(new StaticSidebarDock([left.node], right.node, () => true).render(SIDEBAR_MIN_TERMINAL_WIDTH - 1).map(stripAnsi)).toEqual(["main"]);
+	});
+
+	it("wraps and restores Pi root containers for the legacy dock adapter", () => {
+		const header = component(["header"]).node;
+		const chat = component(["chat"]).node;
+		const pending = component(["pending"]).node;
+		const status = component(["status"]).node;
+		const editor = component(["editor"]).node;
+		const sidebar = component(["side"]).node;
+		const tui = { children: [header, chat, pending, status, editor], requestRender: vi.fn() };
+
+		const restore = dockStaticSidebar(tui, sidebar, () => true);
+
+		expect(restore).toBeTypeOf("function");
+		expect(tui.children).toHaveLength(2);
+		expect(tui.children[0]).toBeInstanceOf(StaticSidebarDock);
+		expect(tui.requestRender).toHaveBeenCalledTimes(1);
+
+		restore?.();
+
+		expect(tui.children).toEqual([header, chat, pending, status, editor]);
+	});
+
+	it("installs the active non-capturing overlay adapter", () => {
+		const sidebar = component(["side"]).node;
+		const hide = vi.fn();
+		const overlayHandle = { hide, setHidden: vi.fn(), isHidden: vi.fn(() => false), focus: vi.fn(), unfocus: vi.fn(), isFocused: vi.fn(() => false) };
+		const showOverlay = vi.fn((_component, _options) => overlayHandle);
+		const tui = { requestRender: vi.fn(), showOverlay };
+
+		const overlay = installNonCapturingSidebarOverlay(tui, sidebar, () => true);
+
+		expect(overlay.hide).toBe(hide);
+		expect(showOverlay).toHaveBeenCalledWith(sidebar, expect.objectContaining({
+			width: SIDEBAR_WIDTH,
+			anchor: "top-right",
+			nonCapturing: true,
+		}));
+		const options = showOverlay.mock.calls[0]![1];
+		expect(options.visible?.(SIDEBAR_MIN_TERMINAL_WIDTH, 24)).toBe(true);
+		expect(options.visible?.(SIDEBAR_MIN_TERMINAL_WIDTH - 1, 24)).toBe(false);
+		expect(tui.requestRender).toHaveBeenCalledWith(true);
+	});
+});

--- a/src/sidebar-placement.ts
+++ b/src/sidebar-placement.ts
@@ -1,0 +1,174 @@
+import type { Component, OverlayHandle, OverlayOptions } from "@mariozechner/pi-tui";
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { surfaceLine } from "./sumo-tui/cathedral/ansi.js";
+
+/**
+ * Threshold below which the sidebar hides itself. Per DESIGN.md §8
+ * (Responsive), the wide layout is ≥ 120 cols: chat ~70 cols + 1 gutter +
+ * 49 sidebar fits comfortably. Below this we collapse to chat-only and let
+ * sidebar info come through `/sumo:memory` etc.
+ */
+export const SIDEBAR_MIN_TERMINAL_WIDTH = 120;
+/** Render width for the sidebar overlay (DESIGN.md §5 — cols 112..160 in the wide layout). */
+export const SIDEBAR_WIDTH = 49;
+
+export type SidebarAnchor = "right-center" | "top-right" | "bottom-right";
+
+/**
+ * Pick a sidebar anchor responsive to terminal aspect ratio. Override always
+ * wins so per-machine `~/.sumocode/local-config.json` can pin a value.
+ */
+export function chooseSidebarAnchor(
+	termWidth: number,
+	termHeight: number,
+	override?: SidebarAnchor,
+): SidebarAnchor {
+	if (override) return override;
+	if (termHeight > termWidth * 1.4) return "top-right";
+	return "right-center";
+}
+
+const STATIC_SIDEBAR_GUTTER = 1;
+const STATIC_SIDEBAR_DOCK_MARKER = Symbol("sumocode.staticSidebarDock");
+
+type MutableTuiRoot = {
+	children: Component[];
+	requestRender(): void;
+};
+
+export interface SidebarOverlayHost {
+	requestRender(force?: boolean): void;
+	showOverlay(component: Component, options?: OverlayOptions): OverlayHandle;
+}
+
+function padToWidth(line: string, width: number): string {
+	const truncated = visibleWidth(line) > width ? truncateToWidth(line, width, "") : line;
+	const padding = Math.max(0, width - visibleWidth(truncated));
+	return `${truncated}${" ".repeat(padding)}`;
+}
+
+function renderComponents(components: readonly Component[], width: number): string[] {
+	return components.flatMap((component) => component.render(width));
+}
+
+/**
+ * Static two-column dock used as a guarded workaround for Pi 0.70.x not
+ * exposing a public side-panel API. It renders chat/pending/status at a
+ * reduced left-column width and appends the sidebar in reserved right columns.
+ *
+ * This remains as a legacy adapter at the sidebar placement seam. The active
+ * adapter is `installNonCapturingSidebarOverlay` because the dock participates
+ * in Pi's vertical flow and can stretch/bounce the chat layout.
+ */
+export class StaticSidebarDock implements Component {
+	readonly [STATIC_SIDEBAR_DOCK_MARKER] = true;
+
+	constructor(
+		private readonly mainComponents: readonly Component[],
+		private readonly sidebarComponent: Component,
+		private readonly shouldShowSidebar: () => boolean,
+	) {}
+
+	invalidate(): void {
+		for (const component of [...this.mainComponents, this.sidebarComponent]) {
+			component.invalidate?.();
+		}
+	}
+
+	render(width: number): string[] {
+		if (width < SIDEBAR_MIN_TERMINAL_WIDTH || !this.shouldShowSidebar()) {
+			return renderComponents(this.mainComponents, width);
+		}
+
+		const mainWidth = Math.max(1, width - SIDEBAR_WIDTH - STATIC_SIDEBAR_GUTTER);
+		const mainLines = renderComponents(this.mainComponents, mainWidth);
+		const sidebarLines = this.sidebarComponent.render(SIDEBAR_WIDTH);
+		// The dock is part of Pi's vertical root flow above the editor/footer. Its
+		// height must be dictated by the main column (header + retained chat +
+		// status), not by sidebar content. If the sidebar is taller, growing the
+		// dock pushes the input/footer down and makes the whole layout bounce during
+		// chat scroll/full redraw. Treat the sidebar as clipped to the main column.
+		const rowCount = mainLines.length;
+		const lines: string[] = [];
+
+		// Pre-build a surface-bg-painted blank sidebar row so rows where the
+		// sidebar has no content still cover the right 49 cols with the cathedral
+		// surface (#241D17). Without this, cells past the last sidebar line fall
+		// back to terminal-default bg — visible as black bands when the chat
+		// content underneath is taller than the sidebar (e.g., long tool outputs).
+		// surfaceLine pads to width and wraps in cathedral surface bg + fg ANSI.
+		const blankSidebarRow = surfaceLine("", SIDEBAR_WIDTH);
+
+		for (let i = 0; i < rowCount; i++) {
+			const left = padToWidth(mainLines[i] ?? "", mainWidth);
+			const right = i < sidebarLines.length
+				? padToWidth(sidebarLines[i]!, SIDEBAR_WIDTH)
+				: blankSidebarRow;
+			lines.push(`${left}${" ".repeat(STATIC_SIDEBAR_GUTTER)}${right}`);
+		}
+
+		return lines;
+	}
+}
+
+function isStaticSidebarDock(component: Component): component is StaticSidebarDock {
+	return (component as Partial<Record<typeof STATIC_SIDEBAR_DOCK_MARKER, boolean>>)[STATIC_SIDEBAR_DOCK_MARKER] === true;
+}
+
+/**
+ * Guarded root-container surgery. Pi currently gives extensions no public API
+ * for static side panels, but `TUI` is a public `Container` and exposes its
+ * children array. We only mutate the expected root shape and return a restore
+ * callback so reload/shutdown can put Pi's tree back exactly as it was.
+ *
+ * The dock wraps header + chat + pending + status (everything above the
+ * editor) so that the splash, which lives in the header, also respects the
+ * reserved sidebar column when the sidebar becomes visible.
+ */
+export function dockStaticSidebar(
+	tui: MutableTuiRoot,
+	sidebarComponent: Component,
+	shouldShowSidebar: () => boolean,
+): (() => void) | undefined {
+	if (tui.children.some(isStaticSidebarDock)) return undefined;
+	if (tui.children.length < 5) return undefined;
+
+	const [header, chat, pending, status, ...rest] = tui.children;
+	if (!header || !chat || !pending || !status || rest.length === 0) return undefined;
+
+	const dock = new StaticSidebarDock([header, chat, pending, status], sidebarComponent, shouldShowSidebar);
+	const original = [...tui.children];
+	tui.children.splice(0, 4, dock);
+	tui.requestRender();
+
+	return () => {
+		const dockIndex = tui.children.indexOf(dock);
+		if (dockIndex !== -1) {
+			tui.children.splice(dockIndex, 1, ...original.slice(0, 4));
+		}
+	};
+}
+
+export function installNonCapturingSidebarOverlay(
+	tui: SidebarOverlayHost,
+	sidebarComponent: Component,
+	shouldShowSidebar: () => boolean,
+): { hide(): void } {
+	// Keep the sidebar out of Pi's normal vertical line flow. The previous
+	// StaticSidebarDock wrapped header/chat/status and made sidebar rows part of
+	// the scrollback snapshot; with long chats, Pi's diff/scroll optimizations
+	// could smear or duplicate sidebar rows. A non-capturing overlay is
+	// screen-relative, so chat can scroll independently while the shell stays
+	// pinned.
+	const overlayOptions: OverlayOptions = {
+		width: SIDEBAR_WIDTH,
+		anchor: "top-right",
+		margin: { top: 1, right: 0, bottom: 4, left: 0 },
+		maxHeight: "90%",
+		nonCapturing: true,
+		visible: (termWidth) => termWidth >= SIDEBAR_MIN_TERMINAL_WIDTH && shouldShowSidebar(),
+	};
+	const overlay = tui.showOverlay(sidebarComponent, overlayOptions);
+	tui.requestRender(true);
+	return overlay;
+}

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -105,6 +105,19 @@ describe("StaticSidebarDock", () => {
 		expect(right.renderCalls).toEqual([]);
 		expect(lines).toEqual(["full width chat"]);
 	});
+
+	it("clips tall sidebar content to the main column height so editor/footer stay pinned", () => {
+		const left = component(["chat row"]);
+		const right = component(["SIDE 1", "SIDE 2", "SIDE 3"]);
+		const dock = new StaticSidebarDock([left.node], right.node, () => true);
+
+		const lines = dock.render(160).map(stripAnsi);
+
+		expect(lines).toHaveLength(1);
+		expect(lines[0]).toContain("chat row");
+		expect(lines[0]).toContain("SIDE 1");
+		expect(lines[0]).not.toContain("SIDE 2");
+	});
 });
 
 describe("dockStaticSidebar", () => {

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,7 +1,6 @@
 import { basename } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { Component } from "@mariozechner/pi-tui";
-import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { resolveGitBranch } from "./footer.js";
 import { createRemnicMemoryClient, type RemnicMemoryClient } from "./memory.js";
 import { MetricsHud } from "./sumo-tui/cathedral/metrics-hud.js";
@@ -14,16 +13,16 @@ import {
 	type SidebarSubTab,
 } from "./sumo-tui/cathedral/sidebar-rendering.js";
 import { surfaceLine } from "./sumo-tui/cathedral/ansi.js";
+import { installNonCapturingSidebarOverlay } from "./sidebar-placement.js";
+export {
+	SIDEBAR_MIN_TERMINAL_WIDTH,
+	SIDEBAR_WIDTH,
+	StaticSidebarDock,
+	chooseSidebarAnchor,
+	dockStaticSidebar,
+	type SidebarAnchor,
+} from "./sidebar-placement.js";
 
-/**
- * Threshold below which the sidebar hides itself. Per DESIGN.md §8
- * (Responsive), the wide layout is ≥ 120 cols: chat ~70 cols + 1 gutter +
- * 49 sidebar fits comfortably. Below this we collapse to chat-only and let
- * sidebar info come through `/sumo:memory` etc.
- */
-export const SIDEBAR_MIN_TERMINAL_WIDTH = 120;
-/** Render width for the sidebar overlay (DESIGN.md §5 — cols 112..160 in the wide layout). */
-export const SIDEBAR_WIDTH = 49;
 /** Debounce used when refreshing memories from user prompt changes. */
 export const SIDEBAR_MEMORY_DEBOUNCE_MS = 200;
 /** Retry cadence while Remnic is unavailable. */
@@ -42,141 +41,8 @@ export type { McpServerSnapshot, SidebarSessionSnapshot, SidebarSubTab };
 
 export type SidebarSnapshot = RegistrySidebarSnapshot;
 
-export type SidebarAnchor = "right-center" | "top-right" | "bottom-right";
-
-/**
- * Pick a sidebar anchor responsive to terminal aspect ratio. Override always
- * wins so per-machine `~/.sumocode/local-config.json` can pin a value.
- */
-export function chooseSidebarAnchor(
-	termWidth: number,
-	termHeight: number,
-	override?: SidebarAnchor,
-): SidebarAnchor {
-	if (override) return override;
-	if (termHeight > termWidth * 1.4) return "top-right";
-	return "right-center";
-}
-
 export function renderSidebar(snapshot: SidebarSnapshot, width: number): string[] {
 	return renderRegistrySidebarLines(snapshot, width).map((line) => surfaceLine(line, width));
-}
-
-const STATIC_SIDEBAR_GUTTER = 1;
-const STATIC_SIDEBAR_DOCK_MARKER = Symbol("sumocode.staticSidebarDock");
-
-type MutableTuiRoot = {
-	children: Component[];
-	requestRender(): void;
-};
-
-function padToWidth(line: string, width: number): string {
-	const truncated = visibleWidth(line) > width ? truncateToWidth(line, width, "") : line;
-	const padding = Math.max(0, width - visibleWidth(truncated));
-	return `${truncated}${" ".repeat(padding)}`;
-}
-
-function renderComponents(components: readonly Component[], width: number): string[] {
-	return components.flatMap((component) => component.render(width));
-}
-
-/**
- * Static two-column dock used as a guarded workaround for Pi 0.70.x not
- * exposing a public side-panel API. It renders chat/pending/status at a
- * reduced left-column width and appends the sidebar in reserved right columns.
- *
- * Cathedral splash discipline: when `shouldShowSidebar()` returns false (no
- * messages yet), the dock renders its main components at full width and skips
- * the sidebar column entirely. The sidebar only earns its column when there is
- * chat to contextualize.
- */
-export class StaticSidebarDock implements Component {
-	readonly [STATIC_SIDEBAR_DOCK_MARKER] = true;
-
-	constructor(
-		private readonly mainComponents: readonly Component[],
-		private readonly sidebarComponent: Component,
-		private readonly shouldShowSidebar: () => boolean,
-	) {}
-
-	invalidate(): void {
-		for (const component of [...this.mainComponents, this.sidebarComponent]) {
-			component.invalidate?.();
-		}
-	}
-
-	render(width: number): string[] {
-		if (width < SIDEBAR_MIN_TERMINAL_WIDTH || !this.shouldShowSidebar()) {
-			return renderComponents(this.mainComponents, width);
-		}
-
-		const mainWidth = Math.max(1, width - SIDEBAR_WIDTH - STATIC_SIDEBAR_GUTTER);
-		const mainLines = renderComponents(this.mainComponents, mainWidth);
-		const sidebarLines = this.sidebarComponent.render(SIDEBAR_WIDTH);
-		// The dock is part of Pi's vertical root flow above the editor/footer. Its
-		// height must be dictated by the main column (header + retained chat +
-		// status), not by sidebar content. If the sidebar is taller, growing the
-		// dock pushes the input/footer down and makes the whole layout bounce during
-		// chat scroll/full redraw. Treat the sidebar as clipped to the main column.
-		const rowCount = mainLines.length;
-		const lines: string[] = [];
-
-		// Pre-build a surface-bg-painted blank sidebar row so rows where the
-		// sidebar has no content still cover the right 49 cols with the cathedral
-		// surface (#241D17). Without this, cells past the last sidebar line fall
-		// back to terminal-default bg — visible as black bands when the chat
-		// content underneath is taller than the sidebar (e.g., long tool outputs).
-		// surfaceLine pads to width and wraps in cathedral surface bg + fg ANSI.
-		const blankSidebarRow = surfaceLine("", SIDEBAR_WIDTH);
-
-		for (let i = 0; i < rowCount; i++) {
-			const left = padToWidth(mainLines[i] ?? "", mainWidth);
-			const right = i < sidebarLines.length
-				? padToWidth(sidebarLines[i]!, SIDEBAR_WIDTH)
-				: blankSidebarRow;
-			lines.push(`${left}${" ".repeat(STATIC_SIDEBAR_GUTTER)}${right}`);
-		}
-
-		return lines;
-	}
-}
-
-function isStaticSidebarDock(component: Component): component is StaticSidebarDock {
-	return (component as Partial<Record<typeof STATIC_SIDEBAR_DOCK_MARKER, boolean>>)[STATIC_SIDEBAR_DOCK_MARKER] === true;
-}
-
-/**
- * Guarded root-container surgery. Pi currently gives extensions no public API
- * for static side panels, but `TUI` is a public `Container` and exposes its
- * children array. We only mutate the expected root shape and return a restore
- * callback so reload/shutdown can put Pi's tree back exactly as it was.
- *
- * The dock wraps header + chat + pending + status (everything above the
- * editor) so that the splash, which lives in the header, also respects the
- * reserved sidebar column when the sidebar becomes visible.
- */
-export function dockStaticSidebar(
-	tui: MutableTuiRoot,
-	sidebarComponent: Component,
-	shouldShowSidebar: () => boolean,
-): (() => void) | undefined {
-	if (tui.children.some(isStaticSidebarDock)) return undefined;
-	if (tui.children.length < 5) return undefined;
-
-	const [header, chat, pending, status, ...rest] = tui.children;
-	if (!header || !chat || !pending || !status || rest.length === 0) return undefined;
-
-	const dock = new StaticSidebarDock([header, chat, pending, status], sidebarComponent, shouldShowSidebar);
-	const original = [...tui.children];
-	tui.children.splice(0, 4, dock);
-	tui.requestRender();
-
-	return () => {
-		const dockIndex = tui.children.indexOf(dock);
-		if (dockIndex !== -1) {
-			tui.children.splice(dockIndex, 1, ...original.slice(0, 4));
-		}
-	};
 }
 
 export type SidebarMemoryCache = {
@@ -346,12 +212,6 @@ export function installSidebar(pi: ExtensionAPI): void {
 		memoryCache = createSidebarMemoryCache(createRemnicMemoryClient());
 
 		ctx.ui.setWidget("sumocode-sidebar-dock", (tui): Component & { dispose(): void } => {
-			// Keep the sidebar out of Pi's normal vertical line flow. The previous
-			// StaticSidebarDock wrapped header/chat/status and made sidebar rows part of
-			// the scrollback snapshot; with long chats, Pi's diff/scroll optimizations
-			// could smear or duplicate sidebar rows. A non-capturing overlay is
-			// screen-relative, so chat can scroll independently while the shell stays
-			// pinned.
 			requestRender = () => tui.requestRender(true);
 			activeMetricsHud?.stop();
 			const metricsHud = new MetricsHud();
@@ -368,15 +228,7 @@ export function installSidebar(pi: ExtensionAPI): void {
 					);
 				},
 			};
-			const overlay = tui.showOverlay(sidebarComponent, {
-				width: SIDEBAR_WIDTH,
-				anchor: "top-right",
-				margin: { top: 1, right: 0, bottom: 4, left: 0 },
-				maxHeight: "90%",
-				nonCapturing: true,
-				visible: (termWidth) => termWidth >= SIDEBAR_MIN_TERMINAL_WIDTH && sessionHasMessages(ctx),
-			});
-			tui.requestRender(true);
+			const overlay = installNonCapturingSidebarOverlay(tui, sidebarComponent, () => sessionHasMessages(ctx));
 			return {
 				invalidate(): void {},
 				render(): string[] {

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -113,7 +113,12 @@ export class StaticSidebarDock implements Component {
 		const mainWidth = Math.max(1, width - SIDEBAR_WIDTH - STATIC_SIDEBAR_GUTTER);
 		const mainLines = renderComponents(this.mainComponents, mainWidth);
 		const sidebarLines = this.sidebarComponent.render(SIDEBAR_WIDTH);
-		const rowCount = Math.max(mainLines.length, sidebarLines.length);
+		// The dock is part of Pi's vertical root flow above the editor/footer. Its
+		// height must be dictated by the main column (header + retained chat +
+		// status), not by sidebar content. If the sidebar is taller, growing the
+		// dock pushes the input/footer down and makes the whole layout bounce during
+		// chat scroll/full redraw. Treat the sidebar as clipped to the main column.
+		const rowCount = mainLines.length;
 		const lines: string[] = [];
 
 		// Pre-build a surface-bg-painted blank sidebar row so rows where the

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -346,7 +346,13 @@ export function installSidebar(pi: ExtensionAPI): void {
 		memoryCache = createSidebarMemoryCache(createRemnicMemoryClient());
 
 		ctx.ui.setWidget("sumocode-sidebar-dock", (tui): Component & { dispose(): void } => {
-			requestRender = () => tui.requestRender();
+			// Keep the sidebar out of Pi's normal vertical line flow. The previous
+			// StaticSidebarDock wrapped header/chat/status and made sidebar rows part of
+			// the scrollback snapshot; with long chats, Pi's diff/scroll optimizations
+			// could smear or duplicate sidebar rows. A non-capturing overlay is
+			// screen-relative, so chat can scroll independently while the shell stays
+			// pinned.
+			requestRender = () => tui.requestRender(true);
 			activeMetricsHud?.stop();
 			const metricsHud = new MetricsHud();
 			activeMetricsHud = metricsHud;
@@ -362,7 +368,15 @@ export function installSidebar(pi: ExtensionAPI): void {
 					);
 				},
 			};
-			const restore = dockStaticSidebar(tui, sidebarComponent, () => sessionHasMessages(ctx));
+			const overlay = tui.showOverlay(sidebarComponent, {
+				width: SIDEBAR_WIDTH,
+				anchor: "top-right",
+				margin: { top: 1, right: 0, bottom: 4, left: 0 },
+				maxHeight: "90%",
+				nonCapturing: true,
+				visible: (termWidth) => termWidth >= SIDEBAR_MIN_TERMINAL_WIDTH && sessionHasMessages(ctx),
+			});
+			tui.requestRender(true);
 			return {
 				invalidate(): void {},
 				render(): string[] {
@@ -371,7 +385,7 @@ export function installSidebar(pi: ExtensionAPI): void {
 				dispose(): void {
 					metricsHud.stop();
 					if (activeMetricsHud === metricsHud) activeMetricsHud = undefined;
-					restore?.();
+					overlay.hide();
 					requestRender = undefined;
 				},
 			};

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
@@ -6,7 +6,7 @@ import { bufferToAnsiLines } from "../render/ansi-writer.js";
 import { CellBuffer } from "../render/buffer.js";
 import { composite } from "../render/compositor.js";
 import { ChatPager } from "../widgets/chat-pager.js";
-import { ChatViewportController, type ChatViewportHost, type ChatViewportRuntime } from "./chat-viewport-controller.js";
+import { ChatViewportController, textFromAgentMessage, type ChatViewportHost, type ChatViewportRuntime } from "./chat-viewport-controller.js";
 
 function rows(count: number): { render(width: number): string[] } {
 	return { render: (_width: number) => Array.from({ length: count }, () => "chrome") };
@@ -66,6 +66,12 @@ async function makeController(options: { terminalRows?: number; terminalColumns?
 }
 
 describe("ChatViewportController", () => {
+	it("extracts streamed assistant text from Pi message shapes", () => {
+		expect(textFromAgentMessage({ role: "user", content: "hello" })).toBe("hello");
+		expect(textFromAgentMessage({ role: "assistant", content: [{ type: "thinking", thinking: "hidden" }, { type: "text", text: "visible" }] })).toBe("visible");
+		expect(textFromAgentMessage({ role: "toolResult", content: [{ type: "text", text: "tool output" }] })).toBe("tool output");
+	});
+
 	it("owns chat viewport geometry, including sidebar-aware width", async () => {
 		const { root, chat, runtime, controller } = await makeController({ terminalRows: 16, terminalColumns: 130 });
 

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from "vitest";
+import { SIDEBAR_WIDTH } from "../../sidebar.js";
+import { SumoNode } from "../layout/node.js";
+import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga } from "../layout/yoga.js";
+import { bufferToAnsiLines } from "../render/ansi-writer.js";
+import { CellBuffer } from "../render/buffer.js";
+import { composite } from "../render/compositor.js";
+import { ChatPager } from "../widgets/chat-pager.js";
+import { ChatViewportController, type ChatViewportHost, type ChatViewportRuntime } from "./chat-viewport-controller.js";
+
+function rows(count: number): { render(width: number): string[] } {
+	return { render: (_width: number) => Array.from({ length: count }, () => "chrome") };
+}
+
+async function makeController(options: { terminalRows?: number; terminalColumns?: number } = {}): Promise<{
+	root: SumoNode;
+	chat: ChatPager;
+	host: ChatViewportHost;
+	runtime: ChatViewportRuntime & {
+		renderCalls: { width: number; height: number }[];
+		writeCalls: { top: number; left: number; width: number; height: number }[];
+		requestRender: ReturnType<typeof vi.fn>;
+		setEmptyChatQuoteState: ReturnType<typeof vi.fn>;
+		noteUserMessage: ReturnType<typeof vi.fn>;
+	};
+	controller: ChatViewportController;
+}> {
+	const yoga = await loadYoga();
+	const root = new SumoNode(yoga.Node.create());
+	root.flexDirection = FLEX_DIRECTION_COLUMN;
+	const chat = ChatPager.create(yoga, root);
+	const renderCalls: { width: number; height: number }[] = [];
+	const writeCalls: { top: number; left: number; width: number; height: number }[] = [];
+	const runtime = {
+		renderCalls,
+		writeCalls,
+		requestRender: vi.fn(),
+		setEmptyChatQuoteState: vi.fn(),
+		noteUserMessage: vi.fn(),
+		renderChatLines(width: number, height: number): string[] {
+			renderCalls.push({ width, height });
+			root.width = width;
+			root.height = height;
+			root.yogaNode.calculateLayout(width, height, DIRECTION_LTR);
+			const frame = new CellBuffer(height, width);
+			composite(root, frame);
+			return bufferToAnsiLines(frame);
+		},
+		writeChatViewport(top: number, left: number, width: number, height: number): boolean {
+			writeCalls.push({ top, left, width, height });
+			return true;
+		},
+	};
+	const host: ChatViewportHost = {
+		ui: { terminal: { rows: options.terminalRows ?? 12, columns: options.terminalColumns ?? 80 } },
+		headerContainer: rows(1),
+		pendingMessagesContainer: rows(0),
+		statusContainer: rows(0),
+		widgetContainerAbove: rows(0),
+		editorContainer: rows(2),
+		widgetContainerBelow: rows(0),
+		footer: rows(1),
+	};
+	const controller = new ChatViewportController(runtime, chat, host);
+	return { root, chat, host, runtime, controller };
+}
+
+describe("ChatViewportController", () => {
+	it("owns chat viewport geometry, including sidebar-aware width", async () => {
+		const { root, chat, runtime, controller } = await makeController({ terminalRows: 16, terminalColumns: 130 });
+
+		controller.render(130);
+		expect(runtime.renderCalls.at(-1)).toEqual({ width: 130, height: 12 });
+
+		chat.addMessage("user", "hello");
+		controller.render(130);
+		expect(runtime.renderCalls.at(-1)).toEqual({ width: 130 - SIDEBAR_WIDTH, height: 12 });
+		root.dispose();
+	});
+
+	it("translates wheel and jump-to-bottom input into local viewport repaint", async () => {
+		const { root, chat, runtime, controller } = await makeController({ terminalRows: 12, terminalColumns: 80 });
+		for (let index = 0; index < 50; index += 1) chat.addMessage("user", `message ${index}`);
+		controller.render(80);
+		const bottom = chat.scrollBox.scrollOffset;
+
+		const wheelResult = controller.handleInput("\x1b[<64;10;5M");
+		const afterWheel = chat.scrollBox.scrollOffset;
+		const jumpResult = controller.handleInput("\x1b[b");
+
+		expect(wheelResult).toEqual({ consume: true });
+		expect(afterWheel).toBeLessThan(bottom);
+		expect(jumpResult).toEqual({ consume: true });
+		expect(chat.scrollBox.scrollOffset).toBe(bottom);
+		expect(runtime.writeCalls).toContainEqual({ top: 1, left: 0, width: 80, height: 8 });
+		root.dispose();
+	});
+
+	it("owns Pi message ingestion and empty-session state", async () => {
+		const { root, chat, runtime, controller } = await makeController();
+
+		controller.renderSessionContext({ messages: [] });
+		expect(runtime.setEmptyChatQuoteState).toHaveBeenLastCalledWith({ active: true, userMessageCount: 0 });
+
+		controller.handleAgentEvent({ type: "message_start", message: { role: "user", content: "hello" } });
+		controller.handleAgentEvent({ type: "message_start", message: { role: "assistant", content: "" } });
+		controller.handleAgentEvent({ type: "message_update", message: { role: "assistant", content: "hello back" }, assistantMessageEvent: { type: "text_delta", delta: "hello" } });
+		controller.handleAgentEvent({ type: "message_update", message: { role: "assistant", content: "hello back" }, assistantMessageEvent: { type: "text_delta", delta: " back" } });
+		controller.handleAgentEvent({ type: "message_end", message: { role: "assistant", content: "hello back" } });
+
+		expect(runtime.noteUserMessage).toHaveBeenCalledTimes(1);
+		expect(chat.getRenderedMessages().map((message) => message.text)).toEqual(["hello", "hello back"]);
+		root.dispose();
+	});
+});

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -1,0 +1,367 @@
+import { matchesKey } from "@mariozechner/pi-tui";
+import type { KeyEvent } from "../input/key-router.js";
+import { parseSgrMouseStream, type MouseEvent } from "../input/mouse.js";
+import { logDiagnostic } from "../runtime/diagnostics.js";
+import { ChatPager } from "../widgets/chat-pager.js";
+import { SIDEBAR_MIN_TERMINAL_WIDTH, SIDEBAR_WIDTH } from "../../sidebar.js";
+
+interface PiRenderableComponent {
+	render(width: number): string[];
+}
+
+export interface ChatViewportHost {
+	readonly ui?: {
+		readonly terminal?: { readonly rows?: number; readonly columns?: number };
+		requestRender?(force?: boolean): void;
+	};
+	readonly headerContainer?: PiRenderableComponent;
+	readonly pendingMessagesContainer?: PiRenderableComponent;
+	readonly statusContainer?: PiRenderableComponent;
+	readonly widgetContainerAbove?: PiRenderableComponent;
+	readonly widgetContainerBelow?: PiRenderableComponent;
+	readonly editorContainer?: PiRenderableComponent;
+	readonly footer?: PiRenderableComponent;
+}
+
+export interface ChatViewportRuntime {
+	renderChatLines(width: number, height: number): string[];
+	writeChatViewport(top: number, left: number, width: number, height: number): boolean;
+	requestRender(): void;
+	setEmptyChatQuoteState(state: { active: boolean; userMessageCount: number }): void;
+	noteUserMessage(): void;
+}
+
+interface MouseInputDiagnosticsFields {
+	readonly dataLength: number;
+	readonly sourceLength: number;
+	readonly eventCount: number;
+	readonly consumed: boolean;
+	readonly pendingLength: number;
+	readonly leftoverLength: number;
+	readonly sourceHex: string;
+	readonly leftoverHex: string;
+}
+
+const COMPLETE_SGR_MOUSE_SEQUENCE = /\x1b\[<\d+;\d+;\d+[Mm]/g;
+/**
+ * Match a trailing prefix of an SGR mouse sequence so we can buffer partial
+ * input across stdin chunks. Matches any of:
+ *
+ *   ESC, ESC [, ESC [ <, ESC [ < digits, ESC [ < digits ; digits ...
+ *
+ * The terminating M / m is intentionally absent — that's what makes it a
+ * prefix. Anchored to end-of-string only.
+ */
+const SGR_MOUSE_PREFIX_TAIL_PATTERN = /(?:\x1b(?:\[(?:<\d*(?:;\d*){0,2})?)?)$/;
+
+function toHex(value: string): string {
+	let hex = "";
+	for (let index = 0; index < value.length; index += 1) {
+		hex += value.charCodeAt(index).toString(16).padStart(2, "0");
+	}
+	return hex;
+}
+
+function diagnoseMouseInput(fields: MouseInputDiagnosticsFields): void {
+	logDiagnostic("sumo_mouse_input", {
+		data_length: fields.dataLength,
+		source_length: fields.sourceLength,
+		events: fields.eventCount,
+		consumed: fields.consumed,
+		pending_length: fields.pendingLength,
+		leftover_length: fields.leftoverLength,
+		source_hex: fields.sourceHex,
+		leftover_hex: fields.leftoverHex,
+	});
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+function textFromContent(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.map((part) => {
+			const record = asRecord(part);
+			if (!record || record.type !== "text") return undefined;
+			return typeof record.text === "string" ? record.text : undefined;
+		})
+		.filter((part): part is string => typeof part === "string")
+		.join("");
+}
+
+export function textFromAgentMessage(message: unknown): string {
+	const record = asRecord(message);
+	if (!record) return "";
+	if (record.role === "bashExecution") {
+		const command = typeof record.command === "string" ? record.command : "bash";
+		const output = typeof record.output === "string" ? record.output : "";
+		return output ? `$ ${command}\n${output}` : `$ ${command}`;
+	}
+	const text = textFromContent(record.content);
+	if (text.length > 0) return text;
+	return typeof record.errorMessage === "string" ? record.errorMessage : "";
+}
+
+function chatRoleFromAgentMessage(message: unknown): string {
+	const role = asRecord(message)?.role;
+	if (role === "assistant") return "sumo";
+	if (role === "toolResult" || role === "bashExecution") return "tool";
+	if (typeof role === "string") return role;
+	return "system";
+}
+
+function keyFromInput(data: string): KeyEvent | undefined {
+	switch (data) {
+		case "\x1b[5~":
+			return { key: "PageUp", sequence: data };
+		case "\x1b[6~":
+			return { key: "PageDown", sequence: data };
+		case "\x1b[H":
+		case "\x1b[1~":
+			return { key: "Home", sequence: data };
+		case "\x1b[F":
+		case "\x1b[4~":
+			return { key: "End", sequence: data };
+		default:
+			if (matchesKey(data, "shift+down")) return { key: "End", sequence: data };
+			return undefined;
+	}
+}
+
+function renderableLineCount(component: PiRenderableComponent | undefined, width: number): number {
+	if (!component) return 0;
+	try {
+		return component.render(width).length;
+	} catch {
+		return 0;
+	}
+}
+
+function sessionMessages(sessionContext: unknown): unknown[] {
+	const messages = asRecord(sessionContext)?.messages;
+	return Array.isArray(messages) ? messages : [];
+}
+
+function isUserMessage(message: unknown): boolean {
+	return asRecord(message)?.role === "user";
+}
+
+function countUserMessages(messages: readonly unknown[]): number {
+	return messages.filter(isUserMessage).length;
+}
+
+/**
+ * Deep Module for the retained chat viewport seam.
+ *
+ * SumoInteractiveMode owns Pi lifecycle wiring; this Module owns the chat
+ * viewport interface: geometry, input translation, message ingestion, and the
+ * repaint strategy needed to keep chat scroll local to the retained viewport.
+ */
+export class ChatViewportController {
+	private lastAssistantText = "";
+	private lastChatTop = 0;
+	private lastChatWidth = 1;
+	private lastChatHeight = 1;
+	private pendingMouseInput = "";
+
+	public constructor(
+		private readonly runtime: ChatViewportRuntime,
+		private readonly chat: ChatPager,
+		private readonly host: ChatViewportHost,
+	) {}
+
+	public render(width: number): string[] {
+		// Pi's chatContainer is allocated the full terminal width by Pi's TUI.
+		// But Pi separately mounts our installSidebar() widget at the right 49
+		// cols (when the session has messages and terminal width >= 120). If we
+		// composite the chat tree at full width, our chat content paints into the
+		// cols Pi will overpaint with the sidebar — visually that's chat text
+		// running INTO the sidebar boundary before being clobbered.
+		// Fix: narrow our composite to (terminal - SIDEBAR_WIDTH) when the same
+		// predicate Pi uses for showing the sidebar is true. The sidebar's own
+		// 49 cols on the right come from Pi's separate widget paint.
+		const terminalWidth = Math.max(1, Math.floor(width));
+		const sidebarVisible = terminalWidth >= SIDEBAR_MIN_TERMINAL_WIDTH && this.chat.hasMessages();
+		const effectiveWidth = sidebarVisible ? Math.max(1, terminalWidth - SIDEBAR_WIDTH) : terminalWidth;
+		this.lastChatWidth = effectiveWidth;
+		this.lastChatTop = this.computeChatTop(this.lastChatWidth);
+		this.lastChatHeight = this.computeChatHeight(this.lastChatWidth);
+		return this.runtime.renderChatLines(this.lastChatWidth, this.lastChatHeight);
+	}
+
+	public clear(): void {
+		this.chat.clearMessages();
+		this.lastAssistantText = "";
+		this.pendingMouseInput = "";
+		this.runtime.setEmptyChatQuoteState({ active: false, userMessageCount: 0 });
+	}
+
+	public handleInput(data: string): { consume?: boolean; data?: string } | void {
+		const source = this.pendingMouseInput + data;
+		this.pendingMouseInput = "";
+		let nextData = source;
+		let consumed = false;
+
+		if (source.includes("\x1b")) {
+			const parsed = parseSgrMouseStream(source);
+			for (const event of parsed.events) {
+				this.handleMouse(event);
+			}
+
+			// Strip every complete SGR mouse sequence — including wheel-left/right
+			// (button codes 66/67) and any other variants the parser may not
+			// recognize. Anything matching `\x1b[<\d+;\d+;\d+[Mm]` is mouse input
+			// and must never reach Pi's editor as visible text.
+			const beforeCompleteStrip = nextData;
+			nextData = nextData.replace(COMPLETE_SGR_MOUSE_SEQUENCE, "");
+			if (nextData !== beforeCompleteStrip) consumed = true;
+
+			// Buffer trailing partial mouse sequences across chunks.
+			const tailMatch = nextData.match(SGR_MOUSE_PREFIX_TAIL_PATTERN);
+			if (tailMatch && tailMatch[0].length > 0) {
+				this.pendingMouseInput = tailMatch[0];
+				nextData = nextData.slice(0, nextData.length - tailMatch[0].length);
+				consumed = true;
+			}
+
+			// Anything else starting with `\x1b[<` is a corrupt/stale mouse
+			// fragment. Drop it instead of forwarding raw bytes to Pi's editor.
+			if (nextData.includes("\x1b[<")) {
+				const stripped = nextData.replace(/\x1b\[<[\d;]*[Mm]?/g, "");
+				if (stripped !== nextData) {
+					nextData = stripped;
+					consumed = true;
+				}
+			}
+
+			diagnoseMouseInput({
+				dataLength: data.length,
+				sourceLength: source.length,
+				eventCount: parsed.events.length,
+				consumed,
+				pendingLength: this.pendingMouseInput.length,
+				leftoverLength: nextData.length,
+				sourceHex: toHex(source.slice(0, 64)),
+				leftoverHex: toHex(nextData.slice(0, 64)),
+			});
+		}
+
+		const keyEvent = keyFromInput(nextData);
+		if (keyEvent && this.chat.handleKey(keyEvent)) {
+			this.renderChatViewportOrRequest();
+			return { consume: true };
+		}
+
+		if (nextData.length === 0 && consumed) return { consume: true };
+		if (nextData !== data) return { data: nextData };
+		return undefined;
+	}
+
+	public handleAgentEvent(event: unknown): void {
+		const record = asRecord(event);
+		if (!record || typeof record.type !== "string") return;
+		const message = record.message;
+		switch (record.type) {
+			case "message_start":
+				this.handleMessageStart(message);
+				break;
+			case "message_update":
+				this.handleMessageUpdate(message, record.assistantMessageEvent);
+				break;
+			case "message_end":
+				this.handleMessageEnd(message);
+				break;
+			case "agent_end":
+				this.chat.endStreaming();
+				break;
+		}
+	}
+
+	public renderSessionContext(sessionContext: unknown): void {
+		this.clear();
+		const messages = sessionMessages(sessionContext);
+		this.runtime.setEmptyChatQuoteState({ active: messages.length === 0, userMessageCount: countUserMessages(messages) });
+		for (const message of messages) {
+			const text = textFromAgentMessage(message);
+			if (text.length === 0) continue;
+			this.chat.addMessage(chatRoleFromAgentMessage(message), text);
+		}
+	}
+
+	private handleMessageStart(message: unknown): void {
+		const role = asRecord(message)?.role;
+		if (role === "user") this.runtime.noteUserMessage();
+		if (role === "assistant") {
+			this.lastAssistantText = "";
+			this.chat.addMessage("sumo", "");
+			return;
+		}
+		const text = textFromAgentMessage(message);
+		if (text.length === 0) return;
+		this.chat.addMessage(chatRoleFromAgentMessage(message), text);
+	}
+
+	private handleMessageUpdate(message: unknown, assistantMessageEvent: unknown): void {
+		if (asRecord(message)?.role !== "assistant") return;
+		const streamEvent = asRecord(assistantMessageEvent);
+		if (streamEvent?.type === "text_delta" && typeof streamEvent.delta === "string") {
+			this.chat.appendToLast(streamEvent.delta);
+			this.lastAssistantText += streamEvent.delta;
+			return;
+		}
+		const text = textFromAgentMessage(message);
+		if (text.length === 0 || text === this.lastAssistantText) return;
+		this.chat.replaceLast(text);
+		this.lastAssistantText = text;
+	}
+
+	private handleMessageEnd(message: unknown): void {
+		if (asRecord(message)?.role === "assistant") {
+			const text = textFromAgentMessage(message);
+			if (text.length > 0 && text !== this.lastAssistantText) {
+				this.chat.replaceLast(text);
+				this.lastAssistantText = text;
+			}
+			this.chat.endStreaming();
+		}
+	}
+
+	private handleMouse(event: MouseEvent): boolean {
+		const localEvent: MouseEvent = {
+			...event,
+			row: event.row - this.lastChatTop,
+			col: event.col,
+		};
+		if (localEvent.row < 0 || localEvent.row >= this.lastChatHeight || localEvent.col < 0 || localEvent.col >= this.lastChatWidth) return false;
+		const handled = this.chat.handleMouseEvent(localEvent);
+		if (handled) this.renderChatViewportOrRequest();
+		return handled;
+	}
+
+	private renderChatViewportOrRequest(): void {
+		if (!this.runtime.writeChatViewport(this.lastChatTop, 0, this.lastChatWidth, this.lastChatHeight)) {
+			this.runtime.requestRender();
+		}
+	}
+
+	private computeChatTop(width: number): number {
+		return renderableLineCount(this.host.headerContainer, width);
+	}
+
+	private computeChatHeight(width: number): number {
+		const terminalRows = Math.max(1, this.host.ui?.terminal?.rows ?? 24);
+		const terminalWidth = Math.max(1, this.host.ui?.terminal?.columns ?? width);
+		const chromeRows =
+			renderableLineCount(this.host.headerContainer, width) +
+			renderableLineCount(this.host.pendingMessagesContainer, width) +
+			renderableLineCount(this.host.statusContainer, width) +
+			renderableLineCount(this.host.widgetContainerAbove, terminalWidth) +
+			renderableLineCount(this.host.editorContainer, terminalWidth) +
+			renderableLineCount(this.host.widgetContainerBelow, terminalWidth) +
+			renderableLineCount(this.host.footer, terminalWidth);
+		return Math.max(1, terminalRows - chromeRows);
+	}
+}

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -451,5 +451,3 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 	target[CHAT_VIEWPORT_BRIDGE_INSTALLED] = cleanup;
 	return cleanup;
 }
-
-export const installChatPagerBridge = installChatViewportBridge;

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -5,15 +5,26 @@ import { logDiagnostic } from "../runtime/diagnostics.js";
 import { ChatPager } from "../widgets/chat-pager.js";
 import { SIDEBAR_MIN_TERMINAL_WIDTH, SIDEBAR_WIDTH } from "../../sidebar.js";
 
+const CHAT_VIEWPORT_BRIDGE_INSTALLED = Symbol("sumo-tui.chat-viewport-bridge-installed");
+
 interface PiRenderableComponent {
 	render(width: number): string[];
 }
 
+interface PiChatContainer {
+	clear?(): void;
+	invalidate?(): void;
+	render?(width: number): string[];
+}
+
+interface PiTuiLike {
+	readonly terminal?: { readonly rows?: number; readonly columns?: number };
+	requestRender?(force?: boolean): void;
+	addInputListener?(listener: (data: string) => { consume?: boolean; data?: string } | void): () => void;
+}
+
 export interface ChatViewportHost {
-	readonly ui?: {
-		readonly terminal?: { readonly rows?: number; readonly columns?: number };
-		requestRender?(force?: boolean): void;
-	};
+	readonly ui?: PiTuiLike;
 	readonly headerContainer?: PiRenderableComponent;
 	readonly pendingMessagesContainer?: PiRenderableComponent;
 	readonly statusContainer?: PiRenderableComponent;
@@ -29,6 +40,18 @@ export interface ChatViewportRuntime {
 	requestRender(): void;
 	setEmptyChatQuoteState(state: { active: boolean; userMessageCount: number }): void;
 	noteUserMessage(): void;
+}
+
+interface ChatViewportBridgeRuntime extends ChatViewportRuntime {
+	getSnapshot(): { readonly chat: ChatPager } | undefined;
+	setExternalRenderControls(controls: { scheduleRender(): void; setStreamingMode(enabled: boolean): void } | undefined): void;
+}
+
+interface ChatViewportBridgeHost extends ChatViewportHost {
+	chatContainer?: PiChatContainer;
+	handleEvent?(event: unknown): unknown;
+	renderSessionContext?(sessionContext: unknown, options?: unknown): unknown;
+	[CHAT_VIEWPORT_BRIDGE_INSTALLED]?: () => void;
 }
 
 interface MouseInputDiagnosticsFields {
@@ -365,3 +388,68 @@ export class ChatViewportController {
 		return Math.max(1, terminalRows - chromeRows);
 	}
 }
+
+export function installChatViewportBridge(upstream: unknown, runtime: ChatViewportBridgeRuntime): (() => void) | undefined {
+	const target = upstream as ChatViewportBridgeHost;
+	if (target[CHAT_VIEWPORT_BRIDGE_INSTALLED]) return undefined;
+	const snapshot = runtime.getSnapshot();
+	if (!snapshot || !target.chatContainer) return undefined;
+	const controller = new ChatViewportController(runtime, snapshot.chat, target);
+	const chatContainer = target.chatContainer;
+	const originalRender = chatContainer.render?.bind(chatContainer);
+	const originalClear = chatContainer.clear?.bind(chatContainer);
+	const originalInvalidate = chatContainer.invalidate?.bind(chatContainer);
+	const originalHandleEvent = target.handleEvent?.bind(target);
+	const originalRenderSessionContext = target.renderSessionContext?.bind(target);
+	const removeInputListener = target.ui?.addInputListener?.((data) => controller.handleInput(data));
+
+	runtime.setExternalRenderControls({
+		// Pi's normal differential renderer optimizes line shifts with terminal
+		// scroll sequences. In SumoCode's hybrid shell, chat scroll changes only
+		// the left content while the sidebar/footer remain fixed; terminal scroll
+		// sequences move the whole screen and leave stale sidebar/chat fragments.
+		// Force Pi's full redraw path for retained chat updates until Sumo owns the
+		// entire root renderer.
+		scheduleRender: () => target.ui?.requestRender?.(true),
+		setStreamingMode: () => target.ui?.requestRender?.(true),
+	});
+	chatContainer.render = (width: number): string[] => controller.render(width);
+	chatContainer.clear = (): void => {
+		controller.clear();
+		originalClear?.();
+	};
+	chatContainer.invalidate = (): void => {
+		originalInvalidate?.();
+		runtime.requestRender();
+	};
+	if (originalHandleEvent) {
+		target.handleEvent = async (event: unknown): Promise<unknown> => {
+			controller.handleAgentEvent(event);
+			return originalHandleEvent(event);
+		};
+	}
+	if (originalRenderSessionContext) {
+		target.renderSessionContext = (sessionContext: unknown, options?: unknown): unknown => {
+			controller.renderSessionContext(sessionContext);
+			return originalRenderSessionContext(sessionContext, options);
+		};
+	}
+
+	const cleanup = (): void => {
+		removeInputListener?.();
+		runtime.setExternalRenderControls(undefined);
+		if (originalRender) chatContainer.render = originalRender;
+		else delete chatContainer.render;
+		if (originalClear) chatContainer.clear = originalClear;
+		else delete chatContainer.clear;
+		if (originalInvalidate) chatContainer.invalidate = originalInvalidate;
+		else delete chatContainer.invalidate;
+		if (originalHandleEvent) target.handleEvent = originalHandleEvent;
+		if (originalRenderSessionContext) target.renderSessionContext = originalRenderSessionContext;
+		delete target[CHAT_VIEWPORT_BRIDGE_INSTALLED];
+	};
+	target[CHAT_VIEWPORT_BRIDGE_INSTALLED] = cleanup;
+	return cleanup;
+}
+
+export const installChatPagerBridge = installChatViewportBridge;

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -1,8 +1,7 @@
-import { matchesKey } from "@mariozechner/pi-tui";
-import type { KeyEvent } from "../input/key-router.js";
 import { parseSgrMouseStream, type MouseEvent } from "../input/mouse.js";
 import { logDiagnostic } from "../runtime/diagnostics.js";
 import { ChatPager } from "../widgets/chat-pager.js";
+import { chatScrollCommandFromInput } from "../widgets/chat-scroll-command.js";
 import { SIDEBAR_MIN_TERMINAL_WIDTH, SIDEBAR_WIDTH } from "../../sidebar.js";
 
 const CHAT_VIEWPORT_BRIDGE_INSTALLED = Symbol("sumo-tui.chat-viewport-bridge-installed");
@@ -136,24 +135,6 @@ function chatRoleFromAgentMessage(message: unknown): string {
 	return "system";
 }
 
-function keyFromInput(data: string): KeyEvent | undefined {
-	switch (data) {
-		case "\x1b[5~":
-			return { key: "PageUp", sequence: data };
-		case "\x1b[6~":
-			return { key: "PageDown", sequence: data };
-		case "\x1b[H":
-		case "\x1b[1~":
-			return { key: "Home", sequence: data };
-		case "\x1b[F":
-		case "\x1b[4~":
-			return { key: "End", sequence: data };
-		default:
-			if (matchesKey(data, "shift+down")) return { key: "End", sequence: data };
-			return undefined;
-	}
-}
-
 function renderableLineCount(component: PiRenderableComponent | undefined, width: number): number {
 	if (!component) return 0;
 	try {
@@ -272,7 +253,7 @@ export class ChatViewportController {
 			});
 		}
 
-		const keyEvent = keyFromInput(nextData);
+		const keyEvent = chatScrollCommandFromInput(nextData);
 		if (keyEvent && this.chat.handleKey(keyEvent)) {
 			this.renderChatViewportOrRequest();
 			return { consume: true };

--- a/src/sumo-tui/pi-compat/pi-interactive-adapter.test.ts
+++ b/src/sumo-tui/pi-compat/pi-interactive-adapter.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	filterPiNoiseChildren,
+	forceHardwareCursorVisible,
+	installPiNoiseFilter,
+	isPiNoiseTextComponent,
+	shouldForceHardwareCursor,
+	shouldHidePiNoise,
+	type PiNoiseFilterState,
+} from "./pi-interactive-adapter.js";
+
+class TextNode {
+	public constructor(public text: string) {}
+}
+
+class Spacer {}
+
+describe("Pi interactive adapter", () => {
+	it("matches Pi startup noise Text components after ANSI styling", () => {
+		expect(isPiNoiseTextComponent(new TextNode("\x1b[33m[Extension issues]\x1b[0m\nshortcut conflict"))).toBe(true);
+		expect(isPiNoiseTextComponent(new TextNode("\x1b[33mWarning: Anthropic subscription auth is active. Third-party harness usage draws from extra usage.\x1b[0m"))).toBe(true);
+		expect(isPiNoiseTextComponent(new TextNode("Warning: Wait for the current response to finish before reloading."))).toBe(false);
+	});
+
+	it("filters known noise and the spacer Pi appends after it", () => {
+		const keep = new TextNode("real chat message");
+		const state: PiNoiseFilterState = { removedNodes: [], skipNextSpacer: false };
+		const container = {
+			children: [new TextNode("[Extension issues]\nconflict"), new Spacer(), keep],
+		};
+
+		expect(filterPiNoiseChildren(container, state)).toBe(2);
+		expect(container.children).toEqual([keep]);
+		expect(state.removedNodes).toHaveLength(2);
+	});
+
+	it("patches chatContainer.addChild so late Anthropic warnings never enter chat", () => {
+		const state: PiNoiseFilterState = { removedNodes: [], skipNextSpacer: false };
+		const children: unknown[] = [];
+		const upstream = {
+			chatContainer: {
+				children,
+				addChild(component: unknown) {
+					children.push(component);
+				},
+			},
+		};
+		const keep = new TextNode("real warning");
+
+		expect(installPiNoiseFilter(upstream, state)).toBe(true);
+		upstream.chatContainer.addChild(new TextNode("Warning: Anthropic subscription auth is active. Third-party harness usage draws from extra usage."));
+		upstream.chatContainer.addChild(new Spacer());
+		upstream.chatContainer.addChild(keep);
+
+		expect(children).toEqual([keep]);
+		expect(state.removedNodes).toHaveLength(2);
+	});
+
+	it("defaults SUMO_TUI_HIDE_PI_NOISE and hardware cursor forcing on, with env opt-outs", () => {
+		expect(shouldHidePiNoise({})).toBe(true);
+		expect(shouldHidePiNoise({ SUMO_TUI_HIDE_PI_NOISE: "0" })).toBe(false);
+		expect(shouldForceHardwareCursor({})).toBe(true);
+		expect(shouldForceHardwareCursor({ SUMO_TUI_SHOW_HARDWARE_CURSOR: "false" })).toBe(false);
+	});
+
+	it("forces Pi's TUI hardware cursor visible", () => {
+		const setShowHardwareCursor = vi.fn();
+		const upstream = { ui: { setShowHardwareCursor } };
+
+		expect(forceHardwareCursorVisible(upstream)).toBe(true);
+		expect(setShowHardwareCursor).toHaveBeenCalledWith(true);
+	});
+});

--- a/src/sumo-tui/pi-compat/pi-interactive-adapter.ts
+++ b/src/sumo-tui/pi-compat/pi-interactive-adapter.ts
@@ -1,0 +1,125 @@
+const ANSI_PATTERN = /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\)|_[^\x07]*(?:\x07|\x1b\\))/g;
+const FALSE_ENV_VALUES = new Set(["0", "false", "no", "off"]);
+const PI_NOISE_FILTER_INSTALLED = Symbol("sumo-tui.pi-noise-filter-installed");
+
+export const PI_NOISE_TEXT_PATTERNS: readonly RegExp[] = [
+	/\[Extension issues\]/i,
+	/Warning:\s*Anthropic subscription auth is active/i,
+	/Anthropic subscription auth is active\. Third-party harness usage/i,
+];
+
+export interface PiChatContainer {
+	children?: unknown[];
+	addChild?(component: unknown): void;
+	clear?(): void;
+	invalidate?(): void;
+	render?(width: number): string[];
+}
+
+interface FilterablePiChatContainer extends PiChatContainer {
+	[PI_NOISE_FILTER_INSTALLED]?: true;
+}
+
+export interface PiNoiseFilterState {
+	removedNodes: unknown[];
+	skipNextSpacer: boolean;
+}
+
+function envFlagEnabled(value: string | undefined, defaultValue: boolean): boolean {
+	if (value === undefined) return defaultValue;
+	return !FALSE_ENV_VALUES.has(value.trim().toLowerCase());
+}
+
+function stripAnsi(text: string): string {
+	return text.replace(ANSI_PATTERN, "");
+}
+
+function getTextComponentContent(component: unknown): string | undefined {
+	if (typeof component !== "object" || component === null || !("text" in component)) return undefined;
+	const text = (component as { text?: unknown }).text;
+	return typeof text === "string" ? text : undefined;
+}
+
+function isSpacerComponent(component: unknown): boolean {
+	if (typeof component !== "object" || component === null) return false;
+	return component.constructor?.name === "Spacer";
+}
+
+export function shouldHidePiNoise(env: NodeJS.ProcessEnv = process.env): boolean {
+	return envFlagEnabled(env.SUMO_TUI_HIDE_PI_NOISE, true);
+}
+
+export function shouldForceHardwareCursor(env: NodeJS.ProcessEnv = process.env): boolean {
+	return envFlagEnabled(env.SUMO_TUI_SHOW_HARDWARE_CURSOR, true);
+}
+
+export function isPiNoiseTextComponent(component: unknown): boolean {
+	const text = getTextComponentContent(component);
+	if (text === undefined) return false;
+	const plain = stripAnsi(text);
+	return PI_NOISE_TEXT_PATTERNS.some((pattern) => pattern.test(plain));
+}
+
+export function getUpstreamChatContainer(upstream: unknown): PiChatContainer | undefined {
+	if (typeof upstream !== "object" || upstream === null || !("chatContainer" in upstream)) return undefined;
+	const chatContainer = (upstream as { chatContainer?: unknown }).chatContainer;
+	return typeof chatContainer === "object" && chatContainer !== null ? (chatContainer as PiChatContainer) : undefined;
+}
+
+export function filterPiNoiseChildren(container: PiChatContainer, state: PiNoiseFilterState = { removedNodes: [], skipNextSpacer: false }): number {
+	if (!Array.isArray(container.children)) return 0;
+	const nextChildren: unknown[] = [];
+	let removed = 0;
+	let skipNextSpacer = state.skipNextSpacer;
+	for (const child of container.children) {
+		if (isPiNoiseTextComponent(child)) {
+			state.removedNodes.push(child);
+			removed += 1;
+			skipNextSpacer = true;
+			continue;
+		}
+		if (skipNextSpacer && isSpacerComponent(child)) {
+			state.removedNodes.push(child);
+			removed += 1;
+			skipNextSpacer = false;
+			continue;
+		}
+		skipNextSpacer = false;
+		nextChildren.push(child);
+	}
+	container.children = nextChildren;
+	state.skipNextSpacer = skipNextSpacer;
+	return removed;
+}
+
+export function installPiNoiseFilter(upstream: unknown, state: PiNoiseFilterState = { removedNodes: [], skipNextSpacer: false }): boolean {
+	const container = getUpstreamChatContainer(upstream) as FilterablePiChatContainer | undefined;
+	if (!container?.addChild || container[PI_NOISE_FILTER_INSTALLED]) return false;
+	const originalAddChild = container.addChild.bind(container);
+	container.addChild = (component: unknown): void => {
+		if (isPiNoiseTextComponent(component)) {
+			state.removedNodes.push(component);
+			state.skipNextSpacer = true;
+			return;
+		}
+		if (state.skipNextSpacer && isSpacerComponent(component)) {
+			state.removedNodes.push(component);
+			state.skipNextSpacer = false;
+			return;
+		}
+		state.skipNextSpacer = false;
+		originalAddChild(component);
+	};
+	container[PI_NOISE_FILTER_INSTALLED] = true;
+	return true;
+}
+
+export function forceHardwareCursorVisible(upstream: unknown): boolean {
+	if (typeof upstream !== "object" || upstream === null || !("ui" in upstream)) return false;
+	const ui = (upstream as { ui?: unknown }).ui;
+	if (typeof ui !== "object" || ui === null || !("setShowHardwareCursor" in ui)) return false;
+	const setShowHardwareCursor = (ui as { setShowHardwareCursor?: unknown }).setShowHardwareCursor;
+	if (typeof setShowHardwareCursor !== "function") return false;
+	setShowHardwareCursor.call(ui, true);
+	return true;
+}

--- a/src/sumo-tui/pi-compat/retained-shell-transition.test.ts
+++ b/src/sumo-tui/pi-compat/retained-shell-transition.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { EmptyChatQuoteNode } from "../cathedral/empty-chat-quote.js";
+import { createSplashTree, defaultSplashSnapshot } from "../cathedral/splash-tree.js";
+import { SumoNode } from "../layout/node.js";
+import { FLEX_DIRECTION_COLUMN, loadYoga } from "../layout/yoga.js";
+import { ChatPager } from "../widgets/chat-pager.js";
+import { RetainedShellTransition } from "./retained-shell-transition.js";
+
+describe("RetainedShellTransition", () => {
+	it("mounts splash for empty sessions and chat after the first message", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		const chat = ChatPager.create(yoga);
+		const splash = createSplashTree(yoga, undefined, () => defaultSplashSnapshot(chat.hasMessages()));
+		const emptyQuote = new EmptyChatQuoteNode(yoga.Node.create(), () => ({ sidebarVisible: true, isSplash: false, userMessageCount: 0 }));
+		root.addChild(emptyQuote);
+		const transition = new RetainedShellTransition({ root, chat, splash, emptyChatQuote: emptyQuote });
+
+		expect(transition.sync()).toBe("splash");
+		expect(splash.root.parent).toBe(root);
+		expect(chat.parent).toBeUndefined();
+		expect(emptyQuote.parent).toBeUndefined();
+
+		chat.addMessage("user", "hello");
+
+		expect(transition.sync()).toBe("active-chat");
+		expect(chat.parent).toBe(root);
+		expect(splash.root.parent).toBeUndefined();
+
+		root.dispose();
+		chat.dispose();
+		splash.root.dispose();
+		emptyQuote.dispose();
+	});
+});

--- a/src/sumo-tui/pi-compat/retained-shell-transition.ts
+++ b/src/sumo-tui/pi-compat/retained-shell-transition.ts
@@ -1,0 +1,50 @@
+import type { EmptyChatQuoteNode } from "../cathedral/empty-chat-quote.js";
+import type { SplashTree } from "../cathedral/splash-tree.js";
+import type { SumoNode } from "../layout/node.js";
+import type { ChatPager } from "../widgets/chat-pager.js";
+
+export type RetainedShellPhase = "splash" | "active-chat";
+
+export interface RetainedShellTransitionParts {
+	readonly root: SumoNode;
+	readonly chat: ChatPager;
+	readonly splash: SplashTree;
+	readonly emptyChatQuote?: EmptyChatQuoteNode;
+}
+
+/**
+ * Owns the retained shell's no-messages → active-chat transition.
+ *
+ * This keeps the product state machine out of the Pi compatibility runtime:
+ * empty sessions mount the cathedral splash, while the first rendered message
+ * swaps in ChatPager. The empty-chat quote remains allocated for future v2 work
+ * but is deliberately unmounted because UX_SPEC §0 says splash owns the empty
+ * slot.
+ */
+export class RetainedShellTransition {
+	public constructor(private readonly parts: RetainedShellTransitionParts) {}
+
+	public phase(): RetainedShellPhase {
+		return this.parts.chat.hasMessages() ? "active-chat" : "splash";
+	}
+
+	public sync(): RetainedShellPhase {
+		const { root, chat, splash, emptyChatQuote } = this.parts;
+		const phase = this.phase();
+		splash.syncVisibility();
+
+		if (emptyChatQuote && emptyChatQuote.parent === root) {
+			root.removeChild(emptyChatQuote);
+		}
+
+		if (phase === "active-chat") {
+			if (splash.root.parent === root) root.removeChild(splash.root);
+			if (chat.parent !== root) root.addChild(chat);
+			return phase;
+		}
+
+		if (chat.parent === root) root.removeChild(chat);
+		if (splash.root.parent !== root) root.addChild(splash.root);
+		return phase;
+	}
+}

--- a/src/sumo-tui/pi-compat/splash-thinking-fix.test.ts
+++ b/src/sumo-tui/pi-compat/splash-thinking-fix.test.ts
@@ -4,13 +4,12 @@ describe("UX_SPEC §0 — splash takes no-messages slot, not empty-chat-quote (#
 	it("splash predicate triggers when chat has zero messages regardless of sidebar visibility", () => {
 		// Pure regression guard: ensure shouldShowEmptyChatQuote is not on the
 		// hot path of syncChatSlot. We test by inspecting the source surface.
-		const path = new URL("./sumo-interactive-mode.ts", import.meta.url);
+		const path = new URL("./retained-shell-transition.ts", import.meta.url);
 		const source = require("node:fs").readFileSync(path, "utf8") as string;
-		const syncBlock = source.slice(source.indexOf("private syncChatSlot()"), source.indexOf("private syncChatSlot()") + 1500);
-		// The body must NOT branch on showEmptyQuote anymore.
-		expect(syncBlock).not.toContain("showEmptyQuote");
+		// The transition Module must NOT branch on showEmptyQuote anymore.
+		expect(source).not.toContain("showEmptyQuote");
 		// Splash mount must remain.
-		expect(syncBlock).toContain("this.root.addChild(this.splash.root)");
+		expect(source).toContain("root.addChild(splash.root)");
 	});
 });
 

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
@@ -3,14 +3,13 @@ import {
 	SumoInteractiveRuntime,
 	filterPiNoiseChildren,
 	forceHardwareCursorVisible,
-	installChatPagerBridge,
 	installPiNoiseFilter,
 	isPiNoiseTextComponent,
 	shouldForceHardwareCursor,
 	shouldHidePiNoise,
-	textFromAgentMessage,
 	type PiNoiseFilterState,
 } from "./sumo-interactive-mode.js";
+import { installChatViewportBridge } from "./chat-viewport-controller.js";
 import { defaultSplashSnapshot, getSplashContentHeight } from "../cathedral/splash-tree.js";
 import { ALTSCREEN_ENTER_SEQUENCE, MOUSE_SGR_ENABLE_SEQUENCE } from "../runtime/terminal-controller.js";
 
@@ -84,12 +83,6 @@ describe("sumo interactive Pi noise filtering", () => {
 
 		expect(forceHardwareCursorVisible(upstream)).toBe(true);
 		expect(setShowHardwareCursor).toHaveBeenCalledWith(true);
-	});
-
-	it("extracts streamed assistant text from Pi message shapes", () => {
-		expect(textFromAgentMessage({ role: "user", content: "hello" })).toBe("hello");
-		expect(textFromAgentMessage({ role: "assistant", content: [{ type: "thinking", thinking: "hidden" }, { type: "text", text: "visible" }] })).toBe("visible");
-		expect(textFromAgentMessage({ role: "toolResult", content: [{ type: "text", text: "tool output" }] })).toBe("tool output");
 	});
 
 	it("enters altscreen and enables SGR mouse from the retained runtime", async () => {
@@ -179,7 +172,7 @@ describe("sumo interactive Pi noise filtering", () => {
 			handleEvent: vi.fn(),
 		};
 
-		const cleanup = installChatPagerBridge(upstream, runtime);
+		const cleanup = installChatViewportBridge(upstream, runtime);
 		for (let index = 0; index < 50; index += 1) {
 			await upstream.handleEvent({ type: "message_start", message: { role: "user", content: `message ${index}` } });
 		}
@@ -236,7 +229,7 @@ describe("sumo interactive Pi noise filtering", () => {
 			handleEvent: vi.fn(),
 		};
 
-		const cleanup = installChatPagerBridge(upstream, runtime);
+		const cleanup = installChatViewportBridge(upstream, runtime);
 		for (let index = 0; index < 50; index += 1) {
 			await upstream.handleEvent({ type: "message_start", message: { role: "user", content: `message ${index}` } });
 		}
@@ -290,7 +283,7 @@ describe("sumo interactive Pi noise filtering", () => {
 			handleEvent: vi.fn(),
 		};
 
-		const cleanup = installChatPagerBridge(upstream, runtime);
+		const cleanup = installChatViewportBridge(upstream, runtime);
 		for (let index = 0; index < 50; index += 1) {
 			await upstream.handleEvent({ type: "message_start", message: { role: "user", content: `message ${index}` } });
 		}

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
@@ -12,6 +12,7 @@ import {
 	type PiNoiseFilterState,
 } from "./sumo-interactive-mode.js";
 import { defaultSplashSnapshot, getSplashContentHeight } from "../cathedral/splash-tree.js";
+import { ALTSCREEN_ENTER_SEQUENCE, MOUSE_SGR_ENABLE_SEQUENCE } from "../runtime/terminal-controller.js";
 
 const ANSI_PATTERN = /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\)|_[^\x07]*(?:\x07|\x1b\\))/g;
 
@@ -89,6 +90,18 @@ describe("sumo interactive Pi noise filtering", () => {
 		expect(textFromAgentMessage({ role: "user", content: "hello" })).toBe("hello");
 		expect(textFromAgentMessage({ role: "assistant", content: [{ type: "thinking", thinking: "hidden" }, { type: "text", text: "visible" }] })).toBe("visible");
 		expect(textFromAgentMessage({ role: "toolResult", content: [{ type: "text", text: "tool output" }] })).toBe("tool output");
+	});
+
+	it("enters altscreen and enables SGR mouse from the retained runtime", async () => {
+		const write = vi.fn();
+		const runtime = new SumoInteractiveRuntime({ isTTY: true, columns: 100, rows: 30, write });
+
+		await runtime.start();
+
+		const output = write.mock.calls.map(([chunk]) => String(chunk)).join("");
+		expect(output).toContain(ALTSCREEN_ENTER_SEQUENCE);
+		expect(output).toContain(MOUSE_SGR_ENABLE_SEQUENCE);
+		runtime.stop();
 	});
 
 	it("renders the retained splash centered in the chat slot until the first message", async () => {
@@ -178,6 +191,7 @@ describe("sumo interactive Pi noise filtering", () => {
 
 		expect(result).toEqual({ consume: true });
 		expect(after).toBeLessThan(before);
+		expect(upstream.ui.requestRender).toHaveBeenCalledWith(true);
 		const rendered = upstream.chatContainer.render(60).join("\n");
 		expect(rendered).toContain("USER >");
 		expect(rendered).not.toContain("upstream chat");

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
@@ -188,9 +188,13 @@ describe("sumo interactive Pi noise filtering", () => {
 
 		const result = inputListeners[0]?.("\x1b[<64;10;5M");
 		const after = runtime.getSnapshot()?.chat.scrollBox.scrollOffset ?? 0;
+		const jumpResult = inputListeners[0]?.("\x1b[b");
+		const jumped = runtime.getSnapshot()?.chat.scrollBox.scrollOffset ?? 0;
 
 		expect(result).toEqual({ consume: true });
 		expect(after).toBeLessThan(before);
+		expect(jumpResult).toEqual({ consume: true });
+		expect(jumped).toBe(before);
 		expect(upstream.ui.requestRender).toHaveBeenCalledWith(true);
 		const rendered = upstream.chatContainer.render(60).join("\n");
 		expect(rendered).toContain("USER >");

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -43,7 +43,6 @@ import { TerminalController } from "../runtime/terminal-controller.js";
 import { ChatPager } from "../widgets/chat-pager.js";
 import { SIDEBAR_MIN_TERMINAL_WIDTH } from "../../sidebar.js";
 import { installChatViewportBridge } from "./chat-viewport-controller.js";
-export { installChatPagerBridge, textFromAgentMessage } from "./chat-viewport-controller.js";
 import { SumoExtensionUIAdapter, type SumoExtensionUIAdapterOptions } from "./extension-ui-adapter.js";
 import { createForeignAwareUIContext, type ForeignAwareUIOptions } from "./foreign-extension-warning.js";
 
@@ -480,7 +479,7 @@ export class SumoInteractiveMode {
 	private readonly retainedRuntime = new SumoInteractiveRuntime();
 	private readonly piNoiseFilterState: PiNoiseFilterState = { removedNodes: [], skipNextSpacer: false };
 	private retainedUIContext: ExtensionUIContext | undefined;
-	private chatPagerBridgeCleanup: (() => void) | undefined;
+	private chatViewportBridgeCleanup: (() => void) | undefined;
 
 	public constructor(
 		private readonly runtimeHost: AgentSessionRuntime,
@@ -502,8 +501,8 @@ export class SumoInteractiveMode {
 	}
 
 	public stop(): void {
-		this.chatPagerBridgeCleanup?.();
-		this.chatPagerBridgeCleanup = undefined;
+		this.chatViewportBridgeCleanup?.();
+		this.chatViewportBridgeCleanup = undefined;
 		this.upstream?.stop();
 		this.retainedRuntime.stop();
 	}
@@ -539,7 +538,7 @@ export class SumoInteractiveMode {
 
 	private configureUpstreamBeforeInit(upstream: InteractiveMode): void {
 		if (shouldHidePiNoise()) installPiNoiseFilter(upstream, this.piNoiseFilterState);
-		if (!this.chatPagerBridgeCleanup) this.chatPagerBridgeCleanup = installChatViewportBridge(upstream, this.retainedRuntime);
+		if (!this.chatViewportBridgeCleanup) this.chatViewportBridgeCleanup = installChatViewportBridge(upstream, this.retainedRuntime);
 		if (shouldForceHardwareCursor()) forceHardwareCursorVisible(upstream);
 	}
 

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -30,6 +30,7 @@
 import type { AgentSessionRuntime, InteractiveModeOptions } from "@mariozechner/pi-coding-agent";
 import { InteractiveMode } from "@mariozechner/pi-coding-agent";
 import type { ExtensionUIContext } from "@mariozechner/pi-coding-agent";
+import { matchesKey } from "@mariozechner/pi-tui";
 import type { KeyEvent } from "../input/key-router.js";
 import { parseSgrMouseStream, type MouseEvent } from "../input/mouse.js";
 import { EmptyChatQuoteNode, shouldRenderEmptyChatQuote, type EmptyChatQuoteSnapshot } from "../cathedral/empty-chat-quote.js";
@@ -326,6 +327,7 @@ function keyFromInput(data: string): KeyEvent | undefined {
 		case "\x1b[4~":
 			return { key: "End", sequence: data };
 		default:
+			if (matchesKey(data, "shift+down")) return { key: "End", sequence: data };
 			return undefined;
 	}
 }

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -36,8 +36,8 @@ import { SumoNode } from "../layout/node.js";
 import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga, type Yoga } from "../layout/yoga.js";
 import { bufferToAnsiLines } from "../render/ansi-writer.js";
 import { CellBuffer } from "../render/buffer.js";
-import { composite, type HardwareCursor } from "../render/compositor.js";
-import { diffFrames, type FrameDiffPatch } from "../render/diff.js";
+import { composite } from "../render/compositor.js";
+import { diffFrames } from "../render/diff.js";
 import { FrameScheduler } from "../runtime/frame-scheduler.js";
 import { TerminalController } from "../runtime/terminal-controller.js";
 import { ChatPager } from "../widgets/chat-pager.js";
@@ -262,8 +262,7 @@ export class SumoInteractiveRuntime {
 		// runtime must not depend on extension ordering: mouse wheel chat scrolling
 		// only works reliably when SGR mouse mode is enabled before Pi's first
 		// interactive frame.
-		this.terminal.enterAltscreen();
-		this.terminal.enableMouseSGR();
+		this.terminal.startRetainedSession();
 		this.scheduler = new FrameScheduler({ render: () => this.render() });
 		this.resizeHandler = () => this.requestRender();
 		process.stdout.on("resize", this.resizeHandler);
@@ -306,19 +305,8 @@ export class SumoInteractiveRuntime {
 	}
 
 	public writeChatViewport(top: number, left: number, width: number, height: number): boolean {
-		if (!this.output.isTTY) return false;
 		this.invalidateFrameCache();
-		const safeTop = Math.max(0, Math.floor(top));
-		const safeLeft = Math.max(0, Math.floor(left));
-		const lines = this.renderChatLines(width, height);
-		if (lines.length === 0) return false;
-		let output = "\x1b[?2026h\x1b7";
-		for (let row = 0; row < lines.length; row += 1) {
-			output += `\x1b[${safeTop + row + 1};${safeLeft + 1}H${lines[row] ?? ""}`;
-		}
-		output += "\x1b8\x1b[?2026l";
-		this.output.write(output);
-		return true;
+		return this.terminal.writeChatViewport(top, left, this.renderChatLines(width, height));
 	}
 
 	public stop(): void {
@@ -432,26 +420,11 @@ export class SumoInteractiveRuntime {
 		const nextFrame = new CellBuffer(height, width);
 		const result = composite(this.root, nextFrame);
 		const patches = diffFrames(this.previousFrame, nextFrame);
-		this.writePatches(patches, result.hardwareCursor);
+		this.terminal.writeFramePatches(patches, result.hardwareCursor);
 		this.previousFrame = nextFrame.clone();
 		this.renderedVersion = this.frameVersion;
 		this.renderedWidth = width;
 		this.renderedHeight = height;
-	}
-
-	private writePatches(patches: readonly FrameDiffPatch[], hardwareCursor: HardwareCursor | null): void {
-		if (patches.length === 0 && !hardwareCursor) return;
-		let output = "\x1b[?2026h";
-		for (const patch of patches) {
-			if (patch.type === "scroll") {
-				output += patch.ansi;
-				continue;
-			}
-			output += `\x1b[${patch.row + 1};1H${patch.ansi}\x1b[K`;
-		}
-		if (hardwareCursor) output += `\x1b[${hardwareCursor.row + 1};${hardwareCursor.col + 1}H\x1b[?25h`;
-		output += "\x1b[?2026l";
-		this.output.write(output);
 	}
 }
 

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -148,7 +148,7 @@ interface PiRenderableComponent {
 interface PiTuiLike {
 	readonly terminal?: { readonly rows?: number; readonly columns?: number };
 	children?: unknown[];
-	requestRender?(): void;
+	requestRender?(force?: boolean): void;
 	addInputListener?(listener: (data: string) => { consume?: boolean; data?: string } | void): () => void;
 }
 
@@ -405,6 +405,13 @@ export class SumoInteractiveRuntime {
 		this.splash = createSplashTree(this.yoga, undefined, () => defaultSplashSnapshot(this.chat?.hasMessages() ?? false));
 		this.emptyChatQuote = new EmptyChatQuoteNode(this.yoga.Node.create(), () => this.emptyChatQuoteSnapshot());
 		this.syncChatSlot();
+		// Retained SumoInteractiveMode owns the application terminal contract.
+		// The extension lifecycle shim also enters altscreen when loaded, but the
+		// runtime must not depend on extension ordering: mouse wheel chat scrolling
+		// only works reliably when SGR mouse mode is enabled before Pi's first
+		// interactive frame.
+		this.terminal.enterAltscreen();
+		this.terminal.enableMouseSGR();
 		this.scheduler = new FrameScheduler({ render: () => this.render() });
 		this.resizeHandler = () => this.requestRender();
 		process.stdout.on("resize", this.resizeHandler);
@@ -804,8 +811,14 @@ export function installChatPagerBridge(upstream: unknown, runtime: SumoInteracti
 	const removeInputListener = target.ui?.addInputListener?.((data) => bridge.handleInput(data));
 
 	runtime.setExternalRenderControls({
-		scheduleRender: () => target.ui?.requestRender?.(),
-		setStreamingMode: () => target.ui?.requestRender?.(),
+		// Pi's normal differential renderer optimizes line shifts with terminal
+		// scroll sequences. In SumoCode's hybrid shell, chat scroll changes only
+		// the left content while the sidebar/footer remain fixed; terminal scroll
+		// sequences move the whole screen and leave stale sidebar/chat fragments.
+		// Force Pi's full redraw path for retained chat updates until Sumo owns the
+		// entire root renderer.
+		scheduleRender: () => target.ui?.requestRender?.(true),
+		setStreamingMode: () => target.ui?.requestRender?.(true),
 	});
 	chatContainer.render = (width: number): string[] => bridge.render(width);
 	chatContainer.clear = (): void => {

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -43,6 +43,24 @@ import { TerminalController } from "../runtime/terminal-controller.js";
 import { ChatPager } from "../widgets/chat-pager.js";
 import { SIDEBAR_MIN_TERMINAL_WIDTH } from "../../sidebar.js";
 import { installChatViewportBridge } from "./chat-viewport-controller.js";
+import {
+	filterPiNoiseChildren,
+	forceHardwareCursorVisible,
+	getUpstreamChatContainer,
+	installPiNoiseFilter,
+	shouldForceHardwareCursor,
+	shouldHidePiNoise,
+	type PiNoiseFilterState,
+} from "./pi-interactive-adapter.js";
+export {
+	filterPiNoiseChildren,
+	forceHardwareCursorVisible,
+	installPiNoiseFilter,
+	isPiNoiseTextComponent,
+	shouldForceHardwareCursor,
+	shouldHidePiNoise,
+	type PiNoiseFilterState,
+} from "./pi-interactive-adapter.js";
 import { RetainedShellTransition } from "./retained-shell-transition.js";
 import { SumoExtensionUIAdapter, type SumoExtensionUIAdapterOptions } from "./extension-ui-adapter.js";
 import { createForeignAwareUIContext, type ForeignAwareUIOptions } from "./foreign-extension-warning.js";
@@ -76,133 +94,6 @@ interface SumoInteractiveRuntimeSnapshot {
 function debugLog(message: string): void {
 	if (process.env.SUMO_TUI_DEBUG !== "1") return;
 	console.error(`[sumo-tui] ${message}`);
-}
-
-const ANSI_PATTERN = /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\)|_[^\x07]*(?:\x07|\x1b\\))/g;
-const FALSE_ENV_VALUES = new Set(["0", "false", "no", "off"]);
-const PI_NOISE_FILTER_INSTALLED = Symbol("sumo-tui.pi-noise-filter-installed");
-
-export const PI_NOISE_TEXT_PATTERNS: readonly RegExp[] = [
-	/\[Extension issues\]/i,
-	/Warning:\s*Anthropic subscription auth is active/i,
-	/Anthropic subscription auth is active\. Third-party harness usage/i,
-];
-
-interface PiChatContainer {
-	children?: unknown[];
-	addChild?(component: unknown): void;
-	clear?(): void;
-	invalidate?(): void;
-	render?(width: number): string[];
-}
-
-interface FilterablePiChatContainer extends PiChatContainer {
-	[PI_NOISE_FILTER_INSTALLED]?: true;
-}
-
-export interface PiNoiseFilterState {
-	removedNodes: unknown[];
-	skipNextSpacer: boolean;
-}
-
-function envFlagEnabled(value: string | undefined, defaultValue: boolean): boolean {
-	if (value === undefined) return defaultValue;
-	return !FALSE_ENV_VALUES.has(value.trim().toLowerCase());
-}
-
-function stripAnsi(text: string): string {
-	return text.replace(ANSI_PATTERN, "");
-}
-
-function getTextComponentContent(component: unknown): string | undefined {
-	if (typeof component !== "object" || component === null || !("text" in component)) return undefined;
-	const text = (component as { text?: unknown }).text;
-	return typeof text === "string" ? text : undefined;
-}
-
-function isSpacerComponent(component: unknown): boolean {
-	if (typeof component !== "object" || component === null) return false;
-	return component.constructor?.name === "Spacer";
-}
-
-export function shouldHidePiNoise(env: NodeJS.ProcessEnv = process.env): boolean {
-	return envFlagEnabled(env.SUMO_TUI_HIDE_PI_NOISE, true);
-}
-
-export function shouldForceHardwareCursor(env: NodeJS.ProcessEnv = process.env): boolean {
-	return envFlagEnabled(env.SUMO_TUI_SHOW_HARDWARE_CURSOR, true);
-}
-
-export function isPiNoiseTextComponent(component: unknown): boolean {
-	const text = getTextComponentContent(component);
-	if (text === undefined) return false;
-	const plain = stripAnsi(text);
-	return PI_NOISE_TEXT_PATTERNS.some((pattern) => pattern.test(plain));
-}
-
-function getUpstreamChatContainer(upstream: unknown): PiChatContainer | undefined {
-	if (typeof upstream !== "object" || upstream === null || !("chatContainer" in upstream)) return undefined;
-	const chatContainer = (upstream as { chatContainer?: unknown }).chatContainer;
-	return typeof chatContainer === "object" && chatContainer !== null ? (chatContainer as PiChatContainer) : undefined;
-}
-
-export function filterPiNoiseChildren(container: PiChatContainer, state: PiNoiseFilterState = { removedNodes: [], skipNextSpacer: false }): number {
-	if (!Array.isArray(container.children)) return 0;
-	const nextChildren: unknown[] = [];
-	let removed = 0;
-	let skipNextSpacer = state.skipNextSpacer;
-	for (const child of container.children) {
-		if (isPiNoiseTextComponent(child)) {
-			state.removedNodes.push(child);
-			removed += 1;
-			skipNextSpacer = true;
-			continue;
-		}
-		if (skipNextSpacer && isSpacerComponent(child)) {
-			state.removedNodes.push(child);
-			removed += 1;
-			skipNextSpacer = false;
-			continue;
-		}
-		skipNextSpacer = false;
-		nextChildren.push(child);
-	}
-	container.children = nextChildren;
-	state.skipNextSpacer = skipNextSpacer;
-	return removed;
-}
-
-export function installPiNoiseFilter(upstream: unknown, state: PiNoiseFilterState = { removedNodes: [], skipNextSpacer: false }): boolean {
-	const container = getUpstreamChatContainer(upstream) as FilterablePiChatContainer | undefined;
-	if (!container?.addChild || container[PI_NOISE_FILTER_INSTALLED]) return false;
-	const originalAddChild = container.addChild.bind(container);
-	container.addChild = (component: unknown): void => {
-		if (isPiNoiseTextComponent(component)) {
-			state.removedNodes.push(component);
-			state.skipNextSpacer = true;
-			debugLog("suppressed Pi startup noise from chatContainer");
-			return;
-		}
-		if (state.skipNextSpacer && isSpacerComponent(component)) {
-			state.removedNodes.push(component);
-			state.skipNextSpacer = false;
-			return;
-		}
-		state.skipNextSpacer = false;
-		originalAddChild(component);
-	};
-	container[PI_NOISE_FILTER_INSTALLED] = true;
-	return true;
-}
-
-export function forceHardwareCursorVisible(upstream: unknown): boolean {
-	if (typeof upstream !== "object" || upstream === null || !("ui" in upstream)) return false;
-	const ui = (upstream as { ui?: unknown }).ui;
-	if (typeof ui !== "object" || ui === null || !("setShowHardwareCursor" in ui)) return false;
-	const setShowHardwareCursor = (ui as { setShowHardwareCursor?: unknown }).setShowHardwareCursor;
-	if (typeof setShowHardwareCursor !== "function") return false;
-	setShowHardwareCursor.call(ui, true);
-	return true;
 }
 
 /**

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -453,6 +453,22 @@ export class SumoInteractiveRuntime {
 		return [...lines];
 	}
 
+	public writeChatViewport(top: number, left: number, width: number, height: number): boolean {
+		if (!this.output.isTTY) return false;
+		this.invalidateFrameCache();
+		const safeTop = Math.max(0, Math.floor(top));
+		const safeLeft = Math.max(0, Math.floor(left));
+		const lines = this.renderChatLines(width, height);
+		if (lines.length === 0) return false;
+		let output = "\x1b[?2026h\x1b7";
+		for (let row = 0; row < lines.length; row += 1) {
+			output += `\x1b[${safeTop + row + 1};${safeLeft + 1}H${lines[row] ?? ""}`;
+		}
+		output += "\x1b8\x1b[?2026l";
+		this.output.write(output);
+		return true;
+	}
+
 	public stop(): void {
 		if (!this.started) return;
 		if (this.resizeHandler) process.stdout.off("resize", this.resizeHandler);
@@ -679,7 +695,7 @@ class UpstreamChatPagerBridge {
 
 		const keyEvent = keyFromInput(nextData);
 		if (keyEvent && this.chat.handleKey(keyEvent)) {
-			this.requestRender();
+			this.renderChatViewportOrRequest();
 			return { consume: true };
 		}
 
@@ -765,8 +781,14 @@ class UpstreamChatPagerBridge {
 		};
 		if (localEvent.row < 0 || localEvent.row >= this.lastChatHeight || localEvent.col < 0 || localEvent.col >= this.lastChatWidth) return false;
 		const handled = this.chat.handleMouseEvent(localEvent);
-		if (handled) this.requestRender();
+		if (handled) this.renderChatViewportOrRequest();
 		return handled;
+	}
+
+	private renderChatViewportOrRequest(): void {
+		if (!this.runtime.writeChatViewport(this.lastChatTop, 0, this.lastChatWidth, this.lastChatHeight)) {
+			this.requestRender();
+		}
 	}
 
 	private computeChatTop(width: number): number {

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -42,8 +42,8 @@ import { FrameScheduler } from "../runtime/frame-scheduler.js";
 import { TerminalController } from "../runtime/terminal-controller.js";
 import { ChatPager } from "../widgets/chat-pager.js";
 import { SIDEBAR_MIN_TERMINAL_WIDTH } from "../../sidebar.js";
-import { ChatViewportController } from "./chat-viewport-controller.js";
-export { textFromAgentMessage } from "./chat-viewport-controller.js";
+import { installChatViewportBridge } from "./chat-viewport-controller.js";
+export { installChatPagerBridge, textFromAgentMessage } from "./chat-viewport-controller.js";
 import { SumoExtensionUIAdapter, type SumoExtensionUIAdapterOptions } from "./extension-ui-adapter.js";
 import { createForeignAwareUIContext, type ForeignAwareUIOptions } from "./foreign-extension-warning.js";
 
@@ -81,7 +81,6 @@ function debugLog(message: string): void {
 const ANSI_PATTERN = /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\)|_[^\x07]*(?:\x07|\x1b\\))/g;
 const FALSE_ENV_VALUES = new Set(["0", "false", "no", "off"]);
 const PI_NOISE_FILTER_INSTALLED = Symbol("sumo-tui.pi-noise-filter-installed");
-const CHAT_PAGER_BRIDGE_INSTALLED = Symbol("sumo-tui.chat-pager-bridge-installed");
 
 export const PI_NOISE_TEXT_PATTERNS: readonly RegExp[] = [
 	/\[Extension issues\]/i,
@@ -95,31 +94,6 @@ interface PiChatContainer {
 	clear?(): void;
 	invalidate?(): void;
 	render?(width: number): string[];
-}
-
-interface PiRenderableComponent {
-	render(width: number): string[];
-}
-
-interface PiTuiLike {
-	readonly terminal?: { readonly rows?: number; readonly columns?: number };
-	children?: unknown[];
-	requestRender?(force?: boolean): void;
-	addInputListener?(listener: (data: string) => { consume?: boolean; data?: string } | void): () => void;
-}
-
-interface UpstreamInteractiveLike {
-	ui?: PiTuiLike;
-	chatContainer?: PiChatContainer;
-	headerContainer?: PiRenderableComponent;
-	pendingMessagesContainer?: PiRenderableComponent;
-	statusContainer?: PiRenderableComponent;
-	widgetContainerAbove?: PiRenderableComponent;
-	widgetContainerBelow?: PiRenderableComponent;
-	editorContainer?: PiRenderableComponent;
-	footer?: PiRenderableComponent;
-	handleEvent?(event: unknown): unknown;
-	renderSessionContext?(sessionContext: unknown, options?: unknown): unknown;
 }
 
 interface FilterablePiChatContainer extends PiChatContainer {
@@ -482,74 +456,6 @@ export class SumoInteractiveRuntime {
 	}
 }
 
-interface BridgeInstalledUpstream extends UpstreamInteractiveLike {
-	[CHAT_PAGER_BRIDGE_INSTALLED]?: () => void;
-}
-
-export function installChatPagerBridge(upstream: unknown, runtime: SumoInteractiveRuntime): (() => void) | undefined {
-	const target = upstream as BridgeInstalledUpstream;
-	if (target[CHAT_PAGER_BRIDGE_INSTALLED]) return undefined;
-	const snapshot = runtime.getSnapshot();
-	if (!snapshot || !target.chatContainer) return undefined;
-	const bridge = new ChatViewportController(runtime, snapshot.chat, target);
-	const chatContainer = target.chatContainer;
-	const originalRender = chatContainer.render?.bind(chatContainer);
-	const originalClear = chatContainer.clear?.bind(chatContainer);
-	const originalInvalidate = chatContainer.invalidate?.bind(chatContainer);
-	const originalHandleEvent = target.handleEvent?.bind(target);
-	const originalRenderSessionContext = target.renderSessionContext?.bind(target);
-	const removeInputListener = target.ui?.addInputListener?.((data) => bridge.handleInput(data));
-
-	runtime.setExternalRenderControls({
-		// Pi's normal differential renderer optimizes line shifts with terminal
-		// scroll sequences. In SumoCode's hybrid shell, chat scroll changes only
-		// the left content while the sidebar/footer remain fixed; terminal scroll
-		// sequences move the whole screen and leave stale sidebar/chat fragments.
-		// Force Pi's full redraw path for retained chat updates until Sumo owns the
-		// entire root renderer.
-		scheduleRender: () => target.ui?.requestRender?.(true),
-		setStreamingMode: () => target.ui?.requestRender?.(true),
-	});
-	chatContainer.render = (width: number): string[] => bridge.render(width);
-	chatContainer.clear = (): void => {
-		bridge.clear();
-		originalClear?.();
-	};
-	chatContainer.invalidate = (): void => {
-		originalInvalidate?.();
-		runtime.requestRender();
-	};
-	if (originalHandleEvent) {
-		target.handleEvent = async (event: unknown): Promise<unknown> => {
-			bridge.handleAgentEvent(event);
-			return originalHandleEvent(event);
-		};
-	}
-	if (originalRenderSessionContext) {
-		target.renderSessionContext = (sessionContext: unknown, options?: unknown): unknown => {
-			bridge.renderSessionContext(sessionContext);
-			return originalRenderSessionContext(sessionContext, options);
-		};
-	}
-
-	const cleanup = (): void => {
-		removeInputListener?.();
-		runtime.setExternalRenderControls(undefined);
-		if (originalRender) chatContainer.render = originalRender;
-		else delete chatContainer.render;
-		if (originalClear) chatContainer.clear = originalClear;
-		else delete chatContainer.clear;
-		if (originalInvalidate) chatContainer.invalidate = originalInvalidate;
-		else delete chatContainer.invalidate;
-		if (originalHandleEvent) target.handleEvent = originalHandleEvent;
-		if (originalRenderSessionContext) target.renderSessionContext = originalRenderSessionContext;
-		delete target[CHAT_PAGER_BRIDGE_INSTALLED];
-	};
-	target[CHAT_PAGER_BRIDGE_INSTALLED] = cleanup;
-	debugLog("wired upstream Pi chatContainer through ChatPager");
-	return cleanup;
-}
-
 /**
  * Small Phase 4 fork boundary for Pi 0.70.x.
  *
@@ -633,7 +539,7 @@ export class SumoInteractiveMode {
 
 	private configureUpstreamBeforeInit(upstream: InteractiveMode): void {
 		if (shouldHidePiNoise()) installPiNoiseFilter(upstream, this.piNoiseFilterState);
-		if (!this.chatPagerBridgeCleanup) this.chatPagerBridgeCleanup = installChatPagerBridge(upstream, this.retainedRuntime);
+		if (!this.chatPagerBridgeCleanup) this.chatPagerBridgeCleanup = installChatViewportBridge(upstream, this.retainedRuntime);
 		if (shouldForceHardwareCursor()) forceHardwareCursorVisible(upstream);
 	}
 

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -43,6 +43,7 @@ import { TerminalController } from "../runtime/terminal-controller.js";
 import { ChatPager } from "../widgets/chat-pager.js";
 import { SIDEBAR_MIN_TERMINAL_WIDTH } from "../../sidebar.js";
 import { installChatViewportBridge } from "./chat-viewport-controller.js";
+import { RetainedShellTransition } from "./retained-shell-transition.js";
 import { SumoExtensionUIAdapter, type SumoExtensionUIAdapterOptions } from "./extension-ui-adapter.js";
 import { createForeignAwareUIContext, type ForeignAwareUIOptions } from "./foreign-extension-warning.js";
 
@@ -222,6 +223,7 @@ export class SumoInteractiveRuntime {
 	private chat: ChatPager | undefined;
 	private splash: SplashTree | undefined;
 	private emptyChatQuote: EmptyChatQuoteNode | undefined;
+	private shellTransition: RetainedShellTransition | undefined;
 	private scheduler: FrameScheduler | undefined;
 	private previousFrame: CellBuffer | undefined;
 	private resizeHandler: (() => void) | undefined;
@@ -256,6 +258,7 @@ export class SumoInteractiveRuntime {
 		});
 		this.splash = createSplashTree(this.yoga, undefined, () => defaultSplashSnapshot(this.chat?.hasMessages() ?? false));
 		this.emptyChatQuote = new EmptyChatQuoteNode(this.yoga.Node.create(), () => this.emptyChatQuoteSnapshot());
+		this.shellTransition = new RetainedShellTransition({ root: this.root, chat: this.chat, splash: this.splash, emptyChatQuote: this.emptyChatQuote });
 		this.syncChatSlot();
 		// Retained SumoInteractiveMode owns the application terminal contract.
 		// The extension lifecycle shim also enters altscreen when loaded, but the
@@ -324,6 +327,7 @@ export class SumoInteractiveRuntime {
 		this.chat = undefined;
 		this.splash = undefined;
 		this.emptyChatQuote = undefined;
+		this.shellTransition = undefined;
 		this.root = undefined;
 		this.yoga = undefined;
 		this.resizeHandler = undefined;
@@ -360,25 +364,7 @@ export class SumoInteractiveRuntime {
 	}
 
 	private syncChatSlot(): void {
-		if (!this.root || !this.chat || !this.splash) return;
-		const hasMessages = this.chat.hasMessages();
-		this.splash.syncVisibility();
-		// Per UX_SPEC §0: "no messages → splash (cat + SUMOCODE wordmark + quote,
-		// full width); first message / /resume → cathedral active state". The
-		// empty-chat-quote (§4.4) was a misinterpretation that contradicted §0 —
-		// it stole the splash slot whenever sidebar was visible + no messages,
-		// causing the splash to flash for one frame at boot then disappear. We
-		// keep the EmptyChatQuoteNode allocated for v2 work but never mount it.
-		if (this.emptyChatQuote && this.emptyChatQuote.parent === this.root) {
-			this.root.removeChild(this.emptyChatQuote);
-		}
-		if (hasMessages) {
-			if (this.splash.root.parent === this.root) this.root.removeChild(this.splash.root);
-			if (this.chat.parent !== this.root) this.root.addChild(this.chat);
-			return;
-		}
-		if (this.chat.parent === this.root) this.root.removeChild(this.chat);
-		if (this.splash.root.parent !== this.root) this.root.addChild(this.splash.root);
+		this.shellTransition?.sync();
 	}
 
 	private emptyChatQuoteSnapshot(): EmptyChatQuoteSnapshot {

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -30,9 +30,6 @@
 import type { AgentSessionRuntime, InteractiveModeOptions } from "@mariozechner/pi-coding-agent";
 import { InteractiveMode } from "@mariozechner/pi-coding-agent";
 import type { ExtensionUIContext } from "@mariozechner/pi-coding-agent";
-import { matchesKey } from "@mariozechner/pi-tui";
-import type { KeyEvent } from "../input/key-router.js";
-import { parseSgrMouseStream, type MouseEvent } from "../input/mouse.js";
 import { EmptyChatQuoteNode, shouldRenderEmptyChatQuote, type EmptyChatQuoteSnapshot } from "../cathedral/empty-chat-quote.js";
 import { createSplashTree, defaultSplashSnapshot, type SplashTree } from "../cathedral/splash-tree.js";
 import { SumoNode } from "../layout/node.js";
@@ -42,10 +39,11 @@ import { CellBuffer } from "../render/buffer.js";
 import { composite, type HardwareCursor } from "../render/compositor.js";
 import { diffFrames, type FrameDiffPatch } from "../render/diff.js";
 import { FrameScheduler } from "../runtime/frame-scheduler.js";
-import { logDiagnostic } from "../runtime/diagnostics.js";
 import { TerminalController } from "../runtime/terminal-controller.js";
 import { ChatPager } from "../widgets/chat-pager.js";
-import { SIDEBAR_MIN_TERMINAL_WIDTH, SIDEBAR_WIDTH } from "../../sidebar.js";
+import { SIDEBAR_MIN_TERMINAL_WIDTH } from "../../sidebar.js";
+import { ChatViewportController } from "./chat-viewport-controller.js";
+export { textFromAgentMessage } from "./chat-viewport-controller.js";
 import { SumoExtensionUIAdapter, type SumoExtensionUIAdapterOptions } from "./extension-ui-adapter.js";
 import { createForeignAwareUIContext, type ForeignAwareUIOptions } from "./foreign-extension-warning.js";
 
@@ -80,53 +78,10 @@ function debugLog(message: string): void {
 	console.error(`[sumo-tui] ${message}`);
 }
 
-interface MouseInputDiagnosticsFields {
-	readonly dataLength: number;
-	readonly sourceLength: number;
-	readonly eventCount: number;
-	readonly consumed: boolean;
-	readonly pendingLength: number;
-	readonly leftoverLength: number;
-	readonly sourceHex: string;
-	readonly leftoverHex: string;
-}
-
-function toHex(value: string): string {
-	let hex = "";
-	for (let index = 0; index < value.length; index += 1) {
-		hex += value.charCodeAt(index).toString(16).padStart(2, "0");
-	}
-	return hex;
-}
-
-function diagnoseMouseInput(fields: MouseInputDiagnosticsFields): void {
-	logDiagnostic("sumo_mouse_input", {
-		data_length: fields.dataLength,
-		source_length: fields.sourceLength,
-		events: fields.eventCount,
-		consumed: fields.consumed,
-		pending_length: fields.pendingLength,
-		leftover_length: fields.leftoverLength,
-		source_hex: fields.sourceHex,
-		leftover_hex: fields.leftoverHex,
-	});
-}
-
 const ANSI_PATTERN = /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\)|_[^\x07]*(?:\x07|\x1b\\))/g;
 const FALSE_ENV_VALUES = new Set(["0", "false", "no", "off"]);
 const PI_NOISE_FILTER_INSTALLED = Symbol("sumo-tui.pi-noise-filter-installed");
 const CHAT_PAGER_BRIDGE_INSTALLED = Symbol("sumo-tui.chat-pager-bridge-installed");
-const COMPLETE_SGR_MOUSE_SEQUENCE = /\x1b\[<\d+;\d+;\d+[Mm]/g;
-/**
- * Match a trailing prefix of an SGR mouse sequence so we can buffer partial
- * input across stdin chunks. Matches any of:
- *
- *   ESC, ESC [, ESC [ <, ESC [ < digits, ESC [ < digits ; digits ...
- *
- * The terminating M / m is intentionally absent — that's what makes it a
- * prefix. Anchored to end-of-string only.
- */
-const SGR_MOUSE_PREFIX_TAIL_PATTERN = /(?:\x1b(?:\[(?:<\d*(?:;\d*){0,2})?)?)$/;
 
 export const PI_NOISE_TEXT_PATTERNS: readonly RegExp[] = [
 	/\[Extension issues\]/i,
@@ -274,84 +229,6 @@ export function forceHardwareCursorVisible(upstream: unknown): boolean {
 	if (typeof setShowHardwareCursor !== "function") return false;
 	setShowHardwareCursor.call(ui, true);
 	return true;
-}
-
-function asRecord(value: unknown): Record<string, unknown> | undefined {
-	return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
-}
-
-function textFromContent(content: unknown): string {
-	if (typeof content === "string") return content;
-	if (!Array.isArray(content)) return "";
-	return content
-		.map((part) => {
-			const record = asRecord(part);
-			if (!record || record.type !== "text") return undefined;
-			return typeof record.text === "string" ? record.text : undefined;
-		})
-		.filter((part): part is string => typeof part === "string")
-		.join("");
-}
-
-export function textFromAgentMessage(message: unknown): string {
-	const record = asRecord(message);
-	if (!record) return "";
-	if (record.role === "bashExecution") {
-		const command = typeof record.command === "string" ? record.command : "bash";
-		const output = typeof record.output === "string" ? record.output : "";
-		return output ? `$ ${command}\n${output}` : `$ ${command}`;
-	}
-	const text = textFromContent(record.content);
-	if (text.length > 0) return text;
-	return typeof record.errorMessage === "string" ? record.errorMessage : "";
-}
-
-function chatRoleFromAgentMessage(message: unknown): string {
-	const role = asRecord(message)?.role;
-	if (role === "assistant") return "sumo";
-	if (role === "toolResult" || role === "bashExecution") return "tool";
-	if (typeof role === "string") return role;
-	return "system";
-}
-
-function keyFromInput(data: string): KeyEvent | undefined {
-	switch (data) {
-		case "\x1b[5~":
-			return { key: "PageUp", sequence: data };
-		case "\x1b[6~":
-			return { key: "PageDown", sequence: data };
-		case "\x1b[H":
-		case "\x1b[1~":
-			return { key: "Home", sequence: data };
-		case "\x1b[F":
-		case "\x1b[4~":
-			return { key: "End", sequence: data };
-		default:
-			if (matchesKey(data, "shift+down")) return { key: "End", sequence: data };
-			return undefined;
-	}
-}
-
-function renderableLineCount(component: PiRenderableComponent | undefined, width: number): number {
-	if (!component) return 0;
-	try {
-		return component.render(width).length;
-	} catch {
-		return 0;
-	}
-}
-
-function sessionMessages(sessionContext: unknown): unknown[] {
-	const messages = asRecord(sessionContext)?.messages;
-	return Array.isArray(messages) ? messages : [];
-}
-
-function isUserMessage(message: unknown): boolean {
-	return asRecord(message)?.role === "user";
-}
-
-function countUserMessages(messages: readonly unknown[]): number {
-	return messages.filter(isUserMessage).length;
 }
 
 /**
@@ -605,217 +482,6 @@ export class SumoInteractiveRuntime {
 	}
 }
 
-class UpstreamChatPagerBridge {
-	private lastAssistantText = "";
-	private lastChatTop = 0;
-	private lastChatWidth = 1;
-	private lastChatHeight = 1;
-	private pendingMouseInput = "";
-
-	public constructor(
-		private readonly runtime: SumoInteractiveRuntime,
-		private readonly chat: ChatPager,
-		private readonly upstream: UpstreamInteractiveLike,
-	) {}
-
-	public render(width: number): string[] {
-		// Pi's chatContainer is allocated the full terminal width by Pi's TUI.
-		// But Pi separately mounts our installSidebar() widget at the right 49
-		// cols (when the session has messages and terminal width >= 120). If we
-		// composite the chat tree at full width, our chat content paints into the
-		// cols Pi will overpaint with the sidebar — visually that's chat text
-		// running INTO the sidebar boundary before being clobbered.
-		// Fix: narrow our composite to (terminal - SIDEBAR_WIDTH) when the same
-		// predicate Pi uses for showing the sidebar is true. The sidebar's own
-		// 49 cols on the right come from Pi's separate widget paint.
-		const terminalWidth = Math.max(1, Math.floor(width));
-		const sidebarVisible =
-			terminalWidth >= SIDEBAR_MIN_TERMINAL_WIDTH && this.chat.hasMessages();
-		const effectiveWidth = sidebarVisible ? Math.max(1, terminalWidth - SIDEBAR_WIDTH) : terminalWidth;
-		this.lastChatWidth = effectiveWidth;
-		this.lastChatTop = this.computeChatTop(this.lastChatWidth);
-		this.lastChatHeight = this.computeChatHeight(this.lastChatWidth);
-		return this.runtime.renderChatLines(this.lastChatWidth, this.lastChatHeight);
-	}
-
-	public clear(): void {
-		this.chat.clearMessages();
-		this.lastAssistantText = "";
-		this.pendingMouseInput = "";
-		this.runtime.setEmptyChatQuoteState({ active: false, userMessageCount: 0 });
-	}
-
-	public handleInput(data: string): { consume?: boolean; data?: string } | void {
-		const source = this.pendingMouseInput + data;
-		this.pendingMouseInput = "";
-		let nextData = source;
-		let consumed = false;
-
-		if (source.includes("\x1b")) {
-			const parsed = parseSgrMouseStream(source);
-			for (const event of parsed.events) {
-				this.handleMouse(event);
-			}
-
-			// Strip every complete SGR mouse sequence — including wheel-left/right
-			// (button codes 66/67) and any other variants the parser may not
-			// recognize. Anything matching `\x1b[<\d+;\d+;\d+[Mm]` is mouse input
-			// and must never reach Pi's editor as visible text.
-			const beforeCompleteStrip = nextData;
-			nextData = nextData.replace(COMPLETE_SGR_MOUSE_SEQUENCE, "");
-			if (nextData !== beforeCompleteStrip) consumed = true;
-
-			// Buffer trailing partial mouse sequences across chunks.
-			const tailMatch = nextData.match(SGR_MOUSE_PREFIX_TAIL_PATTERN);
-			if (tailMatch && tailMatch[0].length > 0) {
-				this.pendingMouseInput = tailMatch[0];
-				nextData = nextData.slice(0, nextData.length - tailMatch[0].length);
-				consumed = true;
-			}
-
-			// Anything else starting with `\x1b[<` is a corrupt/stale mouse
-			// fragment. Drop it instead of forwarding raw bytes to Pi's editor.
-			if (nextData.includes("\x1b[<")) {
-				const stripped = nextData.replace(/\x1b\[<[\d;]*[Mm]?/g, "");
-				if (stripped !== nextData) {
-					nextData = stripped;
-					consumed = true;
-				}
-			}
-
-			diagnoseMouseInput({
-				dataLength: data.length,
-				sourceLength: source.length,
-				eventCount: parsed.events.length,
-				consumed,
-				pendingLength: this.pendingMouseInput.length,
-				leftoverLength: nextData.length,
-				sourceHex: toHex(source.slice(0, 64)),
-				leftoverHex: toHex(nextData.slice(0, 64)),
-			});
-		}
-
-		const keyEvent = keyFromInput(nextData);
-		if (keyEvent && this.chat.handleKey(keyEvent)) {
-			this.renderChatViewportOrRequest();
-			return { consume: true };
-		}
-
-		if (nextData.length === 0 && consumed) return { consume: true };
-		if (nextData !== data) return { data: nextData };
-		return undefined;
-	}
-
-	public handleAgentEvent(event: unknown): void {
-		const record = asRecord(event);
-		if (!record || typeof record.type !== "string") return;
-		const message = record.message;
-		switch (record.type) {
-			case "message_start":
-				this.handleMessageStart(message);
-				break;
-			case "message_update":
-				this.handleMessageUpdate(message, record.assistantMessageEvent);
-				break;
-			case "message_end":
-				this.handleMessageEnd(message);
-				break;
-			case "agent_end":
-				this.chat.endStreaming();
-				break;
-		}
-	}
-
-	public renderSessionContext(sessionContext: unknown): void {
-		this.clear();
-		const messages = sessionMessages(sessionContext);
-		this.runtime.setEmptyChatQuoteState({ active: messages.length === 0, userMessageCount: countUserMessages(messages) });
-		for (const message of messages) {
-			const text = textFromAgentMessage(message);
-			if (text.length === 0) continue;
-			this.chat.addMessage(chatRoleFromAgentMessage(message), text);
-		}
-	}
-
-	private handleMessageStart(message: unknown): void {
-		const role = asRecord(message)?.role;
-		if (role === "user") this.runtime.noteUserMessage();
-		if (role === "assistant") {
-			this.lastAssistantText = "";
-			this.chat.addMessage("sumo", "");
-			return;
-		}
-		const text = textFromAgentMessage(message);
-		if (text.length === 0) return;
-		this.chat.addMessage(chatRoleFromAgentMessage(message), text);
-	}
-
-	private handleMessageUpdate(message: unknown, assistantMessageEvent: unknown): void {
-		if (asRecord(message)?.role !== "assistant") return;
-		const streamEvent = asRecord(assistantMessageEvent);
-		if (streamEvent?.type === "text_delta" && typeof streamEvent.delta === "string") {
-			this.chat.appendToLast(streamEvent.delta);
-			this.lastAssistantText += streamEvent.delta;
-			return;
-		}
-		const text = textFromAgentMessage(message);
-		if (text.length === 0 || text === this.lastAssistantText) return;
-		this.chat.replaceLast(text);
-		this.lastAssistantText = text;
-	}
-
-	private handleMessageEnd(message: unknown): void {
-		if (asRecord(message)?.role === "assistant") {
-			const text = textFromAgentMessage(message);
-			if (text.length > 0 && text !== this.lastAssistantText) {
-				this.chat.replaceLast(text);
-				this.lastAssistantText = text;
-			}
-			this.chat.endStreaming();
-		}
-	}
-
-	private handleMouse(event: MouseEvent): boolean {
-		const localEvent: MouseEvent = {
-			...event,
-			row: event.row - this.lastChatTop,
-			col: event.col,
-		};
-		if (localEvent.row < 0 || localEvent.row >= this.lastChatHeight || localEvent.col < 0 || localEvent.col >= this.lastChatWidth) return false;
-		const handled = this.chat.handleMouseEvent(localEvent);
-		if (handled) this.renderChatViewportOrRequest();
-		return handled;
-	}
-
-	private renderChatViewportOrRequest(): void {
-		if (!this.runtime.writeChatViewport(this.lastChatTop, 0, this.lastChatWidth, this.lastChatHeight)) {
-			this.requestRender();
-		}
-	}
-
-	private computeChatTop(width: number): number {
-		return renderableLineCount(this.upstream.headerContainer, width);
-	}
-
-	private computeChatHeight(width: number): number {
-		const terminalRows = Math.max(1, this.upstream.ui?.terminal?.rows ?? 24);
-		const terminalWidth = Math.max(1, this.upstream.ui?.terminal?.columns ?? width);
-		const chromeRows =
-			renderableLineCount(this.upstream.headerContainer, width) +
-			renderableLineCount(this.upstream.pendingMessagesContainer, width) +
-			renderableLineCount(this.upstream.statusContainer, width) +
-			renderableLineCount(this.upstream.widgetContainerAbove, terminalWidth) +
-			renderableLineCount(this.upstream.editorContainer, terminalWidth) +
-			renderableLineCount(this.upstream.widgetContainerBelow, terminalWidth) +
-			renderableLineCount(this.upstream.footer, terminalWidth);
-		return Math.max(1, terminalRows - chromeRows);
-	}
-
-	private requestRender(): void {
-		this.runtime.requestRender();
-	}
-}
-
 interface BridgeInstalledUpstream extends UpstreamInteractiveLike {
 	[CHAT_PAGER_BRIDGE_INSTALLED]?: () => void;
 }
@@ -825,7 +491,7 @@ export function installChatPagerBridge(upstream: unknown, runtime: SumoInteracti
 	if (target[CHAT_PAGER_BRIDGE_INSTALLED]) return undefined;
 	const snapshot = runtime.getSnapshot();
 	if (!snapshot || !target.chatContainer) return undefined;
-	const bridge = new UpstreamChatPagerBridge(runtime, snapshot.chat, target);
+	const bridge = new ChatViewportController(runtime, snapshot.chat, target);
 	const chatContainer = target.chatContainer;
 	const originalRender = chatContainer.render?.bind(chatContainer);
 	const originalClear = chatContainer.clear?.bind(chatContainer);

--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -23,6 +23,15 @@ function outputStub(isTTY = true): TerminalOutput & { writes: string[] } {
 }
 
 describe("TerminalController", () => {
+	it("startRetainedSession owns altscreen and mouse mode startup", () => {
+		const output = outputStub();
+		const controller = new TerminalController({ output });
+
+		controller.startRetainedSession();
+
+		expect(output.writes).toEqual([`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}${CURSOR_COLOR_SET}`, MOUSE_SGR_ENABLE_SEQUENCE]);
+	});
+
 	it("enterAltscreen emits altscreen bytes followed by cathedral cursor color", () => {
 		const output = outputStub();
 		const controller = new TerminalController({ output });
@@ -41,6 +50,24 @@ describe("TerminalController", () => {
 
 		expect(output.writes).toEqual([MOUSE_SGR_ENABLE_SEQUENCE]);
 		expect(output.writes[0]).toBe("\x1b[?1000h\x1b[?1006h");
+	});
+
+	it("writes absolute chat viewport rows behind the terminal ownership seam", () => {
+		const output = outputStub();
+		const controller = new TerminalController({ output });
+
+		expect(controller.writeChatViewport(2, 3, ["one", "two"])).toBe(true);
+
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b7\x1b[3;4Hone\x1b[4;4Htwo\x1b8\x1b[?2026l"]);
+	});
+
+	it("writes full-frame patches and hardware cursor behind the terminal ownership seam", () => {
+		const output = outputStub();
+		const controller = new TerminalController({ output });
+
+		controller.writeFramePatches([{ row: 1, ansi: "hello" }], { row: 2, col: 4 });
+
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b[2;1Hhello\x1b[K\x1b[3;5H\x1b[?25h\x1b[?2026l"]);
 	});
 
 	it("exitTerminal resets cursor color before the full cleanup bytes (EC-5.1)", () => {

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -41,6 +41,16 @@ export interface TerminalOutput {
 	write(data: string): unknown;
 }
 
+export interface TerminalCursor {
+	readonly row: number;
+	readonly col: number;
+}
+
+export interface TerminalPatch {
+	readonly row: number;
+	readonly ansi: string;
+}
+
 export interface TerminalControllerOptions {
 	readonly output?: TerminalOutput;
 }
@@ -66,6 +76,11 @@ export class TerminalController {
 		return this.output.isTTY === true;
 	}
 
+	public startRetainedSession(): void {
+		this.enterAltscreen();
+		this.enableMouseSGR();
+	}
+
 	public enterAltscreen(): void {
 		if (!this.isTTY()) return;
 		this.restored = false;
@@ -79,6 +94,30 @@ export class TerminalController {
 		if (!this.isTTY()) return;
 		this.restored = false;
 		this.write(MOUSE_SGR_ENABLE_SEQUENCE);
+	}
+
+	public writeChatViewport(top: number, left: number, lines: readonly string[]): boolean {
+		if (!this.isTTY() || lines.length === 0) return false;
+		const safeTop = Math.max(0, Math.floor(top));
+		const safeLeft = Math.max(0, Math.floor(left));
+		let output = "\x1b[?2026h\x1b7";
+		for (let row = 0; row < lines.length; row += 1) {
+			output += `\x1b[${safeTop + row + 1};${safeLeft + 1}H${lines[row] ?? ""}`;
+		}
+		output += "\x1b8\x1b[?2026l";
+		this.write(output);
+		return true;
+	}
+
+	public writeFramePatches(patches: readonly TerminalPatch[], cursor: TerminalCursor | null): void {
+		if (!this.isTTY() || (patches.length === 0 && !cursor)) return;
+		let output = "\x1b[?2026h";
+		for (const patch of patches) {
+			output += `\x1b[${patch.row + 1};1H${patch.ansi}\x1b[K`;
+		}
+		if (cursor) output += `\x1b[${cursor.row + 1};${cursor.col + 1}H\x1b[?25h`;
+		output += "\x1b[?2026l";
+		this.write(output);
 	}
 
 	/**

--- a/src/sumo-tui/widgets/chat-pager.test.ts
+++ b/src/sumo-tui/widgets/chat-pager.test.ts
@@ -134,7 +134,7 @@ describe("ChatPager", () => {
 		const frame = buffer();
 
 		expect(chat.getUnreadCount()).toBe(1);
-		expect(frame.toPlainRow(4)).toContain("↓ 1 new message — Press End to jump");
+		expect(frame.toPlainRow(4)).toContain("↓ 1 new message — Press ⇧↓ to jump");
 		root.dispose();
 	});
 

--- a/src/sumo-tui/widgets/chat-scroll-command.test.ts
+++ b/src/sumo-tui/widgets/chat-scroll-command.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { chatScrollCommandFromInput, chatScrollCommandFromKey, chatScrollHintLabel } from "./chat-scroll-command.js";
+
+describe("chat scroll commands", () => {
+	it("maps terminal input bytes to scroll key events", () => {
+		expect(chatScrollCommandFromInput("\x1b[5~")?.key).toBe("PageUp");
+		expect(chatScrollCommandFromInput("\x1b[6~")?.key).toBe("PageDown");
+		expect(chatScrollCommandFromInput("\x1b[H")?.key).toBe("Home");
+		expect(chatScrollCommandFromInput("\x1b[F")?.key).toBe("End");
+		expect(chatScrollCommandFromInput("\x1b[b")?.key).toBe("End");
+		expect(chatScrollCommandFromInput("x")).toBeUndefined();
+	});
+
+	it("maps key events to semantic scroll commands", () => {
+		expect(chatScrollCommandFromKey({ key: "PageUp" })).toBe("page-up");
+		expect(chatScrollCommandFromKey({ key: "PgDn" })).toBe("page-down");
+		expect(chatScrollCommandFromKey({ key: "Home" })).toBe("jump-top");
+		expect(chatScrollCommandFromKey({ key: "End" })).toBe("jump-bottom");
+		expect(chatScrollCommandFromKey({ key: "Shift+Down" })).toBe("jump-bottom");
+		expect(chatScrollCommandFromKey({ key: "Down" })).toBeUndefined();
+	});
+
+	it("keeps user-facing command labels next to command definitions", () => {
+		expect(chatScrollHintLabel("jump-bottom")).toBe("⇧↓");
+	});
+});

--- a/src/sumo-tui/widgets/chat-scroll-command.ts
+++ b/src/sumo-tui/widgets/chat-scroll-command.ts
@@ -1,0 +1,46 @@
+import { matchesKey } from "@mariozechner/pi-tui";
+import type { KeyEvent } from "../input/key-router.js";
+
+export type ChatScrollCommand = "page-up" | "page-down" | "jump-top" | "jump-bottom";
+
+export const CHAT_SCROLL_JUMP_BOTTOM_HINT = "⇧↓";
+
+export function chatScrollCommandFromInput(data: string): KeyEvent | undefined {
+	switch (data) {
+		case "\x1b[5~":
+			return { key: "PageUp", sequence: data };
+		case "\x1b[6~":
+			return { key: "PageDown", sequence: data };
+		case "\x1b[H":
+		case "\x1b[1~":
+			return { key: "Home", sequence: data };
+		case "\x1b[F":
+		case "\x1b[4~":
+			return { key: "End", sequence: data };
+		default:
+			if (matchesKey(data, "shift+down")) return { key: "End", sequence: data };
+			return undefined;
+	}
+}
+
+export function chatScrollCommandFromKey(event: KeyEvent): ChatScrollCommand | undefined {
+	const key = event.key.toLowerCase();
+	if (key === "pageup" || key === "pgup") return "page-up";
+	if (key === "pagedown" || key === "pgdn") return "page-down";
+	if (key === "home") return "jump-top";
+	if (key === "end" || key === "shift+down") return "jump-bottom";
+	return undefined;
+}
+
+export function chatScrollHintLabel(command: ChatScrollCommand): string {
+	switch (command) {
+		case "jump-bottom":
+			return CHAT_SCROLL_JUMP_BOTTOM_HINT;
+		case "page-up":
+			return "PgUp";
+		case "page-down":
+			return "PgDn";
+		case "jump-top":
+			return "Home";
+	}
+}

--- a/src/sumo-tui/widgets/scrollbox-input.test.ts
+++ b/src/sumo-tui/widgets/scrollbox-input.test.ts
@@ -55,7 +55,7 @@ describe("ScrollBox input", () => {
 		root.dispose();
 	});
 
-	it("PgUp/PgDn move by half a page, Home/End jump to edges", async () => {
+	it("PgUp/PgDn move by half a page, Home/End/Shift+Down jump to edges", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());
 		const scrollBox = new ScrollBox(yoga.Node.create(), root);
@@ -71,6 +71,10 @@ describe("ScrollBox input", () => {
 		scrollBox.handleKey({ key: "PageUp" });
 		expect(scrollBox.scrollOffset).toBe(4);
 		scrollBox.handleKey({ key: "PageDown" });
+		expect(scrollBox.scrollOffset).toBe(6);
+		scrollBox.handleKey({ key: "Home" });
+		expect(scrollBox.scrollOffset).toBe(0);
+		scrollBox.handleKey({ key: "Shift+Down" });
 		expect(scrollBox.scrollOffset).toBe(6);
 		scrollBox.handleKey({ key: "Home" });
 		expect(scrollBox.scrollOffset).toBe(0);

--- a/src/sumo-tui/widgets/scrollbox.ts
+++ b/src/sumo-tui/widgets/scrollbox.ts
@@ -2,6 +2,7 @@ import { SumoNode } from "../layout/node.js";
 import { FLEX_DIRECTION_COLUMN, POSITION_TYPE_ABSOLUTE, type Yoga, type YogaNode } from "../layout/yoga.js";
 import type { KeyEvent } from "../input/key-router.js";
 import type { MouseEvent } from "../input/mouse.js";
+import { chatScrollCommandFromKey } from "./chat-scroll-command.js";
 import { CellBuffer, type Rect } from "../render/buffer.js";
 import type { HardwareCursor } from "../render/compositor.js";
 
@@ -185,29 +186,28 @@ export class ScrollBox extends SumoNode {
 	}
 
 	public handleKey(event: KeyEvent): boolean {
-		const key = event.key.toLowerCase();
-		if (key === "pageup" || key === "pgup") {
-			// OpenCode pages messages by a viewport fraction (`packages/opencode/src/cli/cmd/tui/routes/session/index.tsx:686-770`).
-			this.scrollBy(-this.halfPage());
-			return true;
+		const command = chatScrollCommandFromKey(event);
+		switch (command) {
+			case "page-up":
+				// OpenCode pages messages by a viewport fraction (`packages/opencode/src/cli/cmd/tui/routes/session/index.tsx:686-770`).
+				this.scrollBy(-this.halfPage());
+				return true;
+			case "page-down":
+				this.scrollBy(this.halfPage());
+				return true;
+			case "jump-top":
+				this.scrollTo(0);
+				return true;
+			case "jump-bottom":
+				this.scrollToBottom();
+				this.manualScroll = false;
+				this.emitStateIfChanged();
+				return true;
+			default:
+				// EC-13.2: drag-selection across messages is intentionally not claimed here;
+				// terminal-native selection requires a later selection model so we let drags bubble.
+				return false;
 		}
-		if (key === "pagedown" || key === "pgdn") {
-			this.scrollBy(this.halfPage());
-			return true;
-		}
-		if (key === "home") {
-			this.scrollTo(0);
-			return true;
-		}
-		if (key === "end" || key === "shift+down") {
-			this.scrollToBottom();
-			this.manualScroll = false;
-			this.emitStateIfChanged();
-			return true;
-		}
-		// EC-13.2: drag-selection across messages is intentionally not claimed here;
-		// terminal-native selection requires a later selection model so we let drags bubble.
-		return false;
 	}
 
 	private halfPage(): number {

--- a/src/sumo-tui/widgets/scrollbox.ts
+++ b/src/sumo-tui/widgets/scrollbox.ts
@@ -199,7 +199,7 @@ export class ScrollBox extends SumoNode {
 			this.scrollTo(0);
 			return true;
 		}
-		if (key === "end") {
+		if (key === "end" || key === "shift+down") {
 			this.scrollToBottom();
 			this.manualScroll = false;
 			this.emitStateIfChanged();

--- a/src/sumo-tui/widgets/scrolled-up-banner.ts
+++ b/src/sumo-tui/widgets/scrolled-up-banner.ts
@@ -47,7 +47,7 @@ export class ScrolledUpBanner extends SumoNode {
 		if (!this.isVisible()) return;
 		const unread = this.getUnreadCount();
 		const noun = unread === 1 ? "message" : "messages";
-		const label = `↓ ${unread} new ${noun} — Press End to jump`;
+		const label = `↓ ${unread} new ${noun} — Press ⇧↓ to jump`;
 		const styled = `\x1b[2m${fg(CATHEDRAL_TOKENS.colors.foregroundDim)}${label}\x1b[0m`;
 		buffer.paintRow(rect.top, styled, rect.left, rect.width);
 	}

--- a/src/sumo-tui/widgets/scrolled-up-banner.ts
+++ b/src/sumo-tui/widgets/scrolled-up-banner.ts
@@ -3,6 +3,7 @@ import { SumoNode } from "../layout/node.js";
 import type { Yoga, YogaNode } from "../layout/yoga.js";
 import type { MouseEvent } from "../input/mouse.js";
 import type { CellBuffer, Rect } from "../render/buffer.js";
+import { chatScrollHintLabel } from "./chat-scroll-command.js";
 
 export interface ScrolledUpBannerOptions {
 	readonly isVisible: () => boolean;
@@ -47,7 +48,7 @@ export class ScrolledUpBanner extends SumoNode {
 		if (!this.isVisible()) return;
 		const unread = this.getUnreadCount();
 		const noun = unread === 1 ? "message" : "messages";
-		const label = `↓ ${unread} new ${noun} — Press ⇧↓ to jump`;
+		const label = `↓ ${unread} new ${noun} — Press ${chatScrollHintLabel("jump-bottom")} to jump`;
 		const styled = `\x1b[2m${fg(CATHEDRAL_TOKENS.colors.foregroundDim)}${label}\x1b[0m`;
 		buffer.paintRow(rect.top, styled, rect.left, rect.width);
 	}

--- a/test/integration/runtime-chat-scroll.test.ts
+++ b/test/integration/runtime-chat-scroll.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
-import { installChatPagerBridge, SumoInteractiveRuntime } from "../../src/sumo-tui/pi-compat/sumo-interactive-mode.js";
+import { SumoInteractiveRuntime } from "../../src/sumo-tui/pi-compat/sumo-interactive-mode.js";
+import { installChatViewportBridge } from "../../src/sumo-tui/pi-compat/chat-viewport-controller.js";
 
 describe("runtime ChatPager scroll bridge", () => {
 	it("moves ChatPager scroll offset after an SGR mouse wheel event", async () => {
@@ -36,7 +37,7 @@ describe("runtime ChatPager scroll bridge", () => {
 			handleEvent: vi.fn(),
 		};
 
-		const cleanup = installChatPagerBridge(upstream, runtime);
+		const cleanup = installChatViewportBridge(upstream, runtime);
 		for (let index = 0; index < 50; index += 1) {
 			await upstream.handleEvent({ type: "message_start", message: { role: "user", content: `fake message ${index}` } });
 		}


### PR DESCRIPTION
## Summary

Draft PR tracking the retained TUI architecture deepening work.

Implemented deepening slices:

1. **Chat viewport Module**
   - Extracted chat viewport behaviour from `SumoInteractiveMode` into `ChatViewportController`.
   - Moved viewport geometry, sidebar-aware width, SGR mouse parsing/buffering, scroll input, Pi message ingestion, session context rendering, and Pi bridge install/cleanup behind one seam.

2. **Terminal ownership Module**
   - Deepened `TerminalController` so retained runtime delegates terminal byte ownership through named methods:
     - `startRetainedSession()`
     - `writeChatViewport(...)`
     - `writeFramePatches(...)`
     - `exitTerminal()`

3. **Chat scroll command Module**
   - Centralised PageUp/PageDown/Home/End/Shift+Down mapping and user-facing jump hint labels in `chat-scroll-command.ts`.

4. **Sidebar placement Module**
   - Extracted sidebar placement adapters into `sidebar-placement.ts`.
   - Keeps the legacy static dock adapter available while making the active non-capturing overlay adapter explicit and testable.

5. **Retained shell transition Module**
   - Extracted the empty-session splash → active-chat state machine into `RetainedShellTransition`.
   - Keeps UX_SPEC §0 splash ownership separate from the Pi compatibility runtime.

6. **Pi interactive adapter Module**
   - Extracted Pi private-shape helpers/noise filtering/hardware cursor forcing into `pi-interactive-adapter.ts`.
   - `SumoInteractiveMode` now delegates these adapter responsibilities instead of owning their implementation.

## Why

Recent retained TUI bugs showed poor locality around:

- chat viewport geometry and repaint strategy
- terminal byte ownership
- scroll command mappings and labels
- sidebar placement vs sidebar content/data
- splash/active shell transitions
- Pi private field access and startup noise filtering

This PR concentrates each behaviour behind a smaller, deeper Module interface.

## Verification

Passed locally:

```sh
pnpm test -- src/sumo-tui/pi-compat/chat-viewport-controller.test.ts src/sumo-tui/pi-compat/pi-interactive-adapter.test.ts src/sumo-tui/pi-compat/retained-shell-transition.test.ts src/sumo-tui/runtime/terminal-controller.test.ts src/sumo-tui/widgets/chat-scroll-command.test.ts src/sidebar-placement.test.ts src/sidebar.test.ts src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts src/sumo-tui/pi-compat/splash-thinking-fix.test.ts
pnpm exec tsc --noEmit
pnpm build
```

Note: an earlier attempted broader integration run invoked unrelated PTY tests that currently fail independently:

- `test/integration/cursor-visibility.test.ts`
- `test/integration/mouse-scroll.test.ts`

Focused refactor tests and required TypeScript/build checks pass.

## Review notes

This branch intentionally keeps backwards-compatible exports where useful for existing callers/tests, but new code imports the deeper Modules directly.
