### PR TITLE
feat(runtime): add cancellable workers

### DIFF
--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -27,6 +27,14 @@ function memoryClient(query: RemnicMemoryClient["query"]): RemnicMemoryClient {
 	};
 }
 
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
 function component(lines: string[]): { renderCalls: number[]; node: { render(width: number): string[]; invalidate(): void } } {
 	const renderCalls: number[] = [];
 	return {
@@ -181,6 +189,24 @@ describe("createSidebarMemoryCache", () => {
 		expect(cache.snapshot()).toEqual({ memory: [], memoryUnavailable: true });
 	});
 
+	it("invalidates stale in-flight prompt refreshes when a newer refresh wins", async () => {
+		const oldRefresh = deferred<Awaited<ReturnType<RemnicMemoryClient["query"]>>>();
+		const newRefresh = deferred<Awaited<ReturnType<RemnicMemoryClient["query"]>>>();
+		const query = vi.fn<RemnicMemoryClient["query"]>((prompt) => prompt === "old" ? oldRefresh.promise : newRefresh.promise);
+		const cache = createSidebarMemoryCache(memoryClient(query));
+
+		const stale = cache.refresh("old");
+		const latest = cache.refresh("new");
+		newRefresh.resolve([{ id: "new", text: "new fact" }]);
+
+		await expect(latest).resolves.toBe(true);
+		expect(cache.snapshot()).toEqual({ memory: ["new fact"], memoryUnavailable: false });
+
+		oldRefresh.resolve([{ id: "old", text: "old fact" }]);
+		await expect(stale).resolves.toBe(false);
+		expect(cache.snapshot()).toEqual({ memory: ["new fact"], memoryUnavailable: false });
+	});
+
 	it("debounces prompt refreshes and only queries the latest prompt", async () => {
 		vi.useFakeTimers();
 		try {
@@ -197,6 +223,37 @@ describe("createSidebarMemoryCache", () => {
 			expect(query).toHaveBeenCalledTimes(1);
 			expect(query).toHaveBeenCalledWith("convex", 5);
 			expect(cache.snapshot().memory).toEqual(["convex preference"]);
+			expect(onChange).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("cancels a stale scheduled session refresh when the prompt changes", async () => {
+		vi.useFakeTimers();
+		try {
+			const oldRefresh = deferred<Awaited<ReturnType<RemnicMemoryClient["query"]>>>();
+			const newRefresh = deferred<Awaited<ReturnType<RemnicMemoryClient["query"]>>>();
+			const query = vi.fn<RemnicMemoryClient["query"]>((prompt) => prompt === "session-a" ? oldRefresh.promise : newRefresh.promise);
+			const onChange = vi.fn();
+			const cache = createSidebarMemoryCache(memoryClient(query));
+
+			cache.schedule("session-a", onChange);
+			await vi.advanceTimersByTimeAsync(SIDEBAR_MEMORY_DEBOUNCE_MS);
+			expect(query).toHaveBeenCalledWith("session-a", 5);
+
+			cache.schedule("session-b", onChange);
+			await vi.advanceTimersByTimeAsync(SIDEBAR_MEMORY_DEBOUNCE_MS);
+			expect(query).toHaveBeenCalledWith("session-b", 5);
+
+			newRefresh.resolve([{ id: "new", text: "new session" }]);
+			await vi.advanceTimersByTimeAsync(0);
+			expect(cache.snapshot()).toEqual({ memory: ["new session"], memoryUnavailable: false });
+			expect(onChange).toHaveBeenCalledTimes(1);
+
+			oldRefresh.resolve([{ id: "old", text: "old session" }]);
+			await vi.advanceTimersByTimeAsync(0);
+			expect(cache.snapshot()).toEqual({ memory: ["new session"], memoryUnavailable: false });
 			expect(onChange).toHaveBeenCalledTimes(1);
 		} finally {
 			vi.useRealTimers();

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -4,6 +4,7 @@ import type { Component } from "@mariozechner/pi-tui";
 import { resolveGitBranch } from "./footer.js";
 import { createRemnicMemoryClient, type RemnicMemoryClient } from "./memory.js";
 import { MetricsHud } from "./sumo-tui/cathedral/metrics-hud.js";
+import { CancellableWorkerRuntime } from "./sumo-tui/runtime/worker-runtime.js";
 import {
 	SIDEBAR_SUB_TABS,
 	renderRegistrySidebarLines,
@@ -53,16 +54,17 @@ export type SidebarMemoryCache = {
 };
 
 const MEMORY_DISPLAY_LIMIT = 5;
+const SIDEBAR_MEMORY_WORKER_GROUP = "sidebar-memory";
 
 export function createSidebarMemoryCache(
 	memoryClient: Pick<RemnicMemoryClient, "query">,
 	debounceMs = SIDEBAR_MEMORY_DEBOUNCE_MS,
+	workerRuntime = new CancellableWorkerRuntime(),
 ): SidebarMemoryCache {
 	let memory: readonly string[] = [];
 	let memoryUnavailable = false;
 	let timer: ReturnType<typeof setTimeout> | undefined;
 	let retryTimer: ReturnType<typeof setTimeout> | undefined;
-	let generation = 0;
 
 	function setSnapshot(nextMemory: readonly string[], nextUnavailable: boolean): boolean {
 		const changed = memoryUnavailable !== nextUnavailable || memory.length !== nextMemory.length || memory.some((item, index) => item !== nextMemory[index]);
@@ -72,15 +74,22 @@ export function createSidebarMemoryCache(
 	}
 
 	async function refresh(prompt: string): Promise<boolean> {
-		const run = ++generation;
-		try {
-			const facts = await memoryClient.query(prompt, MEMORY_DISPLAY_LIMIT);
-			if (run !== generation) return false;
-			return setSnapshot(facts.map((fact) => fact.text), false);
-		} catch {
-			if (run !== generation) return false;
-			return setSnapshot([], true);
-		}
+		const handle = workerRuntime.start({
+			name: "sidebar-memory.refresh",
+			exclusiveGroup: SIDEBAR_MEMORY_WORKER_GROUP,
+			run: async ({ signal }) => {
+				try {
+					const facts = await memoryClient.query(prompt, MEMORY_DISPLAY_LIMIT);
+					if (signal.aborted) return false;
+					return setSnapshot(facts.map((fact) => fact.text), false);
+				} catch {
+					if (signal.aborted) return false;
+					return setSnapshot([], true);
+				}
+			},
+		});
+		const result = await handle.result;
+		return result.status === "completed" ? result.value : false;
 	}
 
 	function clearRetry(): void {
@@ -105,6 +114,7 @@ export function createSidebarMemoryCache(
 		schedule(prompt: string, onChange: () => void): void {
 			if (timer) clearTimeout(timer);
 			clearRetry();
+			workerRuntime.cancelGroup(SIDEBAR_MEMORY_WORKER_GROUP);
 			const normalizedPrompt = prompt.trim();
 			if (normalizedPrompt.length === 0) return;
 			timer = setTimeout(() => {

--- a/src/sumo-tui/runtime/worker-runtime.test.ts
+++ b/src/sumo-tui/runtime/worker-runtime.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { CancellableWorkerRuntime } from "./worker-runtime.js";
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+describe("CancellableWorkerRuntime", () => {
+	it("runs named jobs to completion", async () => {
+		const runtime = new CancellableWorkerRuntime();
+		const handle = runtime.start({
+			name: "session-summary",
+			run: ({ name, signal }) => ({ name, aborted: signal.aborted }),
+		});
+
+		await expect(handle.result).resolves.toEqual({
+			status: "completed",
+			value: { name: "session-summary", aborted: false },
+		});
+	});
+
+	it("cancels and invalidates stale jobs in an exclusive group", async () => {
+		const runtime = new CancellableWorkerRuntime();
+		const firstGate = deferred<string>();
+		const secondGate = deferred<string>();
+		const first = runtime.start({
+			name: "memory-refresh",
+			exclusiveGroup: "sidebar-memory",
+			run: async () => firstGate.promise,
+		});
+		const second = runtime.start({
+			name: "memory-refresh",
+			exclusiveGroup: "sidebar-memory",
+			run: async () => secondGate.promise,
+		});
+
+		expect(first.signal.aborted).toBe(true);
+		expect(first.isCurrent()).toBe(false);
+		expect(second.isCurrent()).toBe(true);
+
+		secondGate.resolve("new");
+		await expect(second.result).resolves.toEqual({ status: "completed", value: "new" });
+
+		firstGate.resolve("old");
+		await expect(first.result).resolves.toEqual({
+			status: "cancelled",
+			id: first.id,
+			name: "memory-refresh",
+			exclusiveGroup: "sidebar-memory",
+		});
+	});
+
+	it("keeps distinct exclusive groups independent", async () => {
+		const runtime = new CancellableWorkerRuntime();
+		const memory = runtime.start({ name: "memory-refresh", exclusiveGroup: "sidebar-memory", run: () => "memory" });
+		const mcp = runtime.start({ name: "mcp-probe", exclusiveGroup: "sidebar-mcp", run: () => "mcp" });
+
+		expect(memory.isCurrent()).toBe(true);
+		expect(mcp.isCurrent()).toBe(true);
+		await expect(memory.result).resolves.toEqual({ status: "completed", value: "memory" });
+		await expect(mcp.result).resolves.toEqual({ status: "completed", value: "mcp" });
+	});
+
+	it("cancelGroup cancels the current exclusive worker", async () => {
+		const runtime = new CancellableWorkerRuntime();
+		const gate = deferred<string>();
+		const handle = runtime.start({ name: "summary", exclusiveGroup: "session-summary", run: async () => gate.promise });
+
+		expect(runtime.cancelGroup("session-summary")).toBe(true);
+		expect(handle.signal.aborted).toBe(true);
+		gate.resolve("done");
+
+		await expect(handle.result).resolves.toEqual({
+			status: "cancelled",
+			id: handle.id,
+			name: "summary",
+			exclusiveGroup: "session-summary",
+		});
+		expect(runtime.cancelGroup("session-summary")).toBe(false);
+	});
+});

--- a/src/sumo-tui/runtime/worker-runtime.ts
+++ b/src/sumo-tui/runtime/worker-runtime.ts
@@ -1,0 +1,112 @@
+export interface WorkerJobContext {
+	readonly id: number;
+	readonly name: string;
+	readonly exclusiveGroup?: string;
+	readonly signal: AbortSignal;
+	isCurrent(): boolean;
+}
+
+export interface WorkerStartOptions<T> {
+	readonly name: string;
+	readonly exclusiveGroup?: string;
+	run(context: WorkerJobContext): Promise<T> | T;
+}
+
+export type WorkerRunResult<T> =
+	| { readonly status: "completed"; readonly value: T }
+	| { readonly status: "cancelled"; readonly id: number; readonly name: string; readonly exclusiveGroup?: string }
+	| { readonly status: "failed"; readonly error: unknown };
+
+export interface WorkerHandle<T> {
+	readonly id: number;
+	readonly name: string;
+	readonly exclusiveGroup?: string;
+	readonly signal: AbortSignal;
+	readonly result: Promise<WorkerRunResult<T>>;
+	isCurrent(): boolean;
+	cancel(): void;
+}
+
+interface MutableWorkerHandle<T> extends WorkerHandle<T> {
+	readonly controller: AbortController;
+}
+
+/**
+ * Small in-process async worker coordinator.
+ *
+ * Jobs are still normal JS promises; cancellation is cooperative via
+ * `AbortSignal`. For work that cannot be interrupted, exclusive groups still
+ * invalidate stale completions so older async results cannot overwrite newer UI
+ * state when they eventually resolve.
+ */
+export class CancellableWorkerRuntime {
+	private nextId = 0;
+	private readonly exclusiveWorkers = new Map<string, MutableWorkerHandle<unknown>>();
+
+	public start<T>(options: WorkerStartOptions<T>): WorkerHandle<T> {
+		const id = ++this.nextId;
+		const controller = new AbortController();
+		let handle: MutableWorkerHandle<T>;
+		let resolveResult!: (result: WorkerRunResult<T>) => void;
+		const result = new Promise<WorkerRunResult<T>>((resolve) => {
+			resolveResult = resolve;
+		});
+		const isCurrent = (): boolean => !options.exclusiveGroup || this.exclusiveWorkers.get(options.exclusiveGroup) === handle;
+		handle = {
+			id,
+			name: options.name,
+			exclusiveGroup: options.exclusiveGroup,
+			signal: controller.signal,
+			controller,
+			isCurrent,
+			cancel: () => controller.abort(),
+			result,
+		};
+
+		if (options.exclusiveGroup) {
+			this.exclusiveWorkers.get(options.exclusiveGroup)?.cancel();
+			this.exclusiveWorkers.set(options.exclusiveGroup, handle as MutableWorkerHandle<unknown>);
+		}
+
+		void this.execute(options, handle).then(resolveResult);
+		return handle;
+	}
+
+	public cancelGroup(exclusiveGroup: string): boolean {
+		const current = this.exclusiveWorkers.get(exclusiveGroup);
+		if (!current) return false;
+		current.cancel();
+		this.exclusiveWorkers.delete(exclusiveGroup);
+		return true;
+	}
+
+	private async execute<T>(options: WorkerStartOptions<T>, handle: MutableWorkerHandle<T>): Promise<WorkerRunResult<T>> {
+		try {
+			const value = await options.run({
+				id: handle.id,
+				name: options.name,
+				exclusiveGroup: options.exclusiveGroup,
+				signal: handle.signal,
+				isCurrent: handle.isCurrent,
+			});
+			if (handle.signal.aborted || !handle.isCurrent()) return this.cancelled(handle);
+			return { status: "completed", value };
+		} catch (error) {
+			if (handle.signal.aborted || !handle.isCurrent()) return this.cancelled(handle);
+			return { status: "failed", error };
+		} finally {
+			if (handle.exclusiveGroup && this.exclusiveWorkers.get(handle.exclusiveGroup) === handle) {
+				this.exclusiveWorkers.delete(handle.exclusiveGroup);
+			}
+		}
+	}
+
+	private cancelled(handle: WorkerHandle<unknown>): WorkerRunResult<never> {
+		return {
+			status: "cancelled",
+			id: handle.id,
+			name: handle.name,
+			exclusiveGroup: handle.exclusiveGroup,
+		};
+	}
+}


### PR DESCRIPTION
## Summary

- Add `CancellableWorkerRuntime` for named async jobs with exclusive groups and cooperative `AbortSignal` cancellation.
- Invalidate stale exclusive workers so old async completions cannot overwrite newer UI state.
- Wire sidebar memory refresh through the worker runtime.
- Cancel in-flight sidebar memory refreshes when prompt/session refresh scheduling changes.
- Add tests for worker completion, exclusive cancellation, group cancellation, stale prompt refreshes, and stale scheduled session refreshes.

## Verification

- `pnpm test` — 72 files passed, 418 tests passed
- `pnpm test:integration` — 11 files passed, 14 tests passed
- `pnpm visual:ci` — passed; required gates did not fail
- `pnpm exec tsc --noEmit && pnpm build` — passed

Closes #102
