### PR TITLE
feat(sidebar): align registry with V2

### DIFF
--- a/docs/SUMO_TUI_AUDIT.md
+++ b/docs/SUMO_TUI_AUDIT.md
@@ -1,0 +1,720 @@
+# SumoTUI Audit — 2026-04-29
+
+> Scope: current `sumocode` worktree, `src/sumo-tui/**`, Cathedral runtime/UI code, SumoTUI research docs, V2 visual spec, and a quick survey of other production TUI frameworks.
+>
+> Bottom line: **SumoTUI is the right strategic bet** for the final goal, but the project is currently in a risky middle state: part retained app-shell, part Pi line-renderer surgery. The fastest path to a daily-driver-quality SumoCode is to stop adding surfaces briefly, align spec/tests/runtime, then deepen SumoTUI into a small, composable app-shell kernel with one owner for terminal lifecycle, input, layout, transcript state, and rendering.
+
+---
+
+## 1. What I think about SumoTUI
+
+SumoTUI is justified. This is not aesthetic overengineering.
+
+Pi is excellent as an agent engine: models, tools, sessions, extension loading, editor edge cases, slash commands, auth, MCP. But Pi's default `pi-tui` render model is fundamentally a vertical `Component.render(width): string[]` concatenator. That model will always fight the final SumoCode goal:
+
+- footer pinned to the viewport bottom;
+- app-owned chat scrollback in altscreen;
+- mouse wheel routing that does not mutate prompt history;
+- portrait/landscape adaptive shell;
+- modal focus stack;
+- structured chat/tool/code blocks;
+- SumoCode-specific visual identity that survives long sessions.
+
+The accepted ADR is directionally correct: **keep Pi as runtime/editor/agent utility, and build SumoTUI as the root experience renderer**.
+
+The current danger is not the decision to build SumoTUI. The danger is the **hybrid phase lasting too long**. Today SumoTUI has real primitives — Yoga nodes, cell buffer, diff writer, ScrollBox, ChatPager, lifecycle, mouse parser — but production still depends on private Pi container overrides and Pi full redraws. That means many bugs are now seam bugs: neither renderer has complete authority.
+
+My high-confidence recommendation:
+
+1. **Do not extract SumoTUI as a package yet.** Keep it bundled until SumoCode daily-drives it for at least 30 stable days.
+2. **Do not add more Cathedral surfaces until runtime/spec/tests are aligned.** Right now new work will compound drift.
+3. **Make SumoTUI a real app-shell kernel, not just a retained widget library.** It needs a model/update/render loop, typed styling primitives, a proper focus/input system, a headless test backend, and a clean Pi adapter seam.
+
+---
+
+## 2. Current health snapshot
+
+### Commands run during audit
+
+```bash
+pnpm exec tsc --noEmit
+pnpm test
+pnpm test:integration
+pnpm visual:ci
+```
+
+### Results
+
+| Check | Result | Notes |
+|---|---:|---|
+| `pnpm exec tsc --noEmit` | ✅ pass | TypeScript is clean. |
+| `pnpm build` | ✅ pass | Build script is `tsc --noEmit`. |
+| `pnpm test` | ✅ pass | 68 files / 399 tests passing on current HEAD `6097b23`. |
+| `pnpm test:integration` | ❌ fail | `cursor-visibility.test.ts` times out. 10 files pass, 1 fails; 13 passing / 14 total. |
+| `pnpm visual:ci` | ✅ review-compatible | 7 scenarios rendered. `footer-ready`, `sidebar-editorial`, `active-portrait` passed; `input`, `top-bar`, `splash`, `active-landscape` are still review states. |
+
+### Immediate interpretation
+
+The code is type-safe and unit coverage is green on the current sidebar V2 commit, but the repo is **not fully green** because one PTY integration test still times out. The remaining failure looks like a runtime/integration contract issue rather than TypeScript or pure renderer breakage. `cursor-visibility.test.ts` still deserves triage because V2 explicitly removed active input labels, and cursor correctness is a daily-driver P0.
+
+Before feature work, align the remaining runtime contract and make integration green.
+
+---
+
+## 3. Current strengths
+
+### 3.1 The ADR and research quality are unusually strong
+
+`docs/adr/0001-sumo-tui-framework.md` and `docs/research/sumo-tui-spike/**` are a good decision trail. The project already captured the key architectural lesson from OpenCode/OpenTUI: **altscreen works only if the app owns scrollback**.
+
+The edge-case catalog is also strong. It anticipates cursor remapping, wide chars, streaming races, resize, crash cleanup, images, no-TTY, Yoga leaks, Pi version drift, and mouse routing.
+
+### 3.2 Core primitives exist and are tested
+
+Good foundations already present:
+
+- `TerminalController` for altscreen, SGR mouse, OSC bg, cleanup.
+- `LifecycleRuntime` for signals, raw-mode restore, crash log.
+- `FrameScheduler` with event-driven idle and streaming coalescing.
+- `SumoNode` + Yoga WASM layout.
+- `CellBuffer` + ANSI writer + frame diff.
+- `ScrollBox` + `ChatPager` with sticky-bottom/manual-scroll behavior.
+- `PiEditorLeaf` cursor-marker remapping.
+- `RegionRegistry` and `SumoExtensionUIAdapter` as a retained replacement path for Pi UI hooks.
+- Visual Bible + V2 visual harness.
+
+This is not just a sketch; it is a real beginning of a terminal app framework.
+
+### 3.3 Performance measurements are encouraging
+
+`docs/research/sumo-tui-performance.md` shows:
+
+- retained render p50 ~1.08ms, p95 ~1.41ms;
+- streaming p95 ~9ms;
+- SumoTUI idle RSS delta vs bare Pi ~19 MiB;
+- streaming RSS well under the 300 MiB target.
+
+`docs/research/sumo-tui-cpu-diagnosis.md` shows idle CPU at ~0.30% after the scheduler guard fixes. That is exactly the discipline this project needs.
+
+### 3.4 The visual verification loop is a real differentiator
+
+The V2 visual harness and Bible are worth keeping. Terminal UIs regress in ways unit tests do not see: stray bg cells, line overflow, missing cursor, stale ANSI. The current `pnpm visual:ci` loop is already catching those classes.
+
+---
+
+## 4. Biggest risks and improvement areas
+
+### P0 — The runtime is stuck between two renderers
+
+Evidence:
+
+- `SumoInteractiveRuntime` starts SumoTUI primitives, then delegates the session loop to upstream `InteractiveMode`.
+- `installChatViewportBridge()` overrides `upstream.chatContainer.render`, `clear`, `invalidate`, `handleEvent`, and `renderSessionContext`.
+- Chat updates force `target.ui?.requestRender?.(true)` because Pi's differential scroll can smear SumoTUI's hybrid chat/sidebar layout.
+- Chat geometry is computed by rendering Pi chrome components to count rows.
+
+This is clever and probably necessary as a transitional bridge, but it is fragile. It means:
+
+- Pi still owns root vertical flow.
+- SumoTUI owns chat rows inside that flow.
+- Sidebar is an overlay outside flow.
+- Chat width is manually reduced by sidebar constants.
+- Mouse events are translated through retained chat coordinates into a Pi-rendered shell.
+
+That is not a stable final architecture.
+
+**Recommendation:** define explicit modes and stop blurring them:
+
+1. **Hybrid-safe mode**: Pi owns terminal/editor/chat. No altscreen unless SumoTUI owns scrollback. SumoCode uses header/footer/sidebar overlays only.
+2. **Owned-shell mode**: SumoTUI owns terminal, root layout, chat viewport, footer, sidebar, modals, input routing. Pi provides agent/session/editor utilities through adapters.
+3. **Experimental full-owned mode**: SumoTUI owns everything, including native editor replacement.
+
+Daily-driver work should move to owned-shell mode. Hybrid-safe is fallback only.
+
+---
+
+### P0 — Some runtime contracts still lag the locked V2 spec
+
+The sidebar V2 unit-test drift appears resolved on current HEAD `6097b23`, but several spec/runtime gaps remain:
+
+- V2 spec says active input has **no label**; `cursor-visibility.test.ts` should not rely on obsolete labels and still times out in PTY.
+- V2 spec says command palette has 6 modes including `SETTINGS`; current `PaletteMode` has 5 modes and no `SETTINGS`.
+- V2 spec says cursor color should respect terminal preference; `TerminalController` unconditionally emits OSC 12 cursor color set/reset.
+- V2 spec mentions `src/sumo-tui/render/truecolor.ts`; the code has `truecolor.test.ts` but no such module.
+- V2 spec calls out command palette active-state opening and drill-down behavior as broken; current implementation still writes slash commands/editor text for some selections.
+
+This is still a velocity killer because every new surface must decide whether to follow the code, the tests, or the V2 spec.
+
+**Recommendation:** add a one-time "contract realignment" PR:
+
+1. Mark `docs/ui/CATHEDRAL_UX_SPEC_V2.md` + Bible HTML as the only visual source of truth.
+2. Keep the newly aligned V2 unit tests green; delete/update stale V1 assertions whenever they reappear.
+3. Lock constants to V2: sidebar width 30, thresholds recomputed, terminal dim line dynamic.
+4. Update integration tests to wait for durable runtime markers, not obsolete labels.
+5. Add a `docs/visual/parity/CONTRACT.md` that defines which crops are review-only vs required.
+
+---
+
+### P0 — Terminal lifecycle has too many owners
+
+Current ownership paths:
+
+- `src/extension.ts` calls `installAltscreen(pi)`.
+- `installAltscreen()` calls `installLifecycle(pi)`.
+- `LifecycleRuntime` enters altscreen + mouse on `session_start` and restores on `session_shutdown`.
+- `SumoInteractiveRuntime.start()` also calls `TerminalController.startRetainedSession()` before upstream init.
+- The controllers are different instances.
+
+This duplicate ownership may be benign in many runs because terminal sequences are idempotent-ish, but it increases risk during `/resume`, `SIGTSTP`, `SIGCONT`, uncaught exceptions, and no-session/no-TTY test modes.
+
+Also, V2 says not to override cursor preference, but `TerminalController` emits:
+
+```ts
+export const CURSOR_COLOR_SET = "\x1b]12;#D97706\x1b\\";
+```
+
+**Recommendation:** introduce one `TerminalSessionOwner` singleton with an explicit reference-count or state machine:
+
+```txt
+idle → starting → active → suspending → suspended → active → stopping → stopped
+```
+
+Rules:
+
+- exactly one place enters/leaves altscreen;
+- exactly one place enables/disables mouse;
+- OSC 11 bg paint is feature-flagged (`/sumo:bg paint|none`);
+- OSC 12 cursor color is off by default and only set by explicit `/sumo:cursor`;
+- no-TTY paths are no-op but still testable through a headless backend.
+
+---
+
+### P0 — Portrait support is still unresolved against the final goal
+
+Project context says Mac mini is portrait and MacBook is landscape. PRD earlier wanted bottom/sidebar adaptations for portrait. V2 spec currently says:
+
+- sidebar hidden on splash;
+- sidebar hidden when `W < 120`;
+- otherwise visible as a right pane.
+
+That may be okay if portrait terminals still exceed 120 columns, but portrait often means narrower width and taller height. Hiding the sidebar entirely removes one of SumoCode's core value props: ambient memory/context.
+
+**Recommendation:** decide this explicitly:
+
+- **Option A:** V1 portrait hides sidebar and footer/hint row absorbs context. Simple, less personal.
+- **Option B:** V1 portrait has a bottom registry band. More work, aligns with PRD/final goal.
+- **Option C:** V1 portrait has a command-toggled overlay only. Middle ground.
+
+My vote: **Option B eventually, Option C immediately.** Right now, make portrait overlay reliable and non-capturing; then add bottom band once the owned layout is stable.
+
+---
+
+### P0 — Command and keybinding conflicts are already visible
+
+Examples:
+
+- `src/command-palette.ts` registers `sumo:memory` as a stub.
+- `src/memory-editor.ts` registers `sumo:memory` again with real behavior.
+- V2 says command palette trigger is `Ctrl+/`, active-state opening is broken, and Enter should drill down rather than insert slash text.
+- V2 says `Ctrl+T` thinking-cycle may be intercepted.
+
+**Recommendation:** centralize command/keybind registration:
+
+```ts
+commands/register.ts
+keybindings/register.ts
+```
+
+Add a startup conflict inspector that emits a structured dev warning:
+
+```txt
+keybind conflict: ctrl+/ owned by command-palette, skipped by X
+slash conflict: /sumo:memory registered by command-palette and memory-editor
+```
+
+Borrow from Textual's event/message routing and Bubble Tea's central message loop: key events should flow through one router with priority, focus, modal stack, and trace logging.
+
+---
+
+### P1 — Rendering is too raw-string-heavy
+
+There are repeated ad hoc helpers across files:
+
+- `fg(hex)`, `bg(hex)`, `color(text, hex)`, `visibleLength()`, `padToWidth()`.
+- ANSI resets and bg repaint logic differ by component.
+- Many renderers emit strings directly rather than styled spans.
+
+This causes the exact bugs already seen: cells falling through to terminal bg, nested resets clearing row bg, over-width lines, stale ANSI after truncation.
+
+**Recommendation:** introduce a small typed render primitive layer before building more UI:
+
+```ts
+type Style = { fg?: Token; bg?: Token; bold?: boolean; italic?: boolean; dim?: boolean };
+type Span = { text: string; style?: Style };
+type Line = Span[];
+
+renderLine(line: Line, width, options): string
+box({ title, width, style, children }): Line[]
+rule(width, style): Line
+pad(line, width, fillStyle): Line
+truncate(line, width): Line
+```
+
+Then build Cathedral surfaces from these primitives:
+
+- `MessageFrame`
+- `ToolPill`
+- `ToolLedger`
+- `CodeBlock`
+- `ScriptoriumModal`
+- `RegistrySidebar`
+- `FooterLine`
+- `InputFrame`
+
+This is the "Lip Gloss" lesson from Charm: make styling/layout primitives pure, reusable, and boring.
+
+---
+
+### P1 — SumoTUI needs a unidirectional app model
+
+Current state is scattered:
+
+- Pi events update footer state directly.
+- Sidebar reads from `ctx.sessionManager` during render.
+- Chat bridge mutates `ChatPager` from Pi event hooks.
+- Memory cache timers call render callbacks.
+- Command palette directly writes editor text or calls UI selects.
+
+This works for a small extension. It will not scale to a full shell.
+
+Borrow the Elm/Bubble Tea pattern:
+
+```ts
+type AppModel = {
+  terminal: TerminalModel;
+  session: SessionModel;
+  chat: ChatModel;
+  sidebar: SidebarModel;
+  modalStack: ModalModel[];
+  input: InputModel;
+  theme: ThemeModel;
+};
+
+type AppMsg =
+  | { type: "pi.message_start"; message: PiMessage }
+  | { type: "pi.tool_result"; result: PiToolResult }
+  | { type: "terminal.resize"; cols: number; rows: number }
+  | { type: "input.key"; event: KeyEvent }
+  | { type: "mouse.event"; event: MouseEvent }
+  | { type: "memory.loaded"; facts: Fact[] }
+  | { type: "theme.changed"; theme: ThemeId };
+
+function update(model: AppModel, msg: AppMsg): [AppModel, Command[]]
+function view(model: AppModel): SumoNode
+```
+
+This gives you:
+
+- deterministic state transitions;
+- replayable bug reports;
+- easier headless tests;
+- a single place to profile resume/startup;
+- clean async via commands/workers.
+
+Borrow Textual's `Worker` idea for memory fetches, session summary, and long-running UI tasks: exclusive workers cancel stale work and avoid races.
+
+---
+
+### P1 — Chat model is not structured enough for V2 elements
+
+V2 needs message frames, skill pills, tool pills, code blocks, scroll/scribe delegation, Divine Query, and later live bash. Current retained chat is mostly text-role messages.
+
+**Recommendation:** introduce a structured transcript model now:
+
+```ts
+type ChatBlock =
+  | { type: "markdown"; text: string }
+  | { type: "code"; lang: string; source: string; collapsed?: boolean }
+  | { type: "tool"; tool: ToolCallViewModel }
+  | { type: "skill"; name: string; expanded: boolean }
+  | { type: "question"; question: QuestionViewModel }
+  | { type: "delegation"; scroll: ScrollViewModel };
+
+type ChatMessageViewModel = {
+  id: string;
+  role: "user" | "sumo" | "system";
+  displayName: string;
+  timestamp?: Date;
+  blocks: ChatBlock[];
+};
+```
+
+Render `ChatMessageViewModel` to retained widgets. Do not keep trying to infer V2 surfaces from plain text rows.
+
+---
+
+### P1 — CellBuffer works, but should be optimized before longer sessions
+
+Current `CellBuffer` uses a `Uint16Array` for chars, but style storage is multiple `Map<number, string|number>` structures. `clone()` copies maps every frame. This is okay at current sizes and measured benchmarks, but it will become a cost under:
+
+- 160×60 full-shell frames;
+- drag selection highlight;
+- code/tool ledgers;
+- animated splash;
+- long streaming sessions;
+- split panes later.
+
+Borrow from Ratatui/OpenTUI:
+
+- store style IDs in typed arrays;
+- maintain a style table `{ fg,bg,attrs } -> id`;
+- keep previous/current buffers and swap them instead of cloning maps;
+- dirty-row/dirty-rect tracking;
+- row hash before per-cell compare;
+- cache wrapped markdown/code blocks by `(contentHash,width,themeVersion)`.
+
+Do this only after contracts are aligned; current perf is acceptable.
+
+---
+
+### P1 — Testing strategy is good but not yet authoritative
+
+The repo has a lot of tests, but the failure mode shows the problem: tests are not tied to the latest spec contract.
+
+Borrow from Ratatui/Textual:
+
+- a **headless backend** that behaves like the terminal but does not write real ANSI;
+- a **Pilot API** that can press keys, send mouse events, resize, and assert visible cells;
+- a **TestBackend** that exposes current/previous buffers and cursor state;
+- visual goldens promoted only after human approval.
+
+Proposed test layers:
+
+1. **Pure render tests**: `renderFoo(snapshot,width)` returns styled lines/cells.
+2. **Headless SumoTUI tests**: app model + backend + input events.
+3. **PTY smoke tests**: real Pi/Sumo integration, terminal lifecycle, cursor, mouse.
+4. **Visual Bible tests**: component/runtime crops.
+5. **Long-session soak tests**: 10k messages, 1h idle, resize storm, streaming while scrolled up.
+
+---
+
+### P1 — Observability/devtools should become a first-class feature
+
+Current diagnostics are good but low-level: JSONL diagnostics, CPU script, visual outputs.
+
+Borrow Textual Devtools and OpenTUI debug overlays:
+
+- `Ctrl+Shift+D` debug overlay with:
+  - current mode: hybrid/owned;
+  - terminal dims;
+  - frame p50/p95;
+  - renders/sec;
+  - dirty queue depth;
+  - focused widget;
+  - modal stack;
+  - scroll offset/manualScroll/unread;
+  - active keybindings;
+  - Pi event rate;
+  - memory worker status.
+- `SUMO_TUI_TRACE=1` writes replayable event logs.
+- `sumocode replay <trace>` replays a bug in headless mode.
+
+This will pay for itself because terminal bugs are hard to describe.
+
+---
+
+## 5. Patterns to borrow from other TUIs
+
+### OpenCode / OpenTUI
+
+Already researched in `docs/research/sumo-tui-spike/01-opencode.md` and `02-opentui.md`.
+
+Steal aggressively:
+
+- App-owned `ScrollBox` with sticky bottom.
+- Prompt outside scrollbox.
+- Explicit snap-to-bottom after async session load/submit.
+- Message-boundary navigation using rendered child positions.
+- Responsive sidebar: dock on wide, overlay on narrow.
+- Theme tokens for every semantic surface.
+- Central renderer lifecycle with suspend/resume/destroy.
+- Hit grid / focus manager / mouse dispatcher.
+- Selection-aware mouse handling.
+
+Do **not** copy blindly:
+
+- Bun/OpenTUI as direct runtime dependency; Pi extensions are Node/jiti today.
+- Fixed FPS loop as the default; SumoTUI's event-driven idle model is better for agent sessions.
+
+### Bubble Tea
+
+Source: `https://github.com/charmbracelet/bubbletea`
+
+Borrow:
+
+- `Model -> Update -> View` architecture.
+- Commands as async effects that return messages.
+- Keep update/view fast; all blocking work becomes a command.
+- Central message channel for safe background work.
+
+Why it matters here: SumoCode currently has direct event-to-render hooks everywhere. A Bubble Tea-like loop would make runtime behavior testable and replayable.
+
+### Ratatui
+
+Sources:
+
+- `https://ratatui.rs/`
+- `https://docs.rs/ratatui/latest/ratatui/backend/struct.TestBackend.html`
+
+Borrow:
+
+- Immediate draw into a buffer, then diff previous/current buffers.
+- TestBackend for integration tests with no terminal.
+- Widget authors render into a `Frame`, not strings.
+- Modular core vs app-facing package split once the API stabilizes.
+
+Why it matters here: SumoTUI already has a retained tree, but the **backend/test** lesson is huge. Build a formal headless backend and stop relying so much on pty parsing for correctness.
+
+### Textual
+
+Sources:
+
+- `https://textual.textualize.io/guide/reactivity/`
+- `https://textual.textualize.io/guide/workers/`
+- `https://textual.textualize.io/guide/events/`
+- `https://textual.textualize.io/guide/testing/`
+- `https://textual.textualize.io/guide/devtools/`
+
+Borrow:
+
+- Reactive properties that automatically invalidate the right widget.
+- Worker API with `exclusive` behavior for canceling stale async tasks.
+- Message pump with selector-style handlers.
+- Headless `run_test()` + Pilot API.
+- Devtools console that avoids corrupting terminal output.
+- Styling separated from logic.
+
+Why it matters here: memory queries, session summarization, MCP health, and visual state updates all need cancellation/race protection.
+
+### Ink
+
+Source: `https://github.com/vadimdemedes/ink`
+
+Borrow:
+
+- Component composition and flexbox mental model.
+- Eventually, a declarative adapter for complex UI trees.
+
+Do not start there. A React reconciler is a Phase 6+ idea. First make the imperative kernel correct.
+
+### Charm Lip Gloss / Bubbles
+
+Borrow:
+
+- Small reusable styling primitives.
+- Composable widgets that can be used without a full framework.
+- Strong separation between layout/style and app logic.
+
+This directly maps to the suggested `Span/Line/Style` layer.
+
+---
+
+## 6. Feature ideas that move SumoTUI toward the final goal
+
+### Daily-driver UX
+
+1. **Transcript search**: `/` inside chat scrollback, jump between matches, highlight cells.
+2. **Semantic jumps**: next/previous user message, next/previous tool, last failed tool, last code block.
+3. **Session archive overlay**: top-bar ARCHIVE opens a searchable session list.
+4. **Recent session tabs**: passive first, interactive once session switching is stable.
+5. **Command palette drill-downs**: SESSION / MODEL / THINKING / MEMORY / THEME / SETTINGS, all Scriptorium style.
+6. **Keybinding conflict inspector**: visible list of active owner/priority for each binding.
+7. **In-app selection + OSC 52 copy**: required because SGR mouse capture weakens native terminal selection.
+8. **Slow terminal mode**: lower frame cap, disable animations, more aggressive row diffing.
+9. **Safe recovery command**: `sumocode recover` emits reset bytes after SIGKILL/terminal corruption.
+10. **Resume perf budget overlay**: show exact resume path timing when `SUMO_TUI_DEBUG=1`.
+
+### Agent/product features
+
+1. **Tool ledger cards**: compact by default, expanded on demand.
+2. **Bash live view**: optional v2, preserve Pi security semantics.
+3. **Code block frames/gutters**: shared renderer with edit/read ledgers.
+4. **Skill pill**: `[skill] frontend-design (⌘O to expand)` inside SUMO messages.
+5. **Divine Query modal**: replaces ugly question/confirm prompts.
+6. **Approval modal**: use Pi risk policy, SumoTUI rendering.
+7. **Memory Scriptorium**: read/edit/delete/search facts; deterministic panel routing.
+8. **Primary agent display name**: `sumocode.json` controls `SUMO` vs `ZEUS` chat headers.
+9. **MCP health real data**: replace placeholder MCP server rows.
+10. **Memory diff on session end**: show what was remembered, allow reject/edit.
+
+### Developer ergonomics
+
+1. **Storybook-like Bible runner**: render individual components with fixtures.
+2. **Trace replay**: record `AppMsg` stream and replay headlessly.
+3. **Layout inspector**: show Yoga rects and z-index overlays.
+4. **Perf budget CI**: fail if p95 render or idle CPU regresses beyond thresholds.
+5. **Pi upgrade smoke matrix**: run against pinned + latest compatible Pi versions.
+
+---
+
+## 7. Recommended architecture target
+
+### 7.1 SumoTUI should become a kernel with seven seams
+
+```txt
+┌─────────────────────────────────────────────────────────┐
+│ SumoCode product shell                                  │
+│  - Cathedral surfaces                                   │
+│  - command palette, memory, sidebar, footer, chat        │
+└─────────────────────────────────────────────────────────┘
+                         │
+┌─────────────────────────────────────────────────────────┐
+│ SumoTUI kernel                                           │
+│ 1. AppModel + Update loop                                │
+│ 2. TerminalSessionOwner                                  │
+│ 3. InputRouter + FocusManager + SelectionManager         │
+│ 4. LayoutTree / Yoga nodes                               │
+│ 5. Renderer backend: CellBuffer + diff + writer          │
+│ 6. Widget primitives: Box/Text/ScrollBox/Modal/TextInput │
+│ 7. Headless TestBackend + TraceReplay                    │
+└─────────────────────────────────────────────────────────┘
+                         │
+┌─────────────────────────────────────────────────────────┐
+│ Pi adapter                                               │
+│  - agent/session event subscription                      │
+│  - Pi editor leaf or native editor fallback              │
+│  - extension UI compatibility                            │
+│  - model/theme/settings/tool bridge                      │
+└─────────────────────────────────────────────────────────┘
+                         │
+┌─────────────────────────────────────────────────────────┐
+│ Pi runtime                                               │
+│  - LLMs, tools, MCP, auth, sessions, skills              │
+└─────────────────────────────────────────────────────────┘
+```
+
+### 7.2 Deep modules to carve out
+
+| Module | Responsibility | Why it is deep |
+|---|---|---|
+| `terminal-session-owner` | terminal mode state machine | Prevents cleanup/cursor/mouse regressions. |
+| `app-runtime` | Model/Update/View + command effects | Gives locality for state/race bugs. |
+| `input-router` | key/mouse/focus/modal/selection routing | Stops keybinding conflicts and lost focus. |
+| `style` | tokens -> spans -> ANSI/cells | Prevents bg/reset/width bugs. |
+| `transcript` | structured messages + virtualization | Enables chat frames/tool/code/search. |
+| `pi-adapter` | private Pi seams isolated | Contains Pi drift risk. |
+| `test-backend` | headless terminal + pilot | Makes runtime testable without pty flake. |
+
+### 7.3 What should stay shallow
+
+- Individual Cathedral renderers once built on primitives.
+- Slash command registration wrappers.
+- Static token definitions.
+- Demo extensions.
+- Bible scenario fixtures.
+
+---
+
+## 8. Prioritized backlog
+
+### P0 — Contract and stability reset
+
+1. **Remove stale Convex workflow from workspace agent instructions.** Done in `../AGENTS.md` during this audit.
+2. **Make integration tests green.** Unit tests now pass; the cursor PTY test still times out.
+3. **Pick and encode sidebar policy.** 30-col V2 is the apparent direction; portrait behavior still needs an explicit product decision.
+4. **Single terminal owner.** Remove duplicate lifecycle ownership; gate OSC 11/12.
+5. **Remove duplicate `/sumo:memory` registration.** Command palette should call memory editor; not register a stub.
+6. **Fix command palette active-state open + drill-down behavior.** Align with Element 8.
+7. **Fix integration test cursor marker to V2.** Wait for stable runtime/cursor bytes, not `SCRIPTOR INPUT`.
+8. **Add memory/sidebar timer disposal.** `SidebarMemoryCache` needs `dispose()` to clear debounce/retry timers on session shutdown.
+9. **Run Pi version smoke script in CI/local pre-release.** The fork patch must be verified.
+10. **Update README status.** It still says v0.1 scaffold while the repo now contains a substantial renderer and V2 spec.
+
+### P1 — Kernel deepening
+
+1. Add `AppModel/AppMsg/update()` loop.
+2. Add typed `Style/Span/Line` rendering layer.
+3. Add headless `TestBackend` + pilot.
+4. Add focus/modal stack and keybinding priority system.
+5. Move chat to structured transcript model.
+6. Add selection manager + OSC52 copy.
+7. Add debug overlay.
+
+### P2 — Visual/product surface completion
+
+1. Element 13 chat message frames.
+2. Element 11 Divine Query.
+3. Element 9 tool pills/ledgers.
+4. Element 10 code blocks.
+5. Element 9a skill pill.
+6. Element 12 scroll/scribe delegation.
+7. Element 6 approval modal via Pi risk policy.
+8. Element 7 Memory Scriptorium.
+9. Top-bar LLM summaries + recent sessions.
+
+### P3 — Extraction/public API
+
+Only after 30 days stable:
+
+- decide whether `src/sumo-tui` becomes `@sumodeus/sumo-tui`;
+- publish architecture docs;
+- add third-party Pi extension compatibility tier;
+- consider React/Solid adapter.
+
+---
+
+## 9. Acceptance gates before declaring SumoTUI v1 daily-driver ready
+
+### Correctness gates
+
+- `pnpm test` passes.
+- `pnpm test:integration` passes.
+- `pnpm exec tsc --noEmit` passes.
+- `pnpm build` passes.
+- `pnpm visual:ci` has no hard failures and required crops pass.
+- No known V2 contract contradiction between docs/tests/constants.
+
+### Runtime gates
+
+- Ctrl+C exits cleanly, no escape leakage.
+- Ctrl+Z/fg works.
+- No-TTY `pi --print` / ACPX paths do not emit UI or crash.
+- Mouse wheel scrolls chat, not editor history.
+- Cursor stays visible and correctly placed during typing, autocomplete, resize.
+- Streaming while scrolled up preserves viewport and shows jump-to-bottom affordance.
+- `/resume` active transition under 500ms or dominant cause documented.
+
+### Performance gates
+
+- Idle CPU < 1%.
+- No retained render loop at idle.
+- Streaming p95 render < 16.7ms target / < 33ms acceptable.
+- Long session RSS < 300 MiB after 1h.
+- 10k-message synthetic transcript keeps only virtualized active rows in tree.
+
+### UX gates
+
+- MacBook landscape: sidebar and chat feel balanced.
+- Mac mini portrait: explicit approved behavior, not accidental hide.
+- Visual Bible scenes for active, portrait, tools, code, palette, memory, approval, query, skill all exist.
+- Dhruv has visually approved the promoted crops.
+
+---
+
+## 10. Final recommendation
+
+Keep going with SumoTUI. The final goal needs it.
+
+But spend the next slice on **consolidation**, not new polish:
+
+1. Align V2 spec, constants, tests, and README.
+2. Make terminal lifecycle single-owner.
+3. Centralize commands/keybindings.
+4. Introduce typed style primitives.
+5. Add the app model/update loop and headless backend.
+
+Once those are in place, the remaining Cathedral elements become straightforward surface work instead of brittle ANSI surgery.
+
+The north star should be:
+
+> **SumoCode feels like OpenCode-level terminal ownership, with Pi's agent engine and editor intelligence underneath, and a Cathedral product identity that is stable enough to daily-drive in cmux on both portrait and landscape machines.**

--- a/docs/ui/CATHEDRAL_UX_SPEC_V2.md
+++ b/docs/ui/CATHEDRAL_UX_SPEC_V2.md
@@ -124,7 +124,7 @@ Key design moves:
 - `REGISTRY` is a single-row accent masthead; version metadata does not appear in the sidebar
 - Sub-tabs use **tracked-out** narrow-no-break-space typography (`C O N T E X T`) for editorial display feel
 - Heavy `━` rule (26 chars) separates header from content
-- All section labels (CONTEXT / SESSION / MCP / METRICS) use tracked-out style
+- All section labels (CONTEXT / SESSION / MCP / MEMORY / METRICS) use tracked-out style
 
 **CONTEXT sub-tab content (V2 EDITORIAL)**:
 
@@ -163,16 +163,19 @@ Key design moves:
 ```
 (via fg-approve color)
 
-**MEMORY sub-tab content**:
+**MEMORY sub-tab content (V2 EDITORIAL)**:
 
 ```
-                              ┌ ACTIVE_MEMORY ─
-                              ❧ prefers TS strict
-                              ❧ pnpm not npm
-                              ❧ based London · BST
-                              ❧ Argent → argent-x
-                              ❧ imperative commits
-                              48 more · ⌘M
+  M E M O R Y
+
+  ❧ prefers TS strict
+  ❧ pnpm not npm
+  ❧ based London · BST
+  ❧ Argent → argent-x
+  ❧ imperative commits
+
+  ━━━━━━━━━━━━━━━━━━━━━━━━━━
+  48 more · ⌘M
 ```
 
 `⌘M` opens memory editor (Element 7). Second path alongside `Ctrl+/ → MEMORY`.

--- a/docs/visual/parity/scenarios.json
+++ b/docs/visual/parity/scenarios.json
@@ -159,7 +159,7 @@
 			},
 			"dimensions": {
 				"cols": 30,
-				"rows": 54
+				"rows": 26
 			},
 			"bibleTarget": "01-sidebar-v2-editorial-context.png",
 			"crops": [

--- a/scripts/visual-v2/component-capture.mjs
+++ b/scripts/visual-v2/component-capture.mjs
@@ -69,16 +69,18 @@ async function renderFooterReady(width) {
 async function renderSidebarEditorial(width) {
 	const mod = await jiti.import(`${repoRoot}/src/sidebar.ts`);
 	return mod.renderSidebar({
-		projectName: "sumocode",
+		projectName: "sumo-deus",
 		branch: "main",
 		inputTokens: 42000,
-		outputTokens: 8000,
+		outputTokens: 0,
 		contextWindow: 200000,
+		cumulativeTokens: 3400000,
 		costUsd: 0.42,
 		mcpServers: [
-			{ name: "github", status: "ok" },
-			{ name: "stitch", status: "idle" },
-			{ name: "chrome", status: "idle" },
+			{ name: "github", status: "idle" },
+			{ name: "stitch", status: "ok" },
+			{ name: "context7", status: "idle" },
+			{ name: "chrome-dev", status: "idle" },
 		],
 		memory: [
 			"prefers Scriptorium language",
@@ -88,14 +90,6 @@ async function renderSidebarEditorial(width) {
 		memoryTotal: 48,
 		memoryUnavailable: false,
 		activeSubTab: "CONTEXT",
-		metrics: {
-			cpuPercent: 2.4,
-			memoryMiB: 142,
-			fps: 60,
-			cpuHistory: [1, 1.4, 1.8, 2.0, 2.4, 2.1, 1.9, 2.2, 2.4, 2.4],
-			memoryHistory: [120, 123, 126, 130, 134, 138, 140, 141, 142, 142],
-			fpsHistory: [58, 60, 60, 59, 60, 60, 60, 59, 60, 60],
-		},
 	}, width);
 }
 

--- a/scripts/visual-v2/terminal-dom-renderer.mjs
+++ b/scripts/visual-v2/terminal-dom-renderer.mjs
@@ -49,7 +49,7 @@ export async function renderTerminalSnapshot(snapshot, outputPng, options = {}) 
 export function terminalSnapshotHtml(snapshot, options = {}) {
 	const tokens = readFileSync(bibleTokensCss, "utf8");
 	const fontUrl = pathToFileURL(bibleFontPath).href;
-	const rows = snapshot.cells.map((row) => `<div class="row">${renderRow(row)}</div>`).join("\n");
+	const rows = snapshot.cells.map((row) => `<div class="row" style="background:${rowBackground(row)}">${renderRow(row)}</div>`).join("\n");
 	return `<!doctype html>
 <html>
 <head>
@@ -66,7 +66,13 @@ ${tokens}
 }
 html, body { min-height: 100%; }
 .stage { min-height: auto; align-items: flex-start; justify-content: flex-start; padding: 0; }
-.v2-cell-run { white-space: pre; }
+.v2-cell-run {
+  display: inline-block;
+  height: var(--cell-h);
+  line-height: var(--cell-h);
+  white-space: pre;
+  vertical-align: top;
+}
 </style>
 </head>
 <body>
@@ -77,6 +83,10 @@ ${rows}
 </div>
 </body>
 </html>`;
+}
+
+function rowBackground(row) {
+	return row[0]?.bg ?? "#1A1511";
 }
 
 function renderRow(row) {

--- a/src/sidebar-placement.ts
+++ b/src/sidebar-placement.ts
@@ -4,13 +4,13 @@ import { surfaceLine } from "./sumo-tui/cathedral/ansi.js";
 
 /**
  * Threshold below which the sidebar hides itself. Per DESIGN.md §8
- * (Responsive), the wide layout is ≥ 120 cols: chat ~70 cols + 1 gutter +
- * 49 sidebar fits comfortably. Below this we collapse to chat-only and let
+ * (Responsive), the wide layout is ≥ 120 cols: chat + gutter + the locked
+ * 30-column V2 editorial sidebar fit comfortably. Below this we collapse to chat-only and let
  * sidebar info come through `/sumo:memory` etc.
  */
 export const SIDEBAR_MIN_TERMINAL_WIDTH = 120;
-/** Render width for the sidebar overlay (DESIGN.md §5 — cols 112..160 in the wide layout). */
-export const SIDEBAR_WIDTH = 49;
+/** Render width for the V2 editorial sidebar (Bible Element 1). */
+export const SIDEBAR_WIDTH = 30;
 
 export type SidebarAnchor = "right-center" | "top-right" | "bottom-right";
 
@@ -92,7 +92,7 @@ export class StaticSidebarDock implements Component {
 		const lines: string[] = [];
 
 		// Pre-build a surface-bg-painted blank sidebar row so rows where the
-		// sidebar has no content still cover the right 49 cols with the cathedral
+		// sidebar has no content still cover the right sidebar cols with the cathedral
 		// surface (#241D17). Without this, cells past the last sidebar line fall
 		// back to terminal-default bg — visible as black bands when the chat
 		// content underneath is taller than the sidebar (e.g., long tool outputs).

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -15,6 +15,7 @@ import {
 
 const ANSI = /\u001b\[[0-9;]*m/g;
 const stripAnsi = (s: string): string => s.replace(ANSI, "");
+const untrack = (s: string): string => s.replace(/\u202F/g, "");
 
 function memoryClient(query: RemnicMemoryClient["query"]): RemnicMemoryClient {
 	return {
@@ -266,8 +267,8 @@ describe("createSidebarMemoryCache", () => {
 });
 
 describe("sidebar layout constants", () => {
-	it("defaults to the cathedral 49-column sidebar", () => {
-		expect(SIDEBAR_WIDTH).toBe(49);
+	it("defaults to the cathedral 30-column sidebar", () => {
+		expect(SIDEBAR_WIDTH).toBe(30);
 	});
 
 	it("only mounts at the wide-layout threshold from DESIGN.md §8 (≥ 120 cols)", () => {
@@ -277,7 +278,7 @@ describe("sidebar layout constants", () => {
 
 describe("renderSidebar — surface", () => {
 	it("pads every line to exactly the requested width so the surface fills cleanly", () => {
-		const width = 49;
+		const width = SIDEBAR_WIDTH;
 		const lines = renderSidebar(snapshot(), width);
 		expect(lines.length).toBeGreaterThan(0);
 		for (const line of lines) {
@@ -286,7 +287,7 @@ describe("renderSidebar — surface", () => {
 	});
 
 	it("wraps every line in the cathedral mahogany surface background", () => {
-		const lines = renderSidebar(snapshot(), 49);
+		const lines = renderSidebar(snapshot(), SIDEBAR_WIDTH);
 		for (const line of lines) {
 			// #241D17 -> 36;29;23
 			expect(line).toContain("\u001b[48;2;36;29;23m");
@@ -295,23 +296,25 @@ describe("renderSidebar — surface", () => {
 });
 
 describe("renderSidebar — context section", () => {
-	it("shows project (branch), a filled progress bar, and a 'spent · session' line", () => {
-		const lines = renderSidebar(snapshot(), 49).map(stripAnsi);
-		const blob = lines.join("\n");
+	it("shows project, branch, V2 token bar, and session totals", () => {
+		const lines = renderSidebar(snapshot(), SIDEBAR_WIDTH).map(stripAnsi);
+		const blob = untrack(lines.join("\n"));
 
 		expect(blob).toContain("CONTEXT");
-		expect(blob).toContain("argent-x (main)");
-		expect(blob).toMatch(/\[█+░+\] +20k\/200k/);
-		expect(blob).toContain("$0.42 spent · session");
+		expect(blob).toContain("argent-x");
+		expect(blob).toContain("on main");
+		expect(blob).toMatch(/▉+░+/);
+		expect(blob).toContain("20k / 200k");
+		expect(blob).toContain("$0.42 · 20k cumul");
 	});
 });
 
 describe("renderSidebar — mcp section", () => {
 	it("lists each MCP server with a colored status dot and a right-aligned status pill", () => {
-		const rendered = renderSidebar(snapshot(), 49);
+		const rendered = renderSidebar(snapshot(), SIDEBAR_WIDTH);
 		const blob = rendered.map(stripAnsi).join("\n");
 
-		expect(blob).toContain("MCP");
+		expect(untrack(blob)).toContain("MCP");
 		expect(blob).toContain("github");
 		expect(blob).toContain("stitch");
 
@@ -331,7 +334,7 @@ describe("renderSidebar — mcp section", () => {
 
 describe("renderSidebar — MEMORY sub-tab active", () => {
 	it("renders each memory item with a ❧ bullet (when activeSubTab=MEMORY)", () => {
-		const lines = renderSidebar(snapshot({ activeSubTab: "MEMORY" }), 49);
+		const lines = renderSidebar(snapshot({ activeSubTab: "MEMORY" }), SIDEBAR_WIDTH);
 		const memoryLines = lines.map(stripAnsi).filter((l) => /^\s*❧/.test(l));
 
 		expect(memoryLines.length).toBe(3);
@@ -344,7 +347,7 @@ describe("renderSidebar — MEMORY sub-tab active", () => {
 			activeSubTab: "MEMORY",
 			memory: ["a", "b", "c", "d", "e", "f", "g"],
 		});
-		const lines = renderSidebar(many, 49);
+		const lines = renderSidebar(many, SIDEBAR_WIDTH);
 		const memoryLines = lines.map(stripAnsi).filter((l) => /^\s*❧/.test(l));
 
 		expect(memoryLines.length).toBe(5);
@@ -353,7 +356,7 @@ describe("renderSidebar — MEMORY sub-tab active", () => {
 	});
 
 	it("shows dim no-match copy when memory is healthy but empty", () => {
-		const lines = renderSidebar(snapshot({ activeSubTab: "MEMORY", memory: [], memoryUnavailable: false }), 49);
+		const lines = renderSidebar(snapshot({ activeSubTab: "MEMORY", memory: [], memoryUnavailable: false }), SIDEBAR_WIDTH);
 		const row = lines.find((line) => stripAnsi(line).includes("no memory match"));
 
 		expect(row).toBeDefined();
@@ -362,7 +365,7 @@ describe("renderSidebar — MEMORY sub-tab active", () => {
 	});
 
 	it("shows dim memory unavailable copy when the daemon is down", () => {
-		const lines = renderSidebar(snapshot({ activeSubTab: "MEMORY", memory: [], memoryUnavailable: true }), 49);
+		const lines = renderSidebar(snapshot({ activeSubTab: "MEMORY", memory: [], memoryUnavailable: true }), SIDEBAR_WIDTH);
 		const row = lines.find((line) => stripAnsi(line).includes("memory unavailable"));
 
 		expect(row).toBeDefined();
@@ -375,7 +378,7 @@ describe("renderSidebar — MEMORY sub-tab active", () => {
 			activeSubTab: "MEMORY",
 			memory: ["a", "b", "c", "d", "e"],
 			memoryTotal: 53,
-		}), 49);
+		}), SIDEBAR_WIDTH);
 		const blob = lines.map(stripAnsi).join("\n");
 
 		expect(blob).toContain("48 more · ⌘M");
@@ -386,7 +389,7 @@ describe("renderSidebar — MEMORY sub-tab active", () => {
 			activeSubTab: "MEMORY",
 			memory: ["a", "b", "c"],
 			memoryTotal: 3,
-		}), 49);
+		}), SIDEBAR_WIDTH);
 		const blob = lines.map(stripAnsi).join("\n");
 
 		expect(blob).not.toContain("more · ⌘M");
@@ -395,43 +398,36 @@ describe("renderSidebar — MEMORY sub-tab active", () => {
 
 describe("renderSidebar — sub-tab navigation", () => {
 	it("defaults to CONTEXT sub-tab (no activeSubTab field)", () => {
-		const lines = renderSidebar(snapshot(), 49);
-		const blob = lines.map(stripAnsi).join("\n");
+		const lines = renderSidebar(snapshot(), SIDEBAR_WIDTH);
+		const blob = untrack(lines.map(stripAnsi).join("\n"));
 		expect(blob).toContain("REGISTRY");
 		expect(blob).toContain("CONTEXT");
 		expect(blob).toContain("MEMORY");
 		// CONTEXT sub-tab content shown
 		expect(blob).toContain("argent-x");
 		expect(blob).toContain("github");
-		// Issue #56 keeps Remnic facts visible in the active registry summary.
-		expect(lines.map(stripAnsi).filter((line) => /^\s*❧/.test(line))).toHaveLength(3);
+		expect(lines.map(stripAnsi).filter((line) => /^\s*❧/.test(line))).toHaveLength(0);
 	});
 
-	it("renders REGISTRY header with v 1.0.0 version line", () => {
-		const lines = renderSidebar(snapshot(), 49).map(stripAnsi);
+	it("renders REGISTRY header without version metadata", () => {
+		const lines = renderSidebar(snapshot(), SIDEBAR_WIDTH).map(stripAnsi);
 		const hasRegistry = lines.some((l) => l.includes("REGISTRY"));
 		const hasVersion = lines.some((l) => l.includes("v 1.0.0"));
 		expect(hasRegistry).toBe(true);
-		expect(hasVersion).toBe(true);
+		expect(hasVersion).toBe(false);
 	});
 
-	it("marks active session with ◆ and archived sessions with ▢", () => {
-		const lines = renderSidebar(snapshot({
-			sessions: [
-				{ name: "sumocode", branch: "main", active: true },
-				{ name: "sumocode", branch: "other-branch", active: false },
-			],
-		}), 49).map(stripAnsi);
-		const activeSession = lines.find((l) => l.includes("sumocode (main)"));
-		const archivedSession = lines.find((l) => l.includes("sumocode (other-branch)"));
-		expect(activeSession).toContain("◆");
-		expect(archivedSession).toContain("▢");
+	it("renders project and branch as editorial hero values", () => {
+		const lines = renderSidebar(snapshot({ projectName: "sumocode", branch: "main" }), SIDEBAR_WIDTH).map(stripAnsi);
+		const blob = lines.join("\n");
+		expect(blob).toContain("sumocode");
+		expect(blob).toContain("on main");
 	});
 
 	it("marks active sub-tab with ◆ (filled) and inactive with ▢ (outlined)", () => {
-		const lines = renderSidebar(snapshot({ activeSubTab: "CONTEXT" }), 49).map(stripAnsi);
-		const contextRow = lines.find((l) => l.includes("CONTEXT") && !l.includes("ACTIVE_CONTEXT"));
-		const memoryRow = lines.find((l) => l.includes("MEMORY") && !l.includes("ACTIVE_MEMORY"));
+		const lines = renderSidebar(snapshot({ activeSubTab: "CONTEXT" }), SIDEBAR_WIDTH).map(stripAnsi);
+		const contextRow = lines.find((l) => untrack(l).includes("CONTEXT"));
+		const memoryRow = lines.find((l) => untrack(l).includes("MEMORY"));
 		expect(contextRow).toBeDefined();
 		expect(memoryRow).toBeDefined();
 		expect(contextRow).toContain("◆");
@@ -439,8 +435,8 @@ describe("renderSidebar — sub-tab navigation", () => {
 	});
 
 	it("switching activeSubTab swaps content (CONTEXT → MEMORY)", () => {
-		const contextLines = renderSidebar(snapshot({ activeSubTab: "CONTEXT" }), 49).map(stripAnsi);
-		const memoryLines = renderSidebar(snapshot({ activeSubTab: "MEMORY" }), 49).map(stripAnsi);
+		const contextLines = renderSidebar(snapshot({ activeSubTab: "CONTEXT" }), SIDEBAR_WIDTH).map(stripAnsi);
+		const memoryLines = renderSidebar(snapshot({ activeSubTab: "MEMORY" }), SIDEBAR_WIDTH).map(stripAnsi);
 
 		const contextHasMcp = contextLines.some((l) => l.includes("github"));
 		const memoryHasMcp = memoryLines.some((l) => l.includes("github"));
@@ -454,7 +450,7 @@ describe("renderSidebar — sub-tab navigation", () => {
 
 describe("renderSidebar — memory section bullet indent", () => {
 	it("renders each memory item with a leading two-space indent before ❧", () => {
-		const lines = renderSidebar(snapshot({ activeSubTab: "MEMORY" }), 49);
+		const lines = renderSidebar(snapshot({ activeSubTab: "MEMORY" }), SIDEBAR_WIDTH);
 		const memoryLines = lines.map(stripAnsi).filter((line) => /^\s*❧/.test(line));
 
 		expect(memoryLines.length).toBeGreaterThan(0);

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -33,7 +33,7 @@ export const PLACEHOLDER_MCP: readonly McpServerSnapshot[] = [
 	{ name: "github", status: "idle" },
 	{ name: "stitch", status: "ok" },
 	{ name: "context7", status: "idle" },
-	{ name: "chrome-devtools", status: "idle" },
+	{ name: "chrome-dev", status: "idle" },
 ];
 
 export { SIDEBAR_SUB_TABS };
@@ -169,6 +169,7 @@ function snapshotFromContext(
 		inputTokens: input,
 		outputTokens: output,
 		contextWindow,
+		cumulativeTokens: input + output,
 		costUsd: cost,
 		mcpServers: PLACEHOLDER_MCP,
 		memory: memorySnapshot.memory,

--- a/src/sumo-tui/cathedral/sidebar-mcp-pills.test.ts
+++ b/src/sumo-tui/cathedral/sidebar-mcp-pills.test.ts
@@ -18,10 +18,10 @@ describe("sidebar MCP state pills", () => {
 	});
 
 	it("renders a colored ●, foreground server name, and right-aligned status", () => {
-		const row = renderMcpServerRow({ name: "chrome-devtools", status: "in-flight" }, 49);
+		const row = renderMcpServerRow({ name: "chrome-dev", status: "in-flight" }, 30);
 		const plain = stripAnsi(row);
 
-		expect(plain).toContain("● chrome-devtools");
+		expect(plain).toContain("● chrome-dev");
 		expect(plain).toMatch(/in-flight\s*$/);
 		expect(row).toContain(rgb(CATHEDRAL_TOKENS.colors.states.thinking));
 	});

--- a/src/sumo-tui/cathedral/sidebar-memory-bullets.test.ts
+++ b/src/sumo-tui/cathedral/sidebar-memory-bullets.test.ts
@@ -31,14 +31,14 @@ function snapshot(): RegistrySidebarSnapshot {
 }
 
 describe("sidebar memory bullets", () => {
-	it("renders ACTIVE_MEMORY facts with an accented ❧ bullet", () => {
-		const line = renderMemoryFactLine("prefers TypeScript strict", 49);
+	it("renders MEMORY facts with an accented ❧ bullet", () => {
+		const line = renderMemoryFactLine("prefers TypeScript strict", 30);
 		expect(stripAnsi(line).trim()).toBe("❧ prefers TypeScript strict");
 		expect(line).toContain(rgb(CATHEDRAL_TOKENS.colors.accent));
 	});
 
-	it("caps visible facts at 5 and renders an italic overflow marker", () => {
-		const rendered = renderRegistrySidebarLines(snapshot(), 49);
+	it("caps visible facts at 5 and renders a dim overflow marker", () => {
+		const rendered = renderRegistrySidebarLines(snapshot(), 30);
 		const plain = rendered.map(stripAnsi);
 		const factRows = plain.filter((line) => /^\s*❧/.test(line));
 		const overflow = rendered.find((line) => stripAnsi(line).includes("48 more · ⌘M"));
@@ -46,6 +46,6 @@ describe("sidebar memory bullets", () => {
 		expect(factRows).toHaveLength(5);
 		expect(plain.join("\n")).not.toContain("hidden sixth fact");
 		expect(overflow).toBeDefined();
-		expect(overflow).toContain("\u001b[3m");
+		expect(overflow).toContain(rgb(CATHEDRAL_TOKENS.colors.foregroundDim));
 	});
 });

--- a/src/sumo-tui/cathedral/sidebar-rendering.ts
+++ b/src/sumo-tui/cathedral/sidebar-rendering.ts
@@ -1,8 +1,8 @@
 import { CATHEDRAL_TOKENS, type SumoCodeState } from "../../tokens.js";
 import { formatTokenCount } from "../../footer.js";
 import { VOICE } from "../../voice.js";
-import { bold, colorHex, dim, italic, padAnsiToWidth, renderSidebarSectionHeader, SIDEBAR_INDENT, visibleLength } from "./ansi.js";
-import { renderMetricsHudLines, type MetricsHudSnapshot } from "./metrics-hud.js";
+import { fgHex, padAnsiToWidth, SIDEBAR_INDENT, stripAnsi, visibleLength } from "./ansi.js";
+import type { MetricsHudSnapshot } from "./metrics-hud.js";
 
 export type SidebarSubTab = "CONTEXT" | "MEMORY";
 export const SIDEBAR_SUB_TABS: readonly SidebarSubTab[] = ["CONTEXT", "MEMORY"];
@@ -27,6 +27,7 @@ export interface RegistrySidebarSnapshot {
 	readonly inputTokens: number;
 	readonly outputTokens: number;
 	readonly contextWindow: number;
+	readonly cumulativeTokens?: number;
 	readonly costUsd: number;
 	readonly mcpServers: readonly McpServerSnapshot[];
 	readonly memory: readonly string[];
@@ -38,8 +39,18 @@ export interface RegistrySidebarSnapshot {
 	readonly metrics?: MetricsHudSnapshot;
 }
 
-const TOKEN_BAR_CELLS = 10;
+const TOKEN_BAR_CELLS = 22;
 const MEMORY_DISPLAY_LIMIT = 5;
+const FG_RESET = "\u001b[39m";
+const DIM_OFF = "\u001b[22m";
+
+function colorHex(text: string, hex: string): string {
+	return `${fgHex(hex)}${text}${FG_RESET}`;
+}
+
+function dim(text: string): string {
+	return `\u001b[2m${text}${DIM_OFF}`;
+}
 
 function tokenUsageRatio(used: number, total: number): number {
 	if (total <= 0 || !Number.isFinite(used) || !Number.isFinite(total)) return 0;
@@ -60,6 +71,23 @@ function indented(content: string): string {
 	return `${SIDEBAR_INDENT}${content}`;
 }
 
+function tracked(text: string): string {
+	return text.split("").join("\u202F");
+}
+
+function blank(width: number): string {
+	return padAnsiToWidth("", width);
+}
+
+function rule(width: number): string {
+	const count = Math.max(1, width - visibleLength(SIDEBAR_INDENT) - 2);
+	return padAnsiToWidth(indented(colorHex("━".repeat(count), CATHEDRAL_TOKENS.colors.divider)), width);
+}
+
+function row(content: string, width: number): string {
+	return padAnsiToWidth(indented(content), width);
+}
+
 export function tokenMeterColor(used: number, total: number): string {
 	const ratio = tokenUsageRatio(used, total);
 	if (ratio > 1) return CATHEDRAL_TOKENS.colors.states.approval;
@@ -68,30 +96,37 @@ export function tokenMeterColor(used: number, total: number): string {
 	return CATHEDRAL_TOKENS.colors.states.idle;
 }
 
-/** CATHEDRAL_UX_SPEC.md §4.2 token gauge: `[██████░░░] 42k/200k`. */
+/** Cathedral V2 editorial token gauge: `▉▉▉▉▉░░░...` on its own row. */
 export function renderTokenMeter(used: number, total: number): string {
 	const ratio = tokenUsageRatio(used, total);
-	const filled = Math.round(clampRatio(ratio) * TOKEN_BAR_CELLS);
+	const filled = ratio > 1 ? TOKEN_BAR_CELLS : Math.round(clampRatio(ratio) * TOKEN_BAR_CELLS);
 	const empty = TOKEN_BAR_CELLS - filled;
-	const overBudget = ratio > 1;
 	const meterColor = tokenMeterColor(used, total);
-	const leftBracket = colorHex("[", CATHEDRAL_TOKENS.colors.divider);
-	const rightBracket = colorHex("]", CATHEDRAL_TOKENS.colors.divider);
-	const fill = colorHex("█".repeat(filled), meterColor);
-	const rest = colorHex("░".repeat(empty), CATHEDRAL_TOKENS.colors.divider);
-	const usageText = `${formatTokenCount(used)}/${formatTokenCount(total)}${overBudget ? " OVER" : ""}`;
-	const usage = colorHex(usageText, overBudget ? CATHEDRAL_TOKENS.colors.states.approval : CATHEDRAL_TOKENS.colors.foreground);
-	return `${leftBracket}${fill}${rest}${rightBracket} ${usage}`;
+	return `${colorHex("▉".repeat(filled), meterColor)}${colorHex("░".repeat(empty), CATHEDRAL_TOKENS.colors.divider)}`;
 }
 
 function contextLines(snapshot: RegistrySidebarSnapshot, width: number): string[] {
 	const used = snapshot.inputTokens + snapshot.outputTokens;
-	const projectLabel = snapshot.branch ? `${snapshot.projectName} (${snapshot.branch})` : snapshot.projectName;
+	const overBudget = snapshot.contextWindow > 0 && used > snapshot.contextWindow;
 	return [
-		renderSidebarSectionHeader("ACTIVE_CONTEXT", width),
-		padAnsiToWidth(indented(colorHex(projectLabel, CATHEDRAL_TOKENS.colors.foreground)), width),
-		padAnsiToWidth(indented(renderTokenMeter(used, snapshot.contextWindow)), width),
-		padAnsiToWidth(indented(colorHex(`$${snapshot.costUsd.toFixed(2)} spent · session`, CATHEDRAL_TOKENS.colors.foregroundDim)), width),
+		row(colorHex(snapshot.projectName, CATHEDRAL_TOKENS.colors.foreground), width),
+		row(colorHex(`on ${snapshot.branch ?? "unknown"}`, CATHEDRAL_TOKENS.colors.foregroundDim), width),
+		blank(width),
+		row(colorHex(tracked("CONTEXT"), CATHEDRAL_TOKENS.colors.foregroundDim), width),
+		row(renderTokenMeter(used, snapshot.contextWindow), width),
+		row(
+			`${colorHex(formatTokenCount(used), overBudget ? CATHEDRAL_TOKENS.colors.states.approval : CATHEDRAL_TOKENS.colors.foreground)} ` +
+				`${colorHex(`/ ${formatTokenCount(snapshot.contextWindow)}`, CATHEDRAL_TOKENS.colors.foregroundDim)}` +
+				(overBudget ? ` ${colorHex("OVER", CATHEDRAL_TOKENS.colors.states.approval)}` : ""),
+			width,
+		),
+		blank(width),
+		row(colorHex(tracked("SESSION"), CATHEDRAL_TOKENS.colors.foregroundDim), width),
+		row(
+			`${colorHex(`$${snapshot.costUsd.toFixed(2)}`, CATHEDRAL_TOKENS.colors.foreground)} ` +
+				`${colorHex(`· ${formatTokenCount(snapshot.cumulativeTokens ?? used)} cumul`, CATHEDRAL_TOKENS.colors.foregroundDim)}`,
+			width,
+		),
 	];
 }
 
@@ -132,37 +167,36 @@ export function mcpStatusLabel(status: McpServerStatusLike): string {
 }
 
 export function renderMcpServerRow(server: McpServerSnapshot, width: number): string {
-	const innerWidth = Math.max(1, width - SIDEBAR_INDENT.length);
 	const status = mcpStatusLabel(server.status);
 	const dot = colorHex("●", mcpStatusColor(server.status));
 	const statusText = colorHex(status, CATHEDRAL_TOKENS.colors.foregroundDim);
-	const nameMaxWidth = Math.max(1, innerWidth - 2 - status.length - 1);
-	const name = truncatePlainText(server.name, nameMaxWidth);
-	const gap = Math.max(1, innerWidth - 2 - visibleLength(name) - status.length);
-	return padAnsiToWidth(indented(`${dot} ${colorHex(name, CATHEDRAL_TOKENS.colors.foreground)}${" ".repeat(gap)}${statusText}`), width);
+	const reserve = visibleLength(SIDEBAR_INDENT) + 1 + 1 + status.length + 2;
+	const name = truncatePlainText(server.name, Math.max(1, width - reserve));
+	const gap = Math.max(1, width - visibleLength(SIDEBAR_INDENT) - 2 - visibleLength(name) - status.length - 2);
+	return padAnsiToWidth(indented(`${dot} ${colorHex(name, CATHEDRAL_TOKENS.colors.foreground)}${" ".repeat(gap)}${statusText}  `), width);
 }
 
 function mcpLines(snapshot: RegistrySidebarSnapshot, width: number): string[] {
-	const lines = [renderSidebarSectionHeader("MCP", width)];
+	const lines = [row(colorHex(tracked("MCP"), CATHEDRAL_TOKENS.colors.foregroundDim), width), blank(width)];
 	for (const server of snapshot.mcpServers) lines.push(renderMcpServerRow(server, width));
 	return lines;
 }
 
 export function renderMemoryFactLine(item: string, width: number): string {
-	const available = Math.max(0, width - SIDEBAR_INDENT.length - 2);
+	const available = Math.max(0, width - visibleLength(SIDEBAR_INDENT) - 2);
 	const bullet = colorHex("❧", CATHEDRAL_TOKENS.colors.accent);
 	const text = colorHex(truncatePlainText(item, available), CATHEDRAL_TOKENS.colors.foreground);
 	return padAnsiToWidth(indented(`${bullet} ${text}`), width);
 }
 
 function memoryLines(snapshot: RegistrySidebarSnapshot, width: number): string[] {
-	const lines = [renderSidebarSectionHeader("ACTIVE_MEMORY", width)];
+	const lines = [row(colorHex(tracked("MEMORY"), CATHEDRAL_TOKENS.colors.foregroundDim), width), blank(width)];
 	if (snapshot.memoryUnavailable) {
-		lines.push(padAnsiToWidth(indented(dim(VOICE.errors.daemonDown)), width));
+		lines.push(row(dim(VOICE.errors.daemonDown), width));
 		return lines;
 	}
 	if (snapshot.memory.length === 0) {
-		lines.push(padAnsiToWidth(indented(dim(VOICE.empty.memory)), width));
+		lines.push(row(dim(VOICE.empty.memory), width));
 		return lines;
 	}
 
@@ -172,47 +206,30 @@ function memoryLines(snapshot: RegistrySidebarSnapshot, width: number): string[]
 	const total = snapshot.memoryTotal ?? snapshot.memory.length;
 	const hidden = Math.max(0, total - shown.length);
 	if (hidden > 0) {
-		lines.push(padAnsiToWidth(indented(italic(colorHex(`${hidden} more · ⌘M`, CATHEDRAL_TOKENS.colors.foregroundDim))), width));
+		lines.push(blank(width));
+		lines.push(rule(width));
+		lines.push(row(colorHex(`${hidden} more · ⌘M`, CATHEDRAL_TOKENS.colors.foregroundDim), width));
 	}
 	return lines;
-}
-
-function sessionLabel(session: SidebarSessionSnapshot): string {
-	return session.branch ? `${session.name} (${session.branch})` : session.name;
-}
-
-function registrySessions(snapshot: RegistrySidebarSnapshot): readonly SidebarSessionSnapshot[] {
-	return snapshot.sessions?.length
-		? snapshot.sessions
-		: [{ name: snapshot.projectName, branch: snapshot.branch, active: true }];
 }
 
 export function renderRegistryHeaderLines(snapshot: RegistrySidebarSnapshot, width: number): string[] {
 	const active = snapshot.activeSubTab ?? "CONTEXT";
 	const lines: string[] = [
-		padAnsiToWidth("", width),
-		padAnsiToWidth(indented(colorHex("REGISTRY", CATHEDRAL_TOKENS.colors.accent)), width),
-		padAnsiToWidth(indented(colorHex("v 1.0.0", CATHEDRAL_TOKENS.colors.foregroundDim)), width),
-		padAnsiToWidth("", width),
+		blank(width),
+		row(colorHex("REGISTRY", CATHEDRAL_TOKENS.colors.accent), width),
+		blank(width),
 	];
 
-	for (const [index, session] of registrySessions(snapshot).entries()) {
-		const isActive = session.active ?? index === 0;
-		const marker = colorHex(isActive ? "◆" : "▢", isActive ? CATHEDRAL_TOKENS.colors.accent : CATHEDRAL_TOKENS.colors.foregroundDim);
-		const label = colorHex(sessionLabel(session), isActive ? CATHEDRAL_TOKENS.colors.foreground : CATHEDRAL_TOKENS.colors.foregroundDim);
-		lines.push(padAnsiToWidth(indented(`${marker} ${label}`), width));
-	}
-
-	lines.push(padAnsiToWidth("", width));
 	for (const tab of SIDEBAR_SUB_TABS) {
 		const isActive = tab === active;
 		const marker = colorHex(isActive ? "◆" : "▢", isActive ? CATHEDRAL_TOKENS.colors.accent : CATHEDRAL_TOKENS.colors.foregroundDim);
-		const label = isActive
-			? bold(colorHex(tab, CATHEDRAL_TOKENS.colors.accent))
-			: colorHex(tab, CATHEDRAL_TOKENS.colors.foregroundDim);
+		const label = colorHex(tracked(tab), isActive ? CATHEDRAL_TOKENS.colors.foreground : CATHEDRAL_TOKENS.colors.foregroundDim);
 		lines.push(padAnsiToWidth(indented(`${marker} ${label}`), width));
 	}
-	lines.push(padAnsiToWidth("", width));
+	lines.push(blank(width));
+	lines.push(rule(width));
+	lines.push(blank(width));
 	return lines;
 }
 
@@ -222,17 +239,17 @@ export function renderRegistrySidebarLines(snapshot: RegistrySidebarSnapshot, wi
 
 	if (active === "CONTEXT") {
 		lines.push(...contextLines(snapshot, width));
-		lines.push(padAnsiToWidth("", width));
+		lines.push(blank(width));
+		lines.push(rule(width));
+		lines.push(blank(width));
 		lines.push(...mcpLines(snapshot, width));
-		lines.push(padAnsiToWidth("", width));
-		// Issue #56 polish keeps v1's two-tab sidebar (DECISIONS Element 1) while
-		// surfacing Remnic facts in the active-state registry per UX_SPEC.md §4.2.
-		lines.push(...memoryLines(snapshot, width));
 	} else {
 		lines.push(...memoryLines(snapshot, width));
 	}
 
-	lines.push(padAnsiToWidth("", width));
-	lines.push(...renderMetricsHudLines(snapshot.metrics, width));
 	return lines.map((line) => padAnsiToWidth(line, width));
+}
+
+export function stripSidebarAnsi(text: string): string {
+	return stripAnsi(text);
 }

--- a/src/sumo-tui/cathedral/sidebar-token-bar.test.ts
+++ b/src/sumo-tui/cathedral/sidebar-token-bar.test.ts
@@ -9,9 +9,9 @@ function rgb(hex: string): string {
 }
 
 describe("sidebar token bar", () => {
-	it("renders a 10-cell visual bar plus formatted used/total text", () => {
+	it("renders a 22-cell editorial visual bar", () => {
 		const meter = renderTokenMeter(60_000, 100_000);
-		expect(stripAnsi(meter)).toBe("[██████░░░░] 60k/100k");
+		expect(stripAnsi(meter)).toBe(`${"▉".repeat(13)}${"░".repeat(9)}`);
 	});
 
 	it("uses sage below 50%, amber from 50–80%, accent from 80–100%, and terracotta over budget", () => {
@@ -24,6 +24,6 @@ describe("sidebar token bar", () => {
 		expect(renderTokenMeter(60, 100)).toContain(rgb(CATHEDRAL_TOKENS.colors.states.thinking));
 		expect(renderTokenMeter(90, 100)).toContain(rgb(CATHEDRAL_TOKENS.colors.accent));
 		expect(renderTokenMeter(101, 100)).toContain(rgb(CATHEDRAL_TOKENS.colors.states.approval));
-		expect(stripAnsi(renderTokenMeter(101, 100))).toBe("[██████████] 101/100 OVER");
+		expect(stripAnsi(renderTokenMeter(101, 100))).toBe("▉".repeat(22));
 	});
 });

--- a/src/sumo-tui/cathedral/sidebar-tree-headers.test.ts
+++ b/src/sumo-tui/cathedral/sidebar-tree-headers.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 import { stripAnsi } from "./ansi.js";
 import { renderRegistrySidebarLines, type RegistrySidebarSnapshot } from "./sidebar-rendering.js";
 
+const untrack = (s: string): string => s.replace(/\u202F/g, "");
+
 function snapshot(overrides: Partial<RegistrySidebarSnapshot> = {}): RegistrySidebarSnapshot {
 	return {
 		projectName: "argent-x",
@@ -9,29 +11,23 @@ function snapshot(overrides: Partial<RegistrySidebarSnapshot> = {}): RegistrySid
 		inputTokens: 12_000,
 		outputTokens: 30_000,
 		contextWindow: 200_000,
+		cumulativeTokens: 3_400_000,
 		costUsd: 0.42,
 		mcpServers: [{ name: "stitch", status: "ok" }],
 		memory: ["prefers TypeScript strict"],
-		metrics: {
-			cpuPercent: 1,
-			memoryMiB: 128,
-			fps: 0,
-			cpuHistory: [1],
-			memoryHistory: [128],
-			fpsHistory: [0],
-		},
 		...overrides,
 	};
 }
 
 describe("sidebar-tree headers", () => {
-	it("uses UX_SPEC §4.2 `┌ LABEL ────` headers for all issue #56 panels", () => {
-		const plain = renderRegistrySidebarLines(snapshot(), 49).map(stripAnsi).join("\n");
+	it("uses the V2 editorial tracked labels and thick rules", () => {
+		const plain = untrack(renderRegistrySidebarLines(snapshot(), 30).map(stripAnsi).join("\n"));
 
-		expect(plain).toContain("┌ ACTIVE_CONTEXT ─");
-		expect(plain).toContain("┌ MCP ─");
-		expect(plain).toContain("┌ ACTIVE_MEMORY ─");
-		expect(plain).toContain("┌ METRICS ─");
-		expect(plain).not.toContain("─── CONTEXT ───");
+		expect(plain).toContain("REGISTRY");
+		expect(plain).toContain("◆ CONTEXT");
+		expect(plain).toContain("▢ MEMORY");
+		expect(plain).toContain("━━━━━━━━━━━━━━━━━━━━━━━━━━");
+		expect(plain).not.toContain("┌ ACTIVE_CONTEXT");
+		expect(plain).not.toContain("┌ METRICS");
 	});
 });

--- a/src/sumo-tui/cathedral/sidebar-tree.test.ts
+++ b/src/sumo-tui/cathedral/sidebar-tree.test.ts
@@ -3,6 +3,7 @@ import { SumoNode } from "../layout/node.js";
 import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga } from "../layout/yoga.js";
 import { CellBuffer } from "../render/buffer.js";
 import { composite } from "../render/compositor.js";
+import { SIDEBAR_WIDTH } from "../../sidebar.js";
 import { createSidebarTree, resolveSidebarLayoutMode } from "./sidebar-tree.js";
 
 function plainRowHasPaint(buffer: CellBuffer, row: number): boolean {
@@ -10,7 +11,7 @@ function plainRowHasPaint(buffer: CellBuffer, row: number): boolean {
 }
 
 describe("sidebar-tree", () => {
-	it("docks at width >= 120 with a fixed 49-column sidebar", async () => {
+	it("docks at width >= 120 with a fixed 30-column sidebar", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());
 		root.flexDirection = FLEX_DIRECTION_COLUMN;
@@ -20,9 +21,9 @@ describe("sidebar-tree", () => {
 		root.yogaNode.calculateLayout(130, 20, DIRECTION_LTR);
 
 		expect(tree.mode).toBe("dock");
-		expect(tree.sidebar.getComputedWidth()).toBe(49);
-		expect(tree.chat.getComputedWidth()).toBe(81);
-		expect(tree.sidebar.getComputedLeft()).toBe(81);
+		expect(tree.sidebar.getComputedWidth()).toBe(SIDEBAR_WIDTH);
+		expect(tree.chat.getComputedWidth()).toBe(130 - SIDEBAR_WIDTH);
+		expect(tree.sidebar.getComputedLeft()).toBe(130 - SIDEBAR_WIDTH);
 		root.dispose();
 	});
 
@@ -39,8 +40,8 @@ describe("sidebar-tree", () => {
 
 		expect(tree.mode).toBe("overlay");
 		expect(tree.chat.getComputedWidth()).toBe(80);
-		expect(tree.sidebar.getComputedWidth()).toBe(49);
-		expect(tree.sidebar.getComputedLeft()).toBe(31);
+		expect(tree.sidebar.getComputedWidth()).toBe(SIDEBAR_WIDTH);
+		expect(tree.sidebar.getComputedLeft()).toBe(80 - SIDEBAR_WIDTH);
 		expect(plainRowHasPaint(frame, 0)).toBe(false);
 		expect(frame.getCell(0, 0).bg).toBe("#120D0A");
 		root.dispose();
@@ -60,7 +61,7 @@ describe("sidebar-tree", () => {
 		root.dispose();
 	});
 
-	it("renders REGISTRY chrome with version, session markers, and active sub-tabs", async () => {
+	it("renders REGISTRY chrome with editorial sub-tabs and memory content", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());
 		root.flexDirection = FLEX_DIRECTION_COLUMN;
@@ -82,12 +83,11 @@ describe("sidebar-tree", () => {
 		const sidebarLeft = tree.sidebar.getComputedLeft();
 		const sidebarText = Array.from({ length: 12 }, (_, row) => frame.toPlainRow(row).slice(sidebarLeft)).join("\n");
 
-		expect(sidebarText).toContain("REGISTRY");
-		expect(sidebarText).toContain("v 1.0.0");
-		expect(sidebarText).toContain("◆ sumocode (main)");
-		expect(sidebarText).toContain("▢ sumocode (other-branch)");
-		expect(sidebarText).toContain("▢ CONTEXT");
-		expect(sidebarText).toContain("◆ MEMORY");
+		const normalized = sidebarText.replace(/\u202F/g, "");
+		expect(normalized).toContain("REGISTRY");
+		expect(normalized).not.toContain("v 1.0.0");
+		expect(normalized).toContain("▢ CONTEXT");
+		expect(normalized).toContain("◆ MEMORY");
 		root.dispose();
 	});
 });

--- a/src/sumo-tui/cathedral/sidebar-tree.ts
+++ b/src/sumo-tui/cathedral/sidebar-tree.ts
@@ -48,9 +48,10 @@ export interface SidebarTree {
 }
 
 const DEFAULT_MCP_SERVERS: readonly McpServerSnapshot[] = [
+	{ name: "github", status: "idle" },
 	{ name: "stitch", status: "ok" },
-	{ name: "figma", status: "down" },
-	{ name: "chrome-devtools", status: "idle" },
+	{ name: "context7", status: "idle" },
+	{ name: "chrome-dev", status: "idle" },
 ];
 
 function finiteDimension(value: number, fallback: number): number {
@@ -133,7 +134,7 @@ export class SidebarChromeNode extends SumoNode {
 /**
  * Responsive cathedral sidebar host.
  *
- * Wide terminals dock the sidebar as a fixed 49-column sibling after chat.
+ * Wide terminals dock the sidebar as a fixed 30-column sibling after chat.
  * Narrow terminals let chat keep the full width and place sidebar above it as
  * an absolute right overlay with a dim backdrop. Empty splash state hides both
  * sidebar and backdrop (EC-17.6).

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -179,14 +179,14 @@ export class ChatViewportController {
 
 	public render(width: number): string[] {
 		// Pi's chatContainer is allocated the full terminal width by Pi's TUI.
-		// But Pi separately mounts our installSidebar() widget at the right 49
-		// cols (when the session has messages and terminal width >= 120). If we
-		// composite the chat tree at full width, our chat content paints into the
-		// cols Pi will overpaint with the sidebar — visually that's chat text
-		// running INTO the sidebar boundary before being clobbered.
+		// But Pi separately mounts our installSidebar() widget at the right
+		// SIDEBAR_WIDTH cols (when the session has messages and terminal width >=
+		// 120). If we composite the chat tree at full width, our chat content paints
+		// into the cols Pi will overpaint with the sidebar — visually that's chat
+		// text running INTO the sidebar boundary before being clobbered.
 		// Fix: narrow our composite to (terminal - SIDEBAR_WIDTH) when the same
 		// predicate Pi uses for showing the sidebar is true. The sidebar's own
-		// 49 cols on the right come from Pi's separate widget paint.
+		// right-side cols come from Pi's separate widget paint.
 		const terminalWidth = Math.max(1, Math.floor(width));
 		const sidebarVisible = terminalWidth >= SIDEBAR_MIN_TERMINAL_WIDTH && this.chat.hasMessages();
 		const effectiveWidth = sidebarVisible ? Math.max(1, terminalWidth - SIDEBAR_WIDTH) : terminalWidth;

--- a/src/sumo-tui/pi-compat/region-registry.ts
+++ b/src/sumo-tui/pi-compat/region-registry.ts
@@ -225,7 +225,7 @@ export class RegionRegistry {
 		}
 		const slot = placementToSlot(opts.placement);
 		if (slot === "sidebar") {
-			this.slots.sidebar.width = 49;
+			this.slots.sidebar.width = 30;
 			this.slots.sidebar.flexShrink = 0;
 		}
 		this.mount(key, slot, this.resolveWidget(content));


### PR DESCRIPTION
## Summary

Implements #85 by aligning the runtime sidebar renderer with the V2 Cathedral editorial sidebar target.

Changes:

- Sidebar width is now the locked 30-column V2 editorial width.
- Runtime sidebar uses the REGISTRY masthead with no version metadata.
- Sub-tabs and section labels use tracked-out typography.
- Context view now matches the Bible structure:
  - project hero + `on <branch>` subtitle
  - 22-cell editorial token bar
  - `42k / 200k` token row
  - SESSION cost/cumulative row
  - thick `━` separator
  - MCP rows with left dot/name and right-aligned status
- MEMORY view uses the V2 editorial memory treatment.
- Removed the old combined context+memory+metrics sidebar stack from the default context render.
- Updated sidebar component capture fixture to match the approved Bible target.
- Adjusted sidebar layout tests/tree constants for the 30-column contract.

## Visual evidence

Generated locally:

```txt
pnpm visual:review -- --scenario sidebar-editorial-component
pnpm visual:ci
```

`sidebar-editorial-component` result: `passed`.

Review pack is available locally/Tailscale at:

```txt
/bible-verify/
```

## Verification

```txt
pnpm vitest src/sidebar.test.ts src/sidebar-placement.test.ts src/sumo-tui/cathedral/sidebar-token-bar.test.ts src/sumo-tui/cathedral/sidebar-memory-bullets.test.ts src/sumo-tui/cathedral/sidebar-mcp-pills.test.ts src/sumo-tui/cathedral/sidebar-tree-headers.test.ts src/sumo-tui/cathedral/sidebar-tree.test.ts src/sumo-tui/pi-compat/chat-viewport-controller.test.ts --run
pnpm visual:ci
pnpm test
pnpm exec tsc --noEmit && pnpm build
```

All passed locally.

## Notes

No runtime golden is promoted in this PR yet. No sidebar crop is marked `required`; visual approval/promotion remains HITL.

Unrelated untracked local file left untouched: `docs/SUMO_TUI_AUDIT.md`.
