### PR TITLE
fix(visual): realign V2 parity contract

### DIFF
--- a/docs/CATHEDRAL_PARITY_PLAN.md
+++ b/docs/CATHEDRAL_PARITY_PLAN.md
@@ -1,5 +1,11 @@
 # Cathedral Visual Parity Pass
 
+> **Status:** historical V1 plan. The active V2 visual/runtime contract lives in
+> `docs/visual/parity/CONTRACT.md` and `docs/ui/CATHEDRAL_UX_SPEC_V2.md`.
+> Legacy 49-column sidebar and `SCRIPTOR INPUT` references below are retained as
+> provenance only; new V2 work uses a 30-column sidebar and label-less active
+> input.
+
 > **Goal:** make SumoCode visually 100% aligned with `docs/ui/DESIGN.md` and the
 > Cathedral mockups under `docs/ui/stitch/cathedral/`. Stop adding features
 > (memory commands, sync, etc.) until parity is reached. Verify each step
@@ -88,12 +94,12 @@ We replace it with a hand-authored `cathedral.json` Pi theme.
 
 ### Layer 2 — Sidebar parity
 
-Current sidebar renders a 32-col mahogany card with banners but does not
-match the planned 49-col, 3-section layout from `Sidebar.jsx`.
+**Superseded by V2.** The original plan targeted the older wide React mockup.
+The active V2 contract uses the 30-column editorial registry from the Visual
+Bible and `docs/visual/parity/CONTRACT.md`.
 
-- **2.1** Widen `SIDEBAR_WIDTH` from `32` to `49`.
-- **2.2** Update the auto-hide threshold so the sidebar still fits
-  alongside the chat pane (likely `SIDEBAR_MIN_TERMINAL_WIDTH ≈ 160`).
+- **2.1** Keep `SIDEBAR_WIDTH` at the V2 value of `30`.
+- **2.2** Keep the wide-layout threshold aligned to the V2 split (`SIDEBAR_MIN_TERMINAL_WIDTH = 120`).
 - **2.3** Anchor responsive to terminal aspect ratio (#13):
   landscape → `right-center`; portrait → `top-right`.
   Persist override in per-machine `~/.sumocode/local-config.json`.

--- a/docs/ui/CATHEDRAL_UX_SPEC_V2.md
+++ b/docs/ui/CATHEDRAL_UX_SPEC_V2.md
@@ -299,9 +299,9 @@ Disappears on first keystroke.
                                                         CTRL+/ · COMMANDS
 ```
 
-- **No label** above frame (regression to fix — currently shows `INPUT` / `SCRIPTOR INPUT`)
-- `>` prompt arrow inside frame, accent (currently missing — fix)
-- **No flavour text** on hint row (regression to fix — currently shows `INPUT PROTOCOL AWAITING COMMAND`)
+- **No label** above active frame (fixed in V2 runtime; do not reintroduce `INPUT` / `SCRIPTOR INPUT`)
+- `>` prompt arrow inside frame, accent
+- **No flavour text** on hint row (do not reintroduce `INPUT PROTOCOL AWAITING COMMAND`)
 - Hint row right side only: `CTRL+/ · COMMANDS` until agent switching is functional
 - Frame chars in `divider`
 - Bg inside frame: `surfaceRecess` — **EVERY ROW** including padding rows above/below cursor row
@@ -1023,11 +1023,11 @@ User-perceived: 2-3s splash → active transition on `/resume`. Must be < 500ms.
 
 Each row = one PR + one issue + visual approval.
 
-**Phase A — Element corrections (regressions to fix)**:
-1. Element 4 input frame: drop `SCRIPTOR INPUT` label + drop `INPUT PROTOCOL AWAITING COMMAND` flavour + add `>` prompt
-2. Element 1 sidebar: width 49 → 30, paint inter-section bg, render `N more · ⌘M` overflow marker, ⌘M keybind
+**Phase A — Element corrections**:
+1. Element 4 input frame: label-less active frame, no `INPUT PROTOCOL AWAITING COMMAND`, `>` prompt (locked by #82)
+2. Element 1 sidebar: width 49 → 30, paint inter-section bg, render `N more · ⌘M` overflow marker, ⌘M keybind (30-col editorial registry locked by #85)
 3. Element 1: `/sidebar [show|hide]` slash, `/metrics [on|off]` slash, compact metrics mode
-4. Element 5 footer: drop `↑/↓` cumulative, switch to `42k/200k · $0.42` right zone
+4. Element 5 footer: drop `↑/↓` cumulative, switch to `42k/200k · $0.42` right zone (locked by #83)
 
 **Phase B — Element 13 chat messages + Element 11 questions**:
 5. Element 13 chat message framing (`┌ USER │ ... └`, `┌ SUMO · model · time │ ... └`)

--- a/docs/visual/parity/CONTRACT.md
+++ b/docs/visual/parity/CONTRACT.md
@@ -1,0 +1,117 @@
+# V2 Visual Parity Contract
+
+**Status:** active contract for V2 harness work  
+**Owner:** SumoTUI consolidation #99  
+**Related:** `docs/visual/V2_HARNESS_SPEC.md`, `docs/visual/parity/scenarios.json`
+
+This document defines what the V2 Cathedral Visual Harness is allowed to assert. It exists to keep tests, runtime captures, and review packs aligned while SumoCode moves through the hybrid Pi/SumoTUI consolidation phase.
+
+## 1. Sources of truth
+
+1. **Visual Bible targets** (`docs/ui/bible/*.html` → `docs/ui/bible/renders/*.png`) are the design target.
+2. **Scenario manifest** (`docs/visual/parity/scenarios.json`) is the machine-readable capture/crop contract.
+3. **Runtime goldens** (`docs/visual/parity/approved-runtime/**`) are approved implementation checkpoints, not design targets.
+4. **Review packs** (`docs/visual/out/parity/index.html`) are evidence for human review and remain uncommitted artifacts.
+
+If these disagree, update the Bible/manifest first, then regenerate review evidence, then promote a runtime golden only after explicit developer approval.
+
+## 2. Capture engine
+
+The canonical V2 path is:
+
+```txt
+node-pty bytes
+→ @xterm/headless replay
+→ DOM terminal renderer
+→ Playwright screenshot
+→ crop/mask/diff
+→ HTML review pack
+```
+
+`tmux`, cmux/Ghostty screenshots, and live terminal captures are debugging aids only. They must not define CI pass/fail for V2 pixel parity.
+
+Runtime scenarios invoke SumoCode through the user-facing entry contract:
+
+```bash
+./bin/sumocode.sh --offline --no-extensions --no-session
+```
+
+Runtime scenarios must set deterministic terminal env in the manifest (`PI_OFFLINE=1`, `SUMO_TUI=1`, `TERM=xterm-256color`, `COLORTERM=truecolor`, `FORCE_COLOR=3`).
+
+## 3. V2 dimensions and layout constants
+
+The manifest owns scenario dimensions. Current locked V2 dimensions are:
+
+- Component input frame: `160 × 4`
+- Component footer: `160 × 1`
+- Component top bar: `160 × 1`
+- Component sidebar: `30 × 26`
+- Landscape runtime scenes: `160 × 45`
+- Portrait runtime scenes: `60 × 100`
+
+V2 sidebar width is **30 columns**. Legacy 49-column sidebar references are historical V1/mockup material and must not be used for new V2 assertions.
+
+For 160-column full-screen crops, the sidebar crop starts at `x=130` and spans `30` columns. Chat/runtime content should reserve the matching right-side space only when the runtime sidebar policy says the sidebar is visible.
+
+## 4. Input and cursor contract
+
+The active V2 input frame is label-less. Tests and captures must not wait for or assert legacy labels such as:
+
+- `SCRIPTOR INPUT`
+- `INPUT`
+- `INPUT PROTOCOL AWAITING COMMAND`
+
+Splash/empty-state captures may show `DIVINE INVOCATION`; active typed component captures must keep the frame label-less and use the prompt/caret row as the semantic anchor.
+
+Hardware cursor visibility is a Pi/TUI runtime preference. PTY integration tests that assert hardware cursor behavior must opt in with `PI_HARDWARE_CURSOR=1` and wait for the stable post-render cursor state, not the first incidental `?25h` emitted during startup.
+
+Visual parity screenshots should not rely on terminal cursor color. The V2 terminal ownership contract is: terminal cursor color remains the user's preference unless an explicit future SumoCode cursor command changes it. The current hybrid `TerminalController` still contains the older OSC 12 path; #100/P0-C owns moving that behind the single terminal owner so this #99 test/visual contract does not depend on cursor color.
+
+## 5. Crop status semantics
+
+Each crop resolves its status from the crop entry or its parent scenario:
+
+- `review` — compare Bible/runtime/golden where available, report drift, do not fail CI on pixels.
+- `approved` — a runtime golden is present and drift is visible in review packs, but pixel drift remains non-blocking.
+- `required` — a runtime golden is present and drift from that golden fails CI when the threshold is exceeded.
+
+For `required` crops, the runtime golden is the regression gate. Bible diffs remain review evidence until implementation and design converge. Required crops must not be added without a committed approved runtime golden.
+
+Hard failures always fail, regardless of crop status:
+
+- invalid scenario manifest
+- missing Bible target or required runtime golden
+- runtime capture crash
+- known error screen/output rejection
+- blank capture
+- ANSI replay/render failure
+- crop out of bounds
+- malformed result metadata
+
+## 6. Current required runtime goldens
+
+The required V2 crop gates currently are:
+
+- `input-typed-component/input-frame` — threshold `0.03`
+- `footer-ready-component/footer` — threshold `0.04`
+- `top-bar-default-component/top-bar` — threshold `0.08`
+
+Sidebar editorial parity is review-approved by inspection but not yet promoted as a required crop.
+
+## 7. Promotion and review loop
+
+Promotion is human-in-the-loop only:
+
+```bash
+pnpm visual:promote -- --scenario <scenario-id> --crop <crop-id> --status approved
+pnpm visual:promote -- --scenario <scenario-id> --crop <crop-id> --status required
+```
+
+Before promotion, generate and inspect a review pack:
+
+```bash
+pnpm render:bible
+pnpm visual:review -- --scenario <scenario-id>
+```
+
+Use `/bible-verify/` for local visual review when available. Raw review-pack artifacts stay gitignored; only approved runtime goldens and manifest status changes are committed.

--- a/docs/visual/parity/README.md
+++ b/docs/visual/parity/README.md
@@ -2,6 +2,8 @@
 
 Declarative scenario/crop registry and approved runtime goldens for the V2 Cathedral Visual Harness.
 
+Read `CONTRACT.md` first for the authoritative runtime/crop/status semantics.
+
 ## Run
 
 ```bash
@@ -27,6 +29,15 @@ Run one lane:
 pnpm visual:review -- --lane component
 pnpm visual:review -- --lane runtime
 ```
+
+## Contract
+
+- Visual Bible renders are the design target.
+- Runtime goldens are approved implementation checkpoints, not design targets.
+- `required` crops gate against committed runtime goldens after explicit promotion.
+- Legacy V1 labels such as `SCRIPTOR INPUT` and 49-column sidebar assertions are historical only; V2 active input is label-less and the sidebar is 30 columns.
+
+See `CONTRACT.md` for the full contract.
 
 ## Initial runtime scenario note
 

--- a/src/cathedral/cathedral-editor.ts
+++ b/src/cathedral/cathedral-editor.ts
@@ -84,8 +84,8 @@ function withFrameBackground(line: string): string {
 }
 
 /**
- * Build the cathedral top border with an embedded label, e.g.:
- *   ┌─ SCRIPTOR INPUT ────...─────┐
+ * Build the cathedral top border with an optional embedded label. V2 active
+ * input is label-less; splash uses `DIVINE INVOCATION`.
  */
 function renderTopBorder(width: number, label?: string): string {
 	if (width < 6) return withFrameBackground(color("─".repeat(width), CATHEDRAL_TOKENS.colors.divider));

--- a/src/cathedral/input-frame.ts
+++ b/src/cathedral/input-frame.ts
@@ -80,7 +80,7 @@ function padToWidth(line: string, width: number): string {
 }
 
 export type InputFrameOptions = {
-	/** Top-border label, e.g. "SCRIPTOR INPUT" (splash) or "INPUT" (active). */
+	/** Optional top-border label. V2 active input passes an empty label; splash uses "DIVINE INVOCATION". */
 	label?: string;
 	/** Placeholder text shown when input is empty. Splash state only. */
 	placeholder?: string;

--- a/src/visual-parity-contract.test.ts
+++ b/src/visual-parity-contract.test.ts
@@ -1,0 +1,84 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { SIDEBAR_MIN_TERMINAL_WIDTH, SIDEBAR_WIDTH } from "./sidebar.js";
+
+type CropDefinition =
+	| { kind: "full" }
+	| {
+			x: number;
+			y: number;
+			cols: number;
+			rows: number;
+	  };
+
+type ScenarioCrop = {
+	id: string;
+	status?: "review" | "approved" | "required";
+	threshold?: number;
+};
+
+type Scenario = {
+	id: string;
+	status: "review" | "approved" | "required";
+	dimensions: {
+		cols: number;
+		rows: number;
+	};
+	crops: ScenarioCrop[];
+};
+
+type ScenarioManifest = {
+	version: number;
+	crops: Record<string, CropDefinition>;
+	scenarios: Scenario[];
+};
+
+const manifestPath = join(process.cwd(), "docs/visual/parity/scenarios.json");
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8")) as ScenarioManifest;
+
+function scenario(id: string): Scenario {
+	const found = manifest.scenarios.find((item) => item.id === id);
+	if (!found) throw new Error(`Missing visual parity scenario ${id}`);
+	return found;
+}
+
+function cropDefinition(id: string): CropDefinition {
+	const found = manifest.crops[id];
+	if (!found) throw new Error(`Missing visual parity crop ${id}`);
+	return found;
+}
+
+describe("V2 visual parity contract", () => {
+	it("locks the V2 sidebar and scenario dimensions", () => {
+		expect(SIDEBAR_WIDTH).toBe(30);
+		expect(SIDEBAR_MIN_TERMINAL_WIDTH).toBe(120);
+		expect(scenario("input-typed-component").dimensions).toEqual({ cols: 160, rows: 4 });
+		expect(scenario("footer-ready-component").dimensions).toEqual({ cols: 160, rows: 1 });
+		expect(scenario("top-bar-default-component").dimensions).toEqual({ cols: 160, rows: 1 });
+		expect(scenario("sidebar-editorial-component").dimensions).toEqual({ cols: 30, rows: 26 });
+		expect(scenario("splash-runtime").dimensions).toEqual({ cols: 160, rows: 45 });
+		expect(scenario("active-landscape-runtime").dimensions).toEqual({ cols: 160, rows: 45 });
+		expect(scenario("active-portrait-runtime").dimensions).toEqual({ cols: 60, rows: 100 });
+		expect(cropDefinition("sidebar")).toEqual({ x: 130, y: 3, cols: 30, rows: 34 });
+	});
+
+	it("keeps required crop gates backed by committed runtime goldens", () => {
+		const requiredCrops = manifest.scenarios.flatMap((item) =>
+			item.crops
+				.filter((crop) => (crop.status ?? item.status) === "required")
+				.map((crop) => ({ scenarioId: item.id, crop })),
+		);
+
+		expect(requiredCrops.map(({ scenarioId, crop }) => `${scenarioId}/${crop.id}`)).toEqual([
+			"input-typed-component/input-frame",
+			"footer-ready-component/footer",
+			"top-bar-default-component/top-bar",
+		]);
+
+		for (const { scenarioId, crop } of requiredCrops) {
+			const goldenPath = join(process.cwd(), "docs/visual/parity/approved-runtime", scenarioId, `${crop.id}.png`);
+			expect(existsSync(goldenPath), `${scenarioId}/${crop.id} is required but has no golden`).toBe(true);
+		}
+	});
+});

--- a/test/integration/cursor-visibility.test.ts
+++ b/test/integration/cursor-visibility.test.ts
@@ -21,6 +21,15 @@ function latestVisibleCursorColumn(output: string): number | undefined {
 	return latest;
 }
 
+async function waitForCursorVisible(pty: SpawnedPiPty): Promise<void> {
+	const deadline = Date.now() + 10_000;
+	while (Date.now() < deadline) {
+		if (pty.getCurrentTerminalState().cursorVisible) return;
+		await new Promise((resolve) => setTimeout(resolve, 50));
+	}
+	throw new Error(`Timed out waiting for hardware cursor to become visible. Last output: ${JSON.stringify(pty.getOutput().slice(-1200))}`);
+}
+
 async function waitForCursorAdvance(pty: SpawnedPiPty, previousColumn: number, text: string): Promise<number> {
 	const deadline = Date.now() + 5_000;
 	while (Date.now() < deadline) {
@@ -38,6 +47,7 @@ describe("sumo-tui cursor visibility integration", () => {
 		app = spawnPiPty({
 			env: {
 				PI_CODING_AGENT_DIR: agentDir,
+				PI_HARDWARE_CURSOR: "1",
 				SUMO_TUI: "1",
 				SUMO_TUI_HIDE_PI_NOISE: "1",
 				SUMO_TUI_MODULE: pathToFileURL(join(process.cwd(), "sumo-interactive-mode.js")).href,
@@ -45,13 +55,13 @@ describe("sumo-tui cursor visibility integration", () => {
 		});
 
 		await app.waitForOutput(PI_BOOT_SEQUENCE, 10_000);
-		await app.waitForOutput("SCRIPTOR INPUT", 10_000);
-		await app.waitForOutput("\x1b[?25h", 10_000);
+		await app.waitForOutput("DIVINE INVOCATION", 10_000);
+		await waitForCursorVisible(app);
 		expect(app.getCurrentTerminalState().cursorVisible).toBe(true);
 
 		let typed = "";
 		let previousColumn = 0;
-		for (const char of "abcde") {
+		for (const char of "ZQXJW") {
 			typed += char;
 			app.sendInput(char);
 			const nextColumn = await waitForCursorAdvance(app, previousColumn, typed);
@@ -59,5 +69,5 @@ describe("sumo-tui cursor visibility integration", () => {
 			previousColumn = nextColumn;
 			expect(app.getCurrentTerminalState().cursorVisible).toBe(true);
 		}
-	});
+	}, 30_000);
 });


### PR DESCRIPTION
## Summary

- Fix the cursor integration smoke so it waits for V2 `DIVINE INVOCATION` instead of obsolete `SCRIPTOR INPUT` and opts into `PI_HARDWARE_CURSOR=1` before asserting stable hardware-cursor state.
- Add `docs/visual/parity/CONTRACT.md` to define Bible targets vs runtime goldens, review/approved/required crop semantics, V2 dimensions, and the label-less active input contract.
- Add a unit contract test that locks V2 sidebar width, scenario dimensions, and required crop golden presence.
- Mark stale V1 parity-plan/sidebar/input references as historical so new V2 work follows the 30-column sidebar + label-less input contract.

## Verification

- `pnpm test:integration` — 11 files passed, 14 tests passed
- `pnpm visual:ci` — passed; review-only scenarios reported as review, required gates did not fail
- `pnpm test` — 69 files passed, 401 tests passed
- `pnpm exec tsc --noEmit && pnpm build` — passed

Closes #99
