### PR TITLE
feat(runtime): add terminal session owner

### DIFF
--- a/docs/SUMO_TUI_AUDIT.md
+++ b/docs/SUMO_TUI_AUDIT.md
@@ -3,6 +3,8 @@
 > Scope: current `sumocode` worktree, `src/sumo-tui/**`, Cathedral runtime/UI code, SumoTUI research docs, V2 visual spec, and a quick survey of other production TUI frameworks.
 >
 > Revision log: v1 (2026-04-29) → v2 (2026-04-29, post-review). v2 leads with the spine, adds effort buckets, promotes the Pi-patch question to P0, names a fallback product, picks one app-model direction, and adds a decision section for in-flight V2 UI work.
+>
+> Post-#100 note: P0-C introduced `TerminalSessionOwner`, shared it across lifecycle/runtime startup, and moved OSC 12 cursor color behind an explicit opt-in hook. Findings below that mention duplicate terminal owners or unconditional OSC 12 describe the pre-#100 state.
 
 ---
 

--- a/docs/visual/parity/CONTRACT.md
+++ b/docs/visual/parity/CONTRACT.md
@@ -65,7 +65,7 @@ Splash/empty-state captures may show `DIVINE INVOCATION`; active typed component
 
 Hardware cursor visibility is a Pi/TUI runtime preference. PTY integration tests that assert hardware cursor behavior must opt in with `PI_HARDWARE_CURSOR=1` and wait for the stable post-render cursor state, not the first incidental `?25h` emitted during startup.
 
-Visual parity screenshots should not rely on terminal cursor color. The V2 terminal ownership contract is: terminal cursor color remains the user's preference unless an explicit future SumoCode cursor command changes it. The current hybrid `TerminalController` still contains the older OSC 12 path; #100/P0-C owns moving that behind the single terminal owner so this #99 test/visual contract does not depend on cursor color.
+Visual parity screenshots should not rely on terminal cursor color. The V2 terminal ownership contract is: terminal cursor color remains the user's preference unless an explicit future SumoCode cursor command changes it. `TerminalSessionOwner` therefore does not emit OSC 12 during normal startup; cursor color overrides are opt-in only.
 
 ## 5. Crop status semantics
 

--- a/src/commands/cursor.test.ts
+++ b/src/commands/cursor.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerCursorCommand } from "./cursor.js";
+import { CURSOR_COLOR_RESET, CURSOR_COLOR_SET, TerminalSessionOwner, type TerminalOutput } from "../sumo-tui/runtime/terminal-controller.js";
+
+function outputStub(): TerminalOutput & { writes: string[] } {
+	return {
+		isTTY: true,
+		writes: [],
+		write(data: string) {
+			this.writes.push(data);
+			return true;
+		},
+	};
+}
+
+describe("registerCursorCommand", () => {
+	it("registers /sumo:cursor on the pi API", () => {
+		const registerCommand = vi.fn();
+		registerCursorCommand({ registerCommand } as never, new TerminalSessionOwner({ output: outputStub() }));
+		expect(registerCommand).toHaveBeenCalledWith(
+			"sumo:cursor",
+			expect.objectContaining({ description: expect.any(String), handler: expect.any(Function) }),
+		);
+	});
+
+	it("/sumo:cursor accent explicitly sets OSC 12", async () => {
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+		let handler: ((args: string, ctx: never) => Promise<void>) | undefined;
+		const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
+			handler = options.handler;
+		});
+		const notify = vi.fn();
+
+		registerCursorCommand({ registerCommand } as never, terminal);
+		await handler!("accent", { hasUI: true, ui: { notify } } as never);
+
+		expect(output.writes).toEqual([CURSOR_COLOR_SET]);
+		expect(terminal.getState().cursorColorOverridden).toBe(true);
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("accent"), "info");
+	});
+
+	it("/sumo:cursor reset restores the terminal default cursor color", async () => {
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+		let handler: ((args: string, ctx: never) => Promise<void>) | undefined;
+		const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
+			handler = options.handler;
+		});
+		const notify = vi.fn();
+
+		registerCursorCommand({ registerCommand } as never, terminal);
+		await handler!("accent", { hasUI: true, ui: { notify } } as never);
+		await handler!("reset", { hasUI: true, ui: { notify } } as never);
+
+		expect(output.writes).toEqual([CURSOR_COLOR_SET, CURSOR_COLOR_RESET]);
+		expect(terminal.getState().cursorColorOverridden).toBe(false);
+		expect(notify).toHaveBeenLastCalledWith(expect.stringContaining("terminal default"), "info");
+	});
+
+	it("/sumo:cursor status reports without changing OSC state", async () => {
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+		let handler: ((args: string, ctx: never) => Promise<void>) | undefined;
+		const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
+			handler = options.handler;
+		});
+		const notify = vi.fn();
+
+		registerCursorCommand({ registerCommand } as never, terminal);
+		await handler!("", { hasUI: true, ui: { notify } } as never);
+
+		expect(output.writes).toEqual([]);
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("terminal default"), "info");
+	});
+});

--- a/src/commands/cursor.ts
+++ b/src/commands/cursor.ts
@@ -1,0 +1,46 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { defaultTerminalSessionOwner, type TerminalSessionOwner } from "../sumo-tui/runtime/terminal-controller.js";
+
+export type CursorCommandMode = "accent" | "reset" | "status";
+
+function normalizeCursorCommand(args: string): CursorCommandMode | undefined {
+	const value = args.trim().toLowerCase();
+	if (value === "" || value === "status") return "status";
+	if (["accent", "orange", "cathedral"].includes(value)) return "accent";
+	if (["reset", "default", "system"].includes(value)) return "reset";
+	return undefined;
+}
+
+function report(ctx: ExtensionContext, message: string, level: "info" | "warning" = "info"): void {
+	if (!ctx.hasUI) {
+		process.stdout.write(`${message}\n`);
+		return;
+	}
+	ctx.ui.notify(message, level);
+}
+
+/** Register `/sumo:cursor accent|reset|status` for explicit cursor color overrides. */
+export function registerCursorCommand(pi: ExtensionAPI, terminalSession: TerminalSessionOwner = defaultTerminalSessionOwner): void {
+	pi.registerCommand("sumo:cursor", {
+		description: "Explicitly set or reset the terminal cursor color",
+		handler: async (args: string, ctx: ExtensionContext) => {
+			const mode = normalizeCursorCommand(args);
+			if (mode === "accent") {
+				terminalSession.setCursorColor();
+				report(ctx, "cursor color: cathedral accent", "info");
+				return;
+			}
+			if (mode === "reset") {
+				terminalSession.resetCursorColor();
+				report(ctx, "cursor color: terminal default", "info");
+				return;
+			}
+			if (mode === "status") {
+				const state = terminalSession.getState();
+				report(ctx, `cursor color: ${state.cursorColorOverridden ? "cathedral accent" : "terminal default"}`, "info");
+				return;
+			}
+			report(ctx, "usage: /sumo:cursor accent|reset|status", "warning");
+		},
+	});
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installInputHints } from "./cathedral/input-hints.js";
+import { registerCursorCommand } from "./commands/cursor.js";
 import { registerPersonaCommand } from "./commands/persona.js";
 import { registerSpinnerCommand } from "./commands/spinner.js";
 import { registerTabsCommand } from "./commands/tabs.js";
@@ -109,6 +110,7 @@ export default function sumocode(pi: ExtensionAPI): void {
 	// installApprovalGate(pi); // disabled — see import comment above
 	installSidebar(pi);
 	installWorkingIndicator(pi);
+	registerCursorCommand(pi);
 	registerPersonaCommand(pi);
 	registerSpinnerCommand(pi);
 	registerTabsCommand(pi);

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
@@ -11,7 +11,7 @@ import {
 } from "./sumo-interactive-mode.js";
 import { installChatViewportBridge } from "./chat-viewport-controller.js";
 import { defaultSplashSnapshot, getSplashContentHeight } from "../cathedral/splash-tree.js";
-import { ALTSCREEN_ENTER_SEQUENCE, MOUSE_SGR_ENABLE_SEQUENCE } from "../runtime/terminal-controller.js";
+import { ALTSCREEN_ENTER_SEQUENCE, MOUSE_SGR_ENABLE_SEQUENCE, TerminalSessionOwner } from "../runtime/terminal-controller.js";
 
 const ANSI_PATTERN = /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\)|_[^\x07]*(?:\x07|\x1b\\))/g;
 
@@ -94,6 +94,21 @@ describe("sumo interactive Pi noise filtering", () => {
 		const output = write.mock.calls.map(([chunk]) => String(chunk)).join("");
 		expect(output).toContain(ALTSCREEN_ENTER_SEQUENCE);
 		expect(output).toContain(MOUSE_SGR_ENABLE_SEQUENCE);
+		runtime.stop();
+	});
+
+	it("shares the terminal owner with lifecycle startup without duplicate mode writes", async () => {
+		const write = vi.fn();
+		const output = { isTTY: true, columns: 100, rows: 30, write };
+		const terminal = new TerminalSessionOwner({ output });
+		terminal.startRetainedSession();
+		const runtime = new SumoInteractiveRuntime(output, terminal);
+
+		await runtime.start();
+
+		const written = write.mock.calls.map(([chunk]) => String(chunk)).join("");
+		expect(written.match(/\x1b\[\?1049h/g) ?? []).toHaveLength(1);
+		expect(written.match(/\x1b\[\?1000h\x1b\[\?1006h/g) ?? []).toHaveLength(1);
 		runtime.stop();
 	});
 

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -39,7 +39,7 @@ import { CellBuffer } from "../render/buffer.js";
 import { composite } from "../render/compositor.js";
 import { diffFrames } from "../render/diff.js";
 import { FrameScheduler } from "../runtime/frame-scheduler.js";
-import { TerminalController } from "../runtime/terminal-controller.js";
+import { defaultTerminalSessionOwner, TerminalSessionOwner, type TerminalOutput } from "../runtime/terminal-controller.js";
 import { ChatPager } from "../widgets/chat-pager.js";
 import { SIDEBAR_MIN_TERMINAL_WIDTH } from "../../sidebar.js";
 import { installChatViewportBridge } from "./chat-viewport-controller.js";
@@ -77,11 +77,9 @@ export interface CreateExtensionUIContextOptions extends SumoExtensionUIAdapterO
 	readonly foreignExtensions?: ForeignAwareUIOptions;
 }
 
-interface TerminalLike {
-	readonly isTTY?: boolean;
+interface TerminalLike extends TerminalOutput {
 	readonly columns?: number;
 	readonly rows?: number;
-	write(data: string): unknown;
 }
 
 interface SumoInteractiveRuntimeSnapshot {
@@ -108,7 +106,7 @@ function debugLog(message: string): void {
  */
 export class SumoInteractiveRuntime {
 	private readonly output: TerminalLike;
-	private readonly terminal: TerminalController;
+	private readonly terminal: TerminalSessionOwner;
 	private yoga: Yoga | undefined;
 	private root: SumoNode | undefined;
 	private chat: ChatPager | undefined;
@@ -128,9 +126,9 @@ export class SumoInteractiveRuntime {
 	private emptyChatUserMessageCount = 0;
 	private started = false;
 
-	public constructor(output: TerminalLike = process.stdout) {
+	public constructor(output: TerminalLike = process.stdout, terminalSession?: TerminalSessionOwner) {
 		this.output = output;
-		this.terminal = new TerminalController({ output });
+		this.terminal = terminalSession ?? (output === process.stdout ? defaultTerminalSessionOwner : new TerminalSessionOwner({ output }));
 	}
 
 	public async start(): Promise<SumoInteractiveRuntimeSnapshot> {

--- a/src/sumo-tui/runtime/lifecycle.test.ts
+++ b/src/sumo-tui/runtime/lifecycle.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { createLifecycleRuntime, useTerminalDimensions, type LifecycleInput, type LifecycleListener, type LifecycleProcess, type LifecycleProcessEvent, type LifecycleSignal } from "./lifecycle.js";
-import { ALTSCREEN_ENTER_SEQUENCE, CURSOR_COLOR_RESET, CURSOR_COLOR_SET, MOUSE_SGR_ENABLE_SEQUENCE, TERMINAL_BG_RESET, TERMINAL_BG_SET, TERMINAL_CLEANUP_SEQUENCE, TerminalController, type TerminalOutput } from "./terminal-controller.js";
+import { ALTSCREEN_ENTER_SEQUENCE, MOUSE_SGR_ENABLE_SEQUENCE, TERMINAL_BG_RESET, TERMINAL_BG_SET, TERMINAL_CLEANUP_SEQUENCE, TerminalSessionOwner, type TerminalOutput } from "./terminal-controller.js";
 
 class FakeProcess implements LifecycleProcess {
 	public readonly pid = 4242;
@@ -117,7 +117,7 @@ describe("LifecycleRuntime", () => {
 	it("registers process signal handlers exactly once", () => {
 		const fakeProcess = new FakeProcess();
 		const output = outputStub();
-		const runtime = createLifecycleRuntime({ process: fakeProcess, controller: new TerminalController({ output }) });
+		const runtime = createLifecycleRuntime({ process: fakeProcess, terminalSession: new TerminalSessionOwner({ output }) });
 
 		runtime.installProcessHandlers();
 		runtime.installProcessHandlers();
@@ -132,7 +132,7 @@ describe("LifecycleRuntime", () => {
 	it("installLifecycle wires session_start and session_shutdown through the controller", () => {
 		const fakeProcess = new FakeProcess();
 		const output = outputStub();
-		const runtime = createLifecycleRuntime({ process: fakeProcess, controller: new TerminalController({ output }) });
+		const runtime = createLifecycleRuntime({ process: fakeProcess, terminalSession: new TerminalSessionOwner({ output }) });
 		const { pi, handlers } = buildPiStub();
 
 		runtime.installLifecycle(pi);
@@ -143,13 +143,13 @@ describe("LifecycleRuntime", () => {
 			handler({ type: "session_shutdown" }, { hasUI: true });
 		}
 
-		expect(output.writes).toEqual([`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}${CURSOR_COLOR_SET}`, MOUSE_SGR_ENABLE_SEQUENCE, `${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`]);
+		expect(output.writes).toEqual([`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`, MOUSE_SGR_ENABLE_SEQUENCE, `${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`]);
 	});
 
 	it("session_start ignores non-UI contexts", () => {
 		const fakeProcess = new FakeProcess();
 		const output = outputStub();
-		const runtime = createLifecycleRuntime({ process: fakeProcess, controller: new TerminalController({ output }) });
+		const runtime = createLifecycleRuntime({ process: fakeProcess, terminalSession: new TerminalSessionOwner({ output }) });
 		const { pi, handlers } = buildPiStub();
 
 		runtime.installLifecycle(pi);
@@ -163,24 +163,24 @@ describe("LifecycleRuntime", () => {
 	it("cleanup runs once even if called twice", () => {
 		const fakeProcess = new FakeProcess();
 		const output = outputStub();
-		const runtime = createLifecycleRuntime({ process: fakeProcess, controller: new TerminalController({ output }) });
+		const runtime = createLifecycleRuntime({ process: fakeProcess, terminalSession: new TerminalSessionOwner({ output }) });
 
 		runtime.restoreTerminal();
 		runtime.restoreTerminal();
 
-		expect(output.writes).toEqual([`${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`]);
+		expect(output.writes).toEqual([TERMINAL_CLEANUP_SEQUENCE]);
 	});
 
 	it("SIGINT restores once, unregisters itself, and re-raises (EC-5.1)", () => {
 		const fakeProcess = new FakeProcess();
 		const output = outputStub();
-		const runtime = createLifecycleRuntime({ process: fakeProcess, controller: new TerminalController({ output }) });
+		const runtime = createLifecycleRuntime({ process: fakeProcess, terminalSession: new TerminalSessionOwner({ output }) });
 
 		runtime.installProcessHandlers();
 		fakeProcess.emit("SIGINT");
 		fakeProcess.emit("SIGINT");
 
-		expect(output.writes).toEqual([`${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`]);
+		expect(output.writes).toEqual([TERMINAL_CLEANUP_SEQUENCE]);
 		expect(fakeProcess.kills).toEqual([{ pid: fakeProcess.pid, signal: "SIGINT" }]);
 		expect(fakeProcess.listenerCount("SIGINT")).toBe(0);
 	});
@@ -189,13 +189,13 @@ describe("LifecycleRuntime", () => {
 		const fakeProcess = new FakeProcess();
 		const fakeInput = new FakeInput();
 		const output = outputStub();
-		const runtime = createLifecycleRuntime({ process: fakeProcess, input: fakeInput, controller: new TerminalController({ output }) });
+		const runtime = createLifecycleRuntime({ process: fakeProcess, input: fakeInput, terminalSession: new TerminalSessionOwner({ output }) });
 
 		runtime.installProcessHandlers();
 		fakeProcess.emit("SIGTSTP");
 		fakeProcess.emit("SIGCONT");
 
-		expect(output.writes).toEqual([`${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`, `${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}${CURSOR_COLOR_SET}`, MOUSE_SGR_ENABLE_SEQUENCE]);
+		expect(output.writes).toEqual([TERMINAL_CLEANUP_SEQUENCE, `${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`, MOUSE_SGR_ENABLE_SEQUENCE]);
 		expect(fakeInput.rawModes).toEqual([false, true]);
 		expect(fakeProcess.kills).toEqual([{ pid: fakeProcess.pid, signal: "SIGTSTP" }]);
 		expect(fakeProcess.listenerCount("SIGTSTP")).toBe(1);
@@ -205,14 +205,14 @@ describe("LifecycleRuntime", () => {
 		const fakeProcess = new FakeProcess();
 		const fakeInput = new FakeInput();
 		const output = outputStub();
-		const runtime = createLifecycleRuntime({ process: fakeProcess, input: fakeInput, controller: new TerminalController({ output }) });
+		const runtime = createLifecycleRuntime({ process: fakeProcess, input: fakeInput, terminalSession: new TerminalSessionOwner({ output }) });
 
 		runtime.installProcessHandlers();
 		fakeInput.emit("\x03");
 
 		expect(fakeInput.listenerCount()).toBe(1);
 		expect(fakeInput.rawModes).toEqual([false]);
-		expect(output.writes).toEqual([`${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`]);
+		expect(output.writes).toEqual([TERMINAL_CLEANUP_SEQUENCE]);
 		expect(fakeProcess.exits).toEqual([130]);
 	});
 
@@ -222,7 +222,7 @@ describe("LifecycleRuntime", () => {
 		const tmpHome = await mkdtemp(join(tmpdir(), "sumocode-crash-"));
 		const runtime = createLifecycleRuntime({
 			process: fakeProcess,
-			controller: new TerminalController({ output }),
+			terminalSession: new TerminalSessionOwner({ output }),
 			homeDir: () => tmpHome,
 		});
 		const error = new Error("phase 1 crash proof");
@@ -231,7 +231,7 @@ describe("LifecycleRuntime", () => {
 		expect(() => fakeProcess.emit("uncaughtException", error)).toThrow(error);
 
 		const crashLog = join(tmpHome, ".sumocode", "crash.log");
-		expect(output.writes).toEqual([`${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`]);
+		expect(output.writes).toEqual([TERMINAL_CLEANUP_SEQUENCE]);
 		expect(existsSync(crashLog)).toBe(true);
 		expect(readFileSync(crashLog, "utf8")).toContain("phase 1 crash proof");
 	});

--- a/src/sumo-tui/runtime/lifecycle.ts
+++ b/src/sumo-tui/runtime/lifecycle.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { instrumentPiEventEmitter, logDiagnostic } from "./diagnostics.js";
 import { FrameScheduler, type FrameRenderCallback } from "./frame-scheduler.js";
-import { TerminalController } from "./terminal-controller.js";
+import { defaultTerminalSessionOwner, TerminalSessionOwner } from "./terminal-controller.js";
 
 export type LifecycleSignal = "SIGINT" | "SIGTERM" | "SIGHUP" | "SIGQUIT" | "SIGTSTP" | "SIGCONT";
 export type LifecycleProcessEvent = LifecycleSignal | "exit" | "uncaughtException";
@@ -47,7 +47,7 @@ export interface LifecycleRenderControls {
 }
 
 export interface LifecycleRuntimeOptions {
-	readonly controller?: TerminalController;
+	readonly terminalSession?: TerminalSessionOwner;
 	readonly process?: LifecycleProcess;
 	readonly input?: LifecycleInput;
 	readonly scheduler?: FrameScheduler;
@@ -120,7 +120,7 @@ export function useTerminalDimensions(
  * the Phase 1 crash-recovery requirement.
  */
 export class LifecycleRuntime {
-	private readonly controller: TerminalController;
+	private readonly terminalSession: TerminalSessionOwner;
 	private readonly lifecycleProcess: LifecycleProcess;
 	private readonly input: LifecycleInput | undefined;
 	private readonly scheduler: FrameScheduler;
@@ -133,7 +133,7 @@ export class LifecycleRuntime {
 	private readonly signalHandlers = new Map<LifecycleSignal, LifecycleListener>();
 
 	public constructor(options: LifecycleRuntimeOptions = {}) {
-		this.controller = options.controller ?? new TerminalController();
+		this.terminalSession = options.terminalSession ?? defaultTerminalSessionOwner;
 		this.lifecycleProcess = options.process ?? getNodeProcess();
 		this.input = options.input ?? getNodeInput();
 		this.scheduler = options.scheduler ?? new FrameScheduler({ render: options.render ?? (() => undefined) });
@@ -154,8 +154,7 @@ export class LifecycleRuntime {
 			// mode here or stdin stays line-buffered and mouse bytes (which have
 			// no newline) sit in the kernel buffer until the user presses Enter.
 			this.acquireRawMode();
-			this.controller.enterAltscreen();
-			this.controller.enableMouseSGR();
+			this.terminalSession.startRetainedSession();
 		});
 
 		pi.on("session_shutdown", () => {
@@ -209,7 +208,7 @@ export class LifecycleRuntime {
 
 	public restoreTerminal(): void {
 		this.releaseRawMode();
-		this.controller.exitTerminal();
+		this.terminalSession.exitTerminal();
 	}
 
 	private registerReraisingSignal(signal: (typeof EXIT_SIGNALS)[number]): void {
@@ -257,8 +256,7 @@ export class LifecycleRuntime {
 			logDiagnostic("process_event", { name: "SIGCONT" });
 			this.suspended = false;
 			this.acquireRawMode();
-			this.controller.enterAltscreen();
-			this.controller.enableMouseSGR();
+			this.terminalSession.startRetainedSession();
 			this.registerSuspendSignal();
 		};
 		this.signalHandlers.set("SIGCONT", handler);

--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -7,7 +7,7 @@ import {
 	TERMINAL_BG_RESET,
 	TERMINAL_BG_SET,
 	TERMINAL_CLEANUP_SEQUENCE,
-	TerminalController,
+	TerminalSessionOwner,
 	type TerminalOutput,
 } from "./terminal-controller.js";
 
@@ -22,31 +22,68 @@ function outputStub(isTTY = true): TerminalOutput & { writes: string[] } {
 	};
 }
 
-describe("TerminalController", () => {
-	it("startRetainedSession owns altscreen and mouse mode startup", () => {
+describe("TerminalSessionOwner", () => {
+	it("startRetainedSession owns altscreen and mouse mode startup without overriding cursor color", () => {
 		const output = outputStub();
-		const controller = new TerminalController({ output });
+		const terminal = new TerminalSessionOwner({ output });
 
-		controller.startRetainedSession();
+		terminal.startRetainedSession();
 
-		expect(output.writes).toEqual([`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}${CURSOR_COLOR_SET}`, MOUSE_SGR_ENABLE_SEQUENCE]);
+		expect(output.writes).toEqual([`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`, MOUSE_SGR_ENABLE_SEQUENCE]);
+		expect(output.writes.join("")).not.toContain(CURSOR_COLOR_SET);
+		expect(terminal.getState()).toMatchObject({
+			altscreenActive: true,
+			mouseSGREnabled: true,
+			backgroundPainted: true,
+			cursorColorOverridden: false,
+			restored: false,
+		});
 	});
 
-	it("enterAltscreen emits altscreen bytes followed by cathedral cursor color", () => {
+	it("suppresses duplicate retained lifecycle requests until cleanup", () => {
 		const output = outputStub();
-		const controller = new TerminalController({ output });
+		const terminal = new TerminalSessionOwner({ output });
 
-		controller.enterAltscreen();
+		terminal.startRetainedSession();
+		terminal.startRetainedSession();
+		terminal.enterAltscreen();
+		terminal.enableMouseSGR();
 
-		expect(output.writes).toEqual([`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}${CURSOR_COLOR_SET}`]);
-		expect(output.writes[0]).toBe("\x1b[?1049h\x1b[?25h\x1b[H\x1b]11;#1A1511\x1b\\\x1b]12;#D97706\x1b\\");
+		expect(output.writes).toEqual([`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`, MOUSE_SGR_ENABLE_SEQUENCE]);
+	});
+
+	it("enterAltscreen emits altscreen bytes and terminal background only", () => {
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+
+		terminal.enterAltscreen();
+
+		expect(output.writes).toEqual([`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`]);
+		expect(output.writes[0]).toBe("\x1b[?1049h\x1b[?25h\x1b[H\x1b]11;#1A1511\x1b\\");
+		expect(output.writes[0]).not.toContain("\x1b]12;");
+	});
+
+	it("explicit cursor color overrides are opt-in and reset on cleanup", () => {
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+
+		terminal.startRetainedSession();
+		terminal.setCursorColor();
+		terminal.exitTerminal();
+
+		expect(output.writes).toEqual([
+			`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`,
+			MOUSE_SGR_ENABLE_SEQUENCE,
+			CURSOR_COLOR_SET,
+			`${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`,
+		]);
 	});
 
 	it("enableMouseSGR emits click/wheel SGR bytes without any-event motion tracking", () => {
 		const output = outputStub();
-		const controller = new TerminalController({ output });
+		const terminal = new TerminalSessionOwner({ output });
 
-		controller.enableMouseSGR();
+		terminal.enableMouseSGR();
 
 		expect(output.writes).toEqual([MOUSE_SGR_ENABLE_SEQUENCE]);
 		expect(output.writes[0]).toBe("\x1b[?1000h\x1b[?1006h");
@@ -54,71 +91,78 @@ describe("TerminalController", () => {
 
 	it("writes absolute chat viewport rows behind the terminal ownership seam", () => {
 		const output = outputStub();
-		const controller = new TerminalController({ output });
+		const terminal = new TerminalSessionOwner({ output });
 
-		expect(controller.writeChatViewport(2, 3, ["one", "two"])).toBe(true);
+		expect(terminal.writeChatViewport(2, 3, ["one", "two"])).toBe(true);
 
 		expect(output.writes).toEqual(["\x1b[?2026h\x1b7\x1b[3;4Hone\x1b[4;4Htwo\x1b8\x1b[?2026l"]);
 	});
 
 	it("writes full-frame patches and hardware cursor behind the terminal ownership seam", () => {
 		const output = outputStub();
-		const controller = new TerminalController({ output });
+		const terminal = new TerminalSessionOwner({ output });
 
-		controller.writeFramePatches([{ row: 1, ansi: "hello" }], { row: 2, col: 4 });
+		terminal.writeFramePatches([{ row: 1, ansi: "hello" }], { row: 2, col: 4 });
 
 		expect(output.writes).toEqual(["\x1b[?2026h\x1b[2;1Hhello\x1b[K\x1b[3;5H\x1b[?25h\x1b[?2026l"]);
 	});
 
-	it("exitTerminal resets cursor color before the full cleanup bytes (EC-5.1)", () => {
+	it("exitTerminal emits cleanup without cursor or bg reset when retained mode was never entered", () => {
 		const output = outputStub();
-		const controller = new TerminalController({ output });
+		const terminal = new TerminalSessionOwner({ output });
 
-		controller.exitTerminal();
+		terminal.exitTerminal();
 
-		expect(output.writes).toEqual([`${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`]);
-		expect(output.writes[0]).toBe("\x1b]112\x1b\\\x1b]111\x1b\\\x1b[<u\x1b[>4;0m\x1b[?2004l\x1b[?1003l\x1b[?1006l\x1b[?1000l\x1b[?1049l\x1b[?25h\x1b[0m");
-		expect(controller.restored).toBe(true);
+		expect(output.writes).toEqual([TERMINAL_CLEANUP_SEQUENCE]);
+		expect(output.writes[0]).toBe("\x1b[<u\x1b[>4;0m\x1b[?2004l\x1b[?1003l\x1b[?1006l\x1b[?1000l\x1b[?1049l\x1b[?25h\x1b[0m");
+		expect(output.writes[0]).not.toContain("\x1b]12;");
+		expect(output.writes[0]).not.toContain(CURSOR_COLOR_RESET);
+		expect(terminal.restored).toBe(true);
+	});
+
+	it("exitTerminal restores bg after retained mode was active", () => {
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+
+		terminal.startRetainedSession();
+		terminal.exitTerminal();
+
+		expect(output.writes).toEqual([`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`, MOUSE_SGR_ENABLE_SEQUENCE, `${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`]);
 	});
 
 	it("double cleanup is a no-op after the restored flag is set", () => {
 		const output = outputStub();
-		const controller = new TerminalController({ output });
+		const terminal = new TerminalSessionOwner({ output });
 
-		controller.exitTerminal();
-		controller.exitTerminal();
+		terminal.exitTerminal();
+		terminal.exitTerminal();
 
-		expect(output.writes).toEqual([`${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`]);
+		expect(output.writes).toEqual([TERMINAL_CLEANUP_SEQUENCE]);
 	});
 
 	it("re-entering terminal modes clears the restored flag for the next cleanup", () => {
 		const output = outputStub();
-		const controller = new TerminalController({ output });
+		const terminal = new TerminalSessionOwner({ output });
 
-		controller.exitTerminal();
-		controller.enterAltscreen();
-		controller.enableMouseSGR();
-		controller.exitTerminal();
+		terminal.exitTerminal();
+		terminal.enterAltscreen();
+		terminal.enableMouseSGR();
+		terminal.exitTerminal();
 
-		expect(output.writes).toEqual([
-			`${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`,
-			`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}${CURSOR_COLOR_SET}`,
-			MOUSE_SGR_ENABLE_SEQUENCE,
-			`${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`,
-		]);
+		expect(output.writes).toEqual([TERMINAL_CLEANUP_SEQUENCE, `${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`, MOUSE_SGR_ENABLE_SEQUENCE, `${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`]);
 	});
 
 	it("isTTY=false skips enter and cleanup writes gracefully (EC-10.1)", () => {
 		const output = outputStub(false);
-		const controller = new TerminalController({ output });
+		const terminal = new TerminalSessionOwner({ output });
 
-		controller.enterAltscreen();
-		controller.enableMouseSGR();
-		controller.exitTerminal();
+		terminal.enterAltscreen();
+		terminal.enableMouseSGR();
+		terminal.exitTerminal();
 
-		expect(controller.isTTY()).toBe(false);
+		expect(terminal.isTTY()).toBe(false);
 		expect(output.writes).toEqual([]);
-		expect(controller.restored).toBe(true);
+		expect(terminal.restored).toBe(true);
 	});
 
 	it("catches EPIPE silently and suppresses later writes (EC-5.5)", () => {
@@ -128,12 +172,12 @@ describe("TerminalController", () => {
 			throw error;
 		});
 		const output: TerminalOutput = { isTTY: true, write };
-		const controller = new TerminalController({ output });
+		const terminal = new TerminalSessionOwner({ output });
 
-		expect(() => controller.exitTerminal()).not.toThrow();
-		controller.enterAltscreen();
+		expect(() => terminal.exitTerminal()).not.toThrow();
+		terminal.enterAltscreen();
 
 		expect(write).toHaveBeenCalledTimes(1);
-		expect(controller.restored).toBe(false);
+		expect(terminal.restored).toBe(false);
 	});
 });

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -1,5 +1,5 @@
 /**
- * Terminal lifecycle controller for sumo-tui Phase 1.
+ * Terminal lifecycle owner for sumo-tui.
  *
  * The sequence choices are taken from the accepted sumo-tui ADR and Phase 1
  * plan, which in turn follow the OpenCode/OpenTUI pattern of application-owned
@@ -51,29 +51,64 @@ export interface TerminalPatch {
 	readonly ansi: string;
 }
 
-export interface TerminalControllerOptions {
+export interface TerminalSessionOwnerOptions {
 	readonly output?: TerminalOutput;
+	/** Paint the terminal default bg via OSC 11 while retained mode is active. */
+	readonly paintBackground?: boolean;
+}
+
+export interface TerminalSessionOwnerState {
+	readonly altscreenActive: boolean;
+	readonly mouseSGREnabled: boolean;
+	readonly backgroundPainted: boolean;
+	readonly cursorColorOverridden: boolean;
+	readonly restored: boolean;
 }
 
 function isBrokenPipeError(error: unknown): boolean {
 	return typeof error === "object" && error !== null && "code" in error && (error as { code?: unknown }).code === "EPIPE";
 }
 
+function cursorColorSetSequence(hex: string): string {
+	return `\x1b]12;${hex}\x1b\\`;
+}
+
 /**
- * Owns the byte-level terminal mode transitions for sumo-tui.
+ * Single state machine for retained terminal lifecycle.
+ *
+ * It owns altscreen, mouse mode, terminal background paint, explicit cursor
+ * color overrides, and cleanup. Multiple callers may request retained mode
+ * (the Pi lifecycle shim and the retained runtime currently both do during the
+ * hybrid phase), but duplicate writes are suppressed until cleanup runs.
  */
-export class TerminalController {
+export class TerminalSessionOwner {
 	public restored = false;
 	private readonly output: TerminalOutput;
+	private readonly paintBackground: boolean;
 	private brokenPipe = false;
+	private altscreenActive = false;
+	private mouseSGREnabled = false;
+	private backgroundPainted = false;
+	private cursorColorOverridden = false;
 
-	public constructor(options: TerminalControllerOptions = {}) {
+	public constructor(options: TerminalSessionOwnerOptions = {}) {
 		this.output = options.output ?? process.stdout;
+		this.paintBackground = options.paintBackground ?? true;
 	}
 
 	/** Edge case 10.1: no-op terminal ownership when stdout is not a TTY. */
 	public isTTY(): boolean {
 		return this.output.isTTY === true;
+	}
+
+	public getState(): TerminalSessionOwnerState {
+		return {
+			altscreenActive: this.altscreenActive,
+			mouseSGREnabled: this.mouseSGREnabled,
+			backgroundPainted: this.backgroundPainted,
+			cursorColorOverridden: this.cursorColorOverridden,
+			restored: this.restored,
+		};
 	}
 
 	public startRetainedSession(): void {
@@ -82,18 +117,38 @@ export class TerminalController {
 	}
 
 	public enterAltscreen(): void {
-		if (!this.isTTY()) return;
+		if (!this.isTTY() || this.altscreenActive) return;
 		this.restored = false;
-		// Order matters: enter altscreen first, set terminal-wide bg before any
-		// content writes so empty regions read as cathedral bg, then set cursor
-		// color so the input caret is accent orange.
-		this.write(`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}${CURSOR_COLOR_SET}`);
+		let output = ALTSCREEN_ENTER_SEQUENCE;
+		if (this.paintBackground) {
+			output += TERMINAL_BG_SET;
+			this.backgroundPainted = true;
+		}
+		// V2 contract: do not emit OSC 12 cursor color during normal startup.
+		this.write(output);
+		this.altscreenActive = true;
 	}
 
 	public enableMouseSGR(): void {
-		if (!this.isTTY()) return;
+		if (!this.isTTY() || this.mouseSGREnabled) return;
 		this.restored = false;
 		this.write(MOUSE_SGR_ENABLE_SEQUENCE);
+		this.mouseSGREnabled = true;
+	}
+
+	/** Explicit cursor-color override hook for `/sumo:cursor accent`. */
+	public setCursorColor(hex = "#D97706"): void {
+		if (!this.isTTY()) return;
+		this.restored = false;
+		this.write(cursorColorSetSequence(hex));
+		this.cursorColorOverridden = true;
+	}
+
+	/** Explicit cursor-color reset hook for `/sumo:cursor reset`. */
+	public resetCursorColor(): void {
+		if (!this.isTTY()) return;
+		this.write(CURSOR_COLOR_RESET);
+		this.cursorColorOverridden = false;
 	}
 
 	public writeChatViewport(top: number, left: number, lines: readonly string[]): boolean {
@@ -128,10 +183,18 @@ export class TerminalController {
 	public exitTerminal(): void {
 		if (this.restored) return;
 		this.restored = true;
+		const shouldResetCursorColor = this.cursorColorOverridden;
+		const shouldResetBackground = this.backgroundPainted;
+		this.altscreenActive = false;
+		this.mouseSGREnabled = false;
+		this.backgroundPainted = false;
+		this.cursorColorOverridden = false;
 		if (!this.isTTY()) return;
-		// Reset cursor + bg colors before the rest of the cleanup so the user's
-		// shell returns to its native palette.
-		this.write(`${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`);
+		let output = "";
+		if (shouldResetCursorColor) output += CURSOR_COLOR_RESET;
+		if (shouldResetBackground) output += TERMINAL_BG_RESET;
+		output += TERMINAL_CLEANUP_SEQUENCE;
+		this.write(output);
 	}
 
 	private write(data: string): void {
@@ -149,3 +212,11 @@ export class TerminalController {
 		}
 	}
 }
+
+/**
+ * Backwards-compatible name for the old low-level seam. New code should depend
+ * on `TerminalSessionOwner`; this alias remains for existing imports/tests.
+ */
+export class TerminalController extends TerminalSessionOwner {}
+
+export const defaultTerminalSessionOwner = new TerminalSessionOwner();

--- a/test/integration/altscreen-cleanup.test.ts
+++ b/test/integration/altscreen-cleanup.test.ts
@@ -18,14 +18,13 @@ describe("sumo-tui altscreen cleanup integration", () => {
 		app = spawnPiPty({ env: { PI_CODING_AGENT_DIR: agentDir } });
 
 		await app.waitForOutput(PI_BOOT_SEQUENCE, 10_000);
-		await app.waitForOutput(CURSOR_COLOR_SET, 5_000);
 		app.sendSignal("SIGINT");
 		await app.waitForOutput(TERMINAL_CLEANUP_SEQUENCE, 5_000);
-		await app.waitForOutput(CURSOR_COLOR_RESET, 5_000);
 
+		const output = app.getOutput();
 		const state = app.getCurrentTerminalState();
-		expect(app.getOutput()).toContain(CURSOR_COLOR_SET);
-		expect(app.getOutput()).toContain(CURSOR_COLOR_RESET);
+		expect(output).not.toContain(CURSOR_COLOR_SET);
+		expect(output).not.toContain(CURSOR_COLOR_RESET);
 		expect(state.cleanupSequenceSeen).toBe(true);
 		expect(state.altscreenActive).toBe(false);
 		expect(state.kittyKeyboardPopped).toBe(true);


### PR DESCRIPTION
## Summary

- Add `TerminalSessionOwner` as the shared terminal lifecycle state machine for retained SumoTUI startup/cleanup.
- Wire both the lifecycle shim and `SumoInteractiveRuntime` through the shared owner so duplicate altscreen/mouse startup writes are suppressed during the hybrid phase.
- Stop emitting OSC 12 cursor color during normal startup; cursor color remains terminal-owned by default.
- Add explicit `/sumo:cursor accent|reset|status` behavior for opt-in cursor color changes.
- Update cleanup/integration tests to assert no implicit cursor color override/reset and keep no-TTY paths covered.

## Verification

- `pnpm test:integration` — 11 files passed, 14 tests passed
- `pnpm visual:ci` — passed; required gates did not fail
- `pnpm test` — 70 files passed, 409 tests passed
- `pnpm exec tsc --noEmit && pnpm build` — passed

Closes #100
