### PR TITLE
feat(commands): add interaction registry

### DIFF
--- a/src/command-palette.test.ts
+++ b/src/command-palette.test.ts
@@ -121,6 +121,7 @@ describe("installCommandPalette", () => {
 		const registerCommand = vi.fn();
 		installCommandPalette({ registerShortcut, registerCommand } as never);
 
+		expect(registerCommand).not.toHaveBeenCalled();
 		expect(registerShortcut).toHaveBeenCalledTimes(1);
 		expect(registerShortcut).toHaveBeenCalledWith(COMMAND_PALETTE_SHORTCUT, expect.objectContaining({ handler: expect.any(Function) }));
 		expect(registerShortcut).not.toHaveBeenCalledWith("ctrl+p", expect.anything());

--- a/src/command-palette.ts
+++ b/src/command-palette.ts
@@ -260,13 +260,6 @@ export async function cycleModel(ctx: ExtensionContext, pi: ExtensionAPI, direct
 }
 
 export function installCommandPalette(pi: ExtensionAPI): void {
-	pi.registerCommand("sumo:memory", {
-		description: "Open SumoCode memory browser (stub until Element 7 is installed)",
-		handler: async (_args, ctx) => {
-			ctx.ui.notify("memory editor ships in cathedral element 7", "info");
-		},
-	});
-
 	pi.registerShortcut(COMMAND_PALETTE_SHORTCUT, {
 		description: "Open SumoCode command palette",
 		handler: async (ctx) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,12 +4,6 @@ import { dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installInputHints } from "./cathedral/input-hints.js";
-import { registerCursorCommand } from "./commands/cursor.js";
-import { registerPersonaCommand } from "./commands/persona.js";
-import { registerSpinnerCommand } from "./commands/spinner.js";
-import { registerTabsCommand } from "./commands/tabs.js";
-import { registerThemeCommand } from "./commands/theme.js";
-import { registerThemeCheckCommand } from "./commands/theme-check.js";
 // Element 6 approval gate disabled per Dhruv's request 2026-04-27.
 // The cathedral approval modal was blocking bash/edit/write tool calls and
 // slowing down agent iteration. We trust Pi's own tool security model for now.
@@ -17,10 +11,8 @@ import { registerThemeCheckCommand } from "./commands/theme-check.js";
 // import { installApprovalGate } from "./approval-modal.js";
 import { installAltscreen } from "./cathedral/altscreen.js";
 import { installCathedralEditor } from "./cathedral/cathedral-editor.js";
-import { installCommandPalette } from "./command-palette.js";
+import { installSumoInteractions } from "./interaction-registry.js";
 import { installFooter } from "./footer.js";
-import { registerMemoryCommand } from "./memory-editor.js";
-import { installSidebar } from "./sidebar.js";
 import { installSplash } from "./splash.js";
 import { installTopChrome } from "./top-chrome.js";
 import { installWorkingIndicator } from "./working-indicator.js";
@@ -90,9 +82,8 @@ export function shouldNoopDuplicateInstalledExtension(options: DuplicateInstalle
  * Element 2 (top chrome) replaces the previous tab-bar. The splash and
  * subsequent elements continue to install as separate modules.
  *
- * The sidebar is intentionally NOT installed here yet. Element 1 in the
- * cathedral parity rework re-enables it via `installSidebar(pi)` once
- * the active-state chrome below it is stable.
+ * Slash commands and shortcuts are installed through `installSumoInteractions`
+ * so ownership and startup conflict diagnostics have one registry seam.
  */
 export default function sumocode(pi: ExtensionAPI): void {
 	if (shouldNoopDuplicateInstalledExtension()) {
@@ -106,15 +97,7 @@ export default function sumocode(pi: ExtensionAPI): void {
 	installFooter(pi);
 	installCathedralEditor(pi);
 	installInputHints(pi);
-	installCommandPalette(pi);
 	// installApprovalGate(pi); // disabled — see import comment above
-	installSidebar(pi);
 	installWorkingIndicator(pi);
-	registerCursorCommand(pi);
-	registerPersonaCommand(pi);
-	registerSpinnerCommand(pi);
-	registerTabsCommand(pi);
-	registerThemeCommand(pi);
-	registerThemeCheckCommand(pi);
-	registerMemoryCommand(pi);
+	installSumoInteractions(pi);
 }

--- a/src/interaction-registry.test.ts
+++ b/src/interaction-registry.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+import { createInteractionRegistry, installSumoInteractions, type InteractionConflictDiagnostic } from "./interaction-registry.js";
+
+function buildPiStub() {
+	return {
+		on: vi.fn(),
+		registerCommand: vi.fn(),
+		registerShortcut: vi.fn(),
+	};
+}
+
+describe("InteractionRegistry", () => {
+	it("registers commands once and reports duplicate ownership diagnostics", () => {
+		const pi = buildPiStub();
+		const reported: InteractionConflictDiagnostic[][] = [];
+		const registry = createInteractionRegistry(pi as never, (diagnostics) => reported.push([...diagnostics]));
+
+		registry.install("first", (api) => {
+			api.registerCommand("sumo:memory", { description: "first", handler: async () => undefined });
+		});
+		registry.install("second", (api) => {
+			api.registerCommand("sumo:memory", { description: "second", handler: async () => undefined });
+		});
+		registry.flushDiagnostics();
+
+		expect(pi.registerCommand).toHaveBeenCalledTimes(1);
+		expect(pi.registerCommand).toHaveBeenCalledWith("sumo:memory", expect.objectContaining({ description: "first" }));
+		expect(reported).toEqual([
+			[
+				{
+					kind: "command",
+					id: "sumo:memory",
+					owner: "second",
+					conflictsWith: "first",
+					action: "skipped",
+				},
+			],
+		]);
+	});
+
+	it("registers shortcuts once and reports duplicate ownership diagnostics", () => {
+		const pi = buildPiStub();
+		const diagnostics: InteractionConflictDiagnostic[] = [];
+		const registry = createInteractionRegistry(pi as never, (next) => diagnostics.push(...next));
+
+		registry.install("palette", (api) => {
+			api.registerShortcut("ctrl+/", { description: "palette", handler: () => undefined });
+		});
+		registry.install("other", (api) => {
+			api.registerShortcut("ctrl+/", { description: "other", handler: () => undefined });
+		});
+		registry.flushDiagnostics();
+
+		expect(pi.registerShortcut).toHaveBeenCalledTimes(1);
+		expect(diagnostics).toEqual([
+			{
+				kind: "shortcut",
+				id: "ctrl+/",
+				owner: "other",
+				conflictsWith: "palette",
+				action: "skipped",
+			},
+		]);
+	});
+
+	it("installs SumoCode commands and keybindings through one registry", () => {
+		const pi = buildPiStub();
+		const diagnostics: InteractionConflictDiagnostic[] = [];
+		const snapshot = installSumoInteractions(pi as never, { reporter: (next) => diagnostics.push(...next) });
+
+		expect(diagnostics).toEqual([]);
+		expect(snapshot.diagnostics).toEqual([]);
+		expect(snapshot.commands.map(([id]) => id).sort()).toEqual([
+			"sumo:cursor",
+			"sumo:memory",
+			"sumo:persona",
+			"sumo:spinner",
+			"sumo:tabs",
+			"sumo:theme",
+			"sumo:theme-check",
+		]);
+		expect(snapshot.shortcuts.map(([id]) => id).sort()).toEqual(["ctrl+/", "ctrl+1", "ctrl+2"]);
+		expect(pi.registerCommand).toHaveBeenCalledTimes(7);
+		expect(pi.registerShortcut).toHaveBeenCalledTimes(3);
+	});
+});

--- a/src/interaction-registry.ts
+++ b/src/interaction-registry.ts
@@ -30,6 +30,10 @@ export type InteractionDiagnosticReporter = (diagnostics: readonly InteractionCo
 
 type CommandOptions = Parameters<ExtensionAPI["registerCommand"]>[1];
 type ShortcutOptions = Parameters<ExtensionAPI["registerShortcut"]>[1];
+// Installers must register interactions synchronously. The registry temporarily
+// wraps Pi's registration methods for the duration of `install()` and restores
+// them in `finally`; delayed registrations would intentionally bypass ownership
+// tracking instead of keeping a Proxy/cast-heavy wrapper alive.
 type InteractionInstaller = (pi: ExtensionAPI) => void;
 
 function defaultReporter(diagnostics: readonly InteractionConflictDiagnostic[]): void {

--- a/src/interaction-registry.ts
+++ b/src/interaction-registry.ts
@@ -48,33 +48,31 @@ export class InteractionRegistry {
 	private readonly commands = new Map<string, string>();
 	private readonly shortcuts = new Map<string, string>();
 	private readonly diagnostics: InteractionConflictDiagnostic[] = [];
-	private readonly apiProxy: ExtensionAPI;
 	private activeOwner = "unknown";
 
 	public constructor(
 		private readonly pi: ExtensionAPI,
 		private readonly reporter: InteractionDiagnosticReporter = defaultReporter,
-	) {
-		this.apiProxy = new Proxy(pi as object, {
-			get: (target, property, receiver) => {
-				if (property === "registerCommand") return this.registerCommand;
-				if (property === "registerShortcut") return this.registerShortcut;
-				const value = Reflect.get(target, property, receiver);
-				return typeof value === "function" ? value.bind(target) : value;
-			},
-		}) as ExtensionAPI;
-	}
-
-	public get api(): ExtensionAPI {
-		return this.apiProxy;
-	}
+	) {}
 
 	public install(owner: string, installer: InteractionInstaller): void {
 		const previousOwner = this.activeOwner;
+		const originalRegisterCommand = this.pi.registerCommand;
+		const originalRegisterShortcut = this.pi.registerShortcut;
 		this.activeOwner = owner;
+		this.pi.registerCommand = (name: string, options: CommandOptions): void => {
+			if (!this.claim("command", name, this.commands)) return;
+			originalRegisterCommand.call(this.pi, name, options);
+		};
+		this.pi.registerShortcut = (shortcut: Parameters<ExtensionAPI["registerShortcut"]>[0], options: ShortcutOptions): void => {
+			if (!this.claim("shortcut", String(shortcut), this.shortcuts)) return;
+			originalRegisterShortcut.call(this.pi, shortcut, options);
+		};
 		try {
-			installer(this.apiProxy);
+			installer(this.pi);
 		} finally {
+			this.pi.registerCommand = originalRegisterCommand;
+			this.pi.registerShortcut = originalRegisterShortcut;
 			this.activeOwner = previousOwner;
 		}
 	}
@@ -90,16 +88,6 @@ export class InteractionRegistry {
 			diagnostics: [...this.diagnostics],
 		};
 	}
-
-	private readonly registerCommand = (name: string, options: CommandOptions): void => {
-		if (!this.claim("command", name, this.commands)) return;
-		this.pi.registerCommand(name, options);
-	};
-
-	private readonly registerShortcut = (shortcut: Parameters<ExtensionAPI["registerShortcut"]>[0], options: ShortcutOptions): void => {
-		if (!this.claim("shortcut", String(shortcut), this.shortcuts)) return;
-		this.pi.registerShortcut(shortcut, options);
-	};
 
 	private claim(kind: InteractionKind, id: string, owners: Map<string, string>): boolean {
 		const existingOwner = owners.get(id);

--- a/src/interaction-registry.ts
+++ b/src/interaction-registry.ts
@@ -1,0 +1,142 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { installCommandPalette } from "./command-palette.js";
+import { registerCursorCommand } from "./commands/cursor.js";
+import { registerPersonaCommand } from "./commands/persona.js";
+import { registerSpinnerCommand } from "./commands/spinner.js";
+import { registerTabsCommand } from "./commands/tabs.js";
+import { registerThemeCommand } from "./commands/theme.js";
+import { registerThemeCheckCommand } from "./commands/theme-check.js";
+import { registerMemoryCommand } from "./memory-editor.js";
+import { installSidebar } from "./sidebar.js";
+
+export type InteractionKind = "command" | "shortcut";
+export type InteractionConflictAction = "skipped";
+
+export interface InteractionConflictDiagnostic {
+	readonly kind: InteractionKind;
+	readonly id: string;
+	readonly owner: string;
+	readonly conflictsWith: string;
+	readonly action: InteractionConflictAction;
+}
+
+export interface InteractionRegistrySnapshot {
+	readonly commands: ReadonlyArray<[id: string, owner: string]>;
+	readonly shortcuts: ReadonlyArray<[id: string, owner: string]>;
+	readonly diagnostics: readonly InteractionConflictDiagnostic[];
+}
+
+export type InteractionDiagnosticReporter = (diagnostics: readonly InteractionConflictDiagnostic[]) => void;
+
+type CommandOptions = Parameters<ExtensionAPI["registerCommand"]>[1];
+type ShortcutOptions = Parameters<ExtensionAPI["registerShortcut"]>[1];
+type InteractionInstaller = (pi: ExtensionAPI) => void;
+
+function defaultReporter(diagnostics: readonly InteractionConflictDiagnostic[]): void {
+	if (diagnostics.length === 0) return;
+	console.warn(`[sumocode] interaction-conflicts ${JSON.stringify({ diagnostics })}`);
+}
+
+/**
+ * Central registrar for SumoCode slash commands and keybindings.
+ *
+ * Existing installers still own their handlers, but every `registerCommand` and
+ * `registerShortcut` call flows through this registry so ownership and startup
+ * conflicts are visible in one place.
+ */
+export class InteractionRegistry {
+	private readonly commands = new Map<string, string>();
+	private readonly shortcuts = new Map<string, string>();
+	private readonly diagnostics: InteractionConflictDiagnostic[] = [];
+	private readonly apiProxy: ExtensionAPI;
+	private activeOwner = "unknown";
+
+	public constructor(
+		private readonly pi: ExtensionAPI,
+		private readonly reporter: InteractionDiagnosticReporter = defaultReporter,
+	) {
+		this.apiProxy = new Proxy(pi as object, {
+			get: (target, property, receiver) => {
+				if (property === "registerCommand") return this.registerCommand;
+				if (property === "registerShortcut") return this.registerShortcut;
+				const value = Reflect.get(target, property, receiver);
+				return typeof value === "function" ? value.bind(target) : value;
+			},
+		}) as ExtensionAPI;
+	}
+
+	public get api(): ExtensionAPI {
+		return this.apiProxy;
+	}
+
+	public install(owner: string, installer: InteractionInstaller): void {
+		const previousOwner = this.activeOwner;
+		this.activeOwner = owner;
+		try {
+			installer(this.apiProxy);
+		} finally {
+			this.activeOwner = previousOwner;
+		}
+	}
+
+	public flushDiagnostics(): void {
+		this.reporter(this.diagnostics);
+	}
+
+	public getSnapshot(): InteractionRegistrySnapshot {
+		return {
+			commands: [...this.commands.entries()],
+			shortcuts: [...this.shortcuts.entries()],
+			diagnostics: [...this.diagnostics],
+		};
+	}
+
+	private readonly registerCommand = (name: string, options: CommandOptions): void => {
+		if (!this.claim("command", name, this.commands)) return;
+		this.pi.registerCommand(name, options);
+	};
+
+	private readonly registerShortcut = (shortcut: Parameters<ExtensionAPI["registerShortcut"]>[0], options: ShortcutOptions): void => {
+		if (!this.claim("shortcut", String(shortcut), this.shortcuts)) return;
+		this.pi.registerShortcut(shortcut, options);
+	};
+
+	private claim(kind: InteractionKind, id: string, owners: Map<string, string>): boolean {
+		const existingOwner = owners.get(id);
+		if (existingOwner) {
+			this.diagnostics.push({
+				kind,
+				id,
+				owner: this.activeOwner,
+				conflictsWith: existingOwner,
+				action: "skipped",
+			});
+			return false;
+		}
+		owners.set(id, this.activeOwner);
+		return true;
+	}
+}
+
+export interface InstallSumoInteractionsOptions {
+	readonly reporter?: InteractionDiagnosticReporter;
+}
+
+export function createInteractionRegistry(pi: ExtensionAPI, reporter?: InteractionDiagnosticReporter): InteractionRegistry {
+	return new InteractionRegistry(pi, reporter);
+}
+
+export function installSumoInteractions(pi: ExtensionAPI, options: InstallSumoInteractionsOptions = {}): InteractionRegistrySnapshot {
+	const registry = createInteractionRegistry(pi, options.reporter);
+	registry.install("command-palette", installCommandPalette);
+	registry.install("sidebar", installSidebar);
+	registry.install("commands.cursor", registerCursorCommand);
+	registry.install("commands.persona", registerPersonaCommand);
+	registry.install("commands.spinner", registerSpinnerCommand);
+	registry.install("commands.tabs", registerTabsCommand);
+	registry.install("commands.theme", registerThemeCommand);
+	registry.install("commands.theme-check", registerThemeCheckCommand);
+	registry.install("commands.memory", registerMemoryCommand);
+	registry.flushDiagnostics();
+	return registry.getSnapshot();
+}


### PR DESCRIPTION
## Summary

- Add `InteractionRegistry` as the single registration seam for SumoCode slash commands and shortcuts.
- Route command palette, sidebar shortcuts, and SumoCode slash commands through `installSumoInteractions()` from `src/extension.ts`.
- Add structured duplicate diagnostics with owner/conflict/action metadata and skip duplicate registrations.
- Remove the stale command-palette `/sumo:memory` stub so the real memory editor command is the only `sumo:memory` owner.
- Add registry coverage for duplicate commands, duplicate shortcuts, and the installed SumoCode interaction set.

## Verification

- `pnpm test` — 71 files passed, 412 tests passed
- `pnpm test:integration` — 11 files passed, 14 tests passed
- `pnpm visual:ci` — passed; required gates did not fail
- `pnpm exec tsc --noEmit && pnpm build` — passed

Closes #101
