### PR TITLE
docs(ui): decide portrait sidebar policy

### DIFF
--- a/docs/CATHEDRAL_PARITY_PLAN.md
+++ b/docs/CATHEDRAL_PARITY_PLAN.md
@@ -100,9 +100,7 @@ Bible and `docs/visual/parity/CONTRACT.md`.
 
 - **2.1** Keep `SIDEBAR_WIDTH` at the V2 value of `30`.
 - **2.2** Keep the wide-layout threshold aligned to the V2 split (`SIDEBAR_MIN_TERMINAL_WIDTH = 120`).
-- **2.3** Anchor responsive to terminal aspect ratio (#13):
-  landscape → `right-center`; portrait → `top-right`.
-  Persist override in per-machine `~/.sumocode/local-config.json`.
+- **2.3** Portrait policy superseded by P0-F: V1 hides the sidebar below `120` cols and keeps the canonical portrait scene no-sidebar. Future portrait overlays/bottom bands require a separate V2 issue and visual approval.
 - **2.4** CONTEXT section parity:
   - row 1: `argent-x (main)` (project + branch)
   - row 2: `[██████░░░░░░░░░░░░░░░░░░] 42k/200k`

--- a/docs/SUMO_TUI_CONSOLIDATION_PLAN.md
+++ b/docs/SUMO_TUI_CONSOLIDATION_PLAN.md
@@ -122,13 +122,15 @@ Scope:
 
 **Goal:** choose the Mac mini portrait behavior before #87 resumes.
 
-Options:
+Decision doc: [`docs/SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md`](./SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md)
 
-- A — hide sidebar in portrait, footer/hint absorbs context.
-- B — bottom registry band in portrait.
-- C — command-toggled overlay only.
+Chosen V1 policy: **Option A** — hide the sidebar in portrait/narrow layouts; footer/hint absorbs essential context. Portrait richness is explicitly V2/later.
 
-Decision needed: ship B in V1, or explicitly mark portrait richness as V2.
+Options evaluated:
+
+- A — hide sidebar in portrait, footer/hint absorbs context. **Accepted for V1.**
+- B — bottom registry band in portrait. Deferred to V2/later.
+- C — command-toggled overlay only. Deferred to V2/later.
 
 ---
 

--- a/docs/SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md
+++ b/docs/SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md
@@ -1,0 +1,90 @@
+# SumoTUI Portrait Sidebar Policy
+
+**Status:** accepted V1 policy for P0-F / #104  
+**Date:** 2026-04-29  
+**Parent:** #98 SumoTUI consolidation  
+**Blocks/resumes:** #87 active portrait scene composition  
+**Related:** `docs/SUMO_TUI_CONSOLIDATION_PLAN.md`, `docs/ui/CATHEDRAL_UX_SPEC_V2.md`, `docs/visual/parity/CONTRACT.md`
+
+## Decision
+
+Ship **Option A** for V1: hide the sidebar in portrait/narrow layouts and let the footer + hint row absorb essential context.
+
+Portrait richness is explicitly **V2/later**. Do not build a bottom registry band or command-toggled portrait overlay before #87 resumes.
+
+In practice:
+
+- The canonical portrait runtime size is `60 × 100`.
+- The V2 editorial sidebar remains a `30`-column landscape/wide-layout component.
+- The sidebar is visible only when the runtime policy says the wide layout is available: currently `W >= 120`, the session has messages, and the user has not hidden it.
+- Portrait and other narrow layouts are chat-first, full-width surfaces.
+- Project/branch/context hints move to the hint row/footer when the sidebar is hidden.
+- `/sumo:memory`, command palette entries, and future shortcuts remain the access path for rich registry detail while portrait is collapsed.
+
+## Options evaluated
+
+| Option | Decision | Notes |
+| --- | --- | --- |
+| A — hide sidebar in portrait; footer/hint absorbs context | **Accept for V1** | Matches current runtime behavior, current Bible portrait scene, and the existing `W < 120` sidebar visibility rule. Lowest seam risk during hybrid Pi/SumoTUI consolidation. |
+| B — bottom registry band in portrait | Defer to V2/later | Visually attractive for Mac mini portrait, but introduces a new composed surface, new height budgeting, new crop policy, and likely new scroll/input edge cases before the root renderer is fully consolidated. |
+| C — command-toggled overlay only | Defer to V2/later | Useful as a future optional affordance, but overlay focus/capture behavior is currently one of the fragile Pi/SumoTUI seams. It should not block #87. |
+
+## Rationale
+
+The deep audit concluded that the risk is not SumoTUI itself; it is the hybrid phase where Pi still owns parts of terminal/layout flow while SumoTUI owns retained runtime pieces. Portrait-specific registry surfaces would expand that seam at exactly the point where #87 needs a stable, reviewable target.
+
+Choosing Option A keeps the portrait target simple:
+
+```txt
+portrait = top bar + full-width chat + input + hint row + footer
+```
+
+That lets #87 validate portrait fundamentals:
+
+- no 40/60-column crash
+- no rendered line wider than terminal width
+- no sidebar overlap/smear
+- footer and input stay pinned
+- chat wraps at full terminal width
+- Cathedral breathing rows remain intact
+
+## V1 contract
+
+### Visibility
+
+Sidebar is hidden when any of these is true:
+
+1. Splash/zero-message state.
+2. Terminal width is below `SIDEBAR_MIN_TERMINAL_WIDTH` (`120`).
+3. The user has explicitly hidden it through the sidebar command path once that command is implemented.
+4. The runtime has no session messages to contextualize.
+
+Portrait is not detected by aspect ratio for V1 sidebar visibility; width is the hard rule. A very wide portrait terminal can still use the wide sidebar if `W >= 120`.
+
+### Layout
+
+When hidden, the sidebar reserves **no columns**. Chat, tool output, and the input frame use the full terminal width.
+
+For the canonical `60 × 100` portrait scene:
+
+- chat wraps to full width minus its own internal padding
+- no right sidebar crop exists
+- the hint row carries project/branch context when available
+- the footer right zone remains context window + session cost, not project/branch duplication
+
+### Visual harness
+
+`active-portrait-runtime` remains a no-sidebar scene. It should not add a sidebar crop or bottom-registry crop in V1.
+
+Future V2 portrait richness must get its own issue, Bible target, scenario manifest update, and human visual approval before becoming required.
+
+## Deferred V2 follow-ups
+
+Open a new issue before implementing either deferred option:
+
+- bottom registry band for portrait
+- command-toggled registry overlay for portrait
+- portrait-specific registry crop/golden promotion
+- keyboard/focus policy for any portrait overlay
+
+Do not implement these inside #87. #87 should resume with the Option A no-sidebar portrait contract.

--- a/docs/ui/CATHEDRAL_UX_SPEC_V2.md
+++ b/docs/ui/CATHEDRAL_UX_SPEC_V2.md
@@ -85,11 +85,12 @@ Splash extra     : version line only on splash, above bottom breathing row
 
 **CHANGED v1 → v2**: Sidebar width `49 → 30` cols. Two-pane split adjusts at `W-30`. Full-screen scenes reserve one internal blank row above the top bar and one below the footer so chrome does not glue to the terminal edge.
 
-**Sidebar visibility rules**:
+**Sidebar visibility rules** (P0-F locked in `docs/SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md`):
 - Hidden on splash (always full-width splash content)
-- Hidden when `W < 120` cols (footer absorbs context info — see Element 5)
+- Hidden when `W < 120` cols (footer/hint absorbs context info — see Element 5)
 - Hidden when user runs `/sidebar hide`
 - Visible otherwise
+- V1 portrait policy is chat-first/no-sidebar; bottom registry bands and portrait overlays are V2/later
 
 Modal overlays sit centered. We cannot dim the underlying canvas in a terminal — modals use `surfaceLifted` bg to read as elevated.
 

--- a/docs/visual/parity/CONTRACT.md
+++ b/docs/visual/parity/CONTRACT.md
@@ -51,6 +51,8 @@ The manifest owns scenario dimensions. Current locked V2 dimensions are:
 
 V2 sidebar width is **30 columns**. Legacy 49-column sidebar references are historical V1/mockup material and must not be used for new V2 assertions.
 
+P0-F portrait policy is **Option A**: portrait/narrow layouts hide the sidebar and let the footer/hint row absorb essential context. The canonical `60 × 100` portrait runtime scene is therefore a no-sidebar scene; it must not add a sidebar crop, bottom-registry crop, or portrait overlay crop in V1.
+
 For 160-column full-screen crops, the sidebar crop starts at `x=130` and spans `30` columns. Chat/runtime content should reserve the matching right-side space only when the runtime sidebar policy says the sidebar is visible.
 
 ## 4. Input and cursor contract

--- a/src/sidebar-placement.test.ts
+++ b/src/sidebar-placement.test.ts
@@ -26,7 +26,7 @@ function component(lines: string[]): { renderCalls: number[]; node: { render(wid
 }
 
 describe("sidebar placement", () => {
-	it("chooses portrait-friendly sidebar anchors", () => {
+	it("keeps the legacy portrait anchor helper deterministic", () => {
 		expect(chooseSidebarAnchor(80, 140)).toBe("top-right");
 		expect(chooseSidebarAnchor(140, 80)).toBe("right-center");
 		expect(chooseSidebarAnchor(140, 80, "bottom-right")).toBe("bottom-right");
@@ -94,6 +94,7 @@ describe("sidebar placement", () => {
 		const options = showOverlay.mock.calls[0]![1];
 		expect(options.visible?.(SIDEBAR_MIN_TERMINAL_WIDTH, 24)).toBe(true);
 		expect(options.visible?.(SIDEBAR_MIN_TERMINAL_WIDTH - 1, 24)).toBe(false);
+		expect(options.visible?.(60, 100)).toBe(false);
 		expect(tui.requestRender).toHaveBeenCalledWith(true);
 	});
 });

--- a/src/sidebar-placement.ts
+++ b/src/sidebar-placement.ts
@@ -5,8 +5,9 @@ import { surfaceLine } from "./sumo-tui/cathedral/ansi.js";
 /**
  * Threshold below which the sidebar hides itself. Per DESIGN.md §8
  * (Responsive), the wide layout is ≥ 120 cols: chat + gutter + the locked
- * 30-column V2 editorial sidebar fit comfortably. Below this we collapse to chat-only and let
- * sidebar info come through `/sumo:memory` etc.
+ * 30-column V2 editorial sidebar fit comfortably. Below this — including the canonical
+ * 60x100 portrait runtime — V1 collapses to chat-only and lets sidebar info come
+ * through the hint/footer row plus `/sumo:memory` etc.
  */
 export const SIDEBAR_MIN_TERMINAL_WIDTH = 120;
 /** Render width for the V2 editorial sidebar (Bible Element 1). */
@@ -17,6 +18,10 @@ export type SidebarAnchor = "right-center" | "top-right" | "bottom-right";
 /**
  * Pick a sidebar anchor responsive to terminal aspect ratio. Override always
  * wins so per-machine `~/.sumocode/local-config.json` can pin a value.
+ *
+ * This is a legacy/future placement helper. V1 visibility is still width-gated
+ * by `SIDEBAR_MIN_TERMINAL_WIDTH`, so narrow portrait terminals do not show the
+ * sidebar even though this helper can describe a portrait anchor.
  */
 export function chooseSidebarAnchor(
 	termWidth: number,

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -522,7 +522,7 @@ describe("chooseSidebarAnchor", () => {
 		expect(chooseSidebarAnchor(200, 60)).toBe("right-center");
 	});
 
-	it("defaults to top-right on portrait monitors", () => {
+	it("keeps the legacy portrait anchor stable for future overlays", () => {
 		expect(chooseSidebarAnchor(60, 160)).toBe("top-right");
 	});
 

--- a/src/visual-parity-contract.test.ts
+++ b/src/visual-parity-contract.test.ts
@@ -63,6 +63,13 @@ describe("V2 visual parity contract", () => {
 		expect(cropDefinition("sidebar")).toEqual({ x: 130, y: 3, cols: 30, rows: 34 });
 	});
 
+	it("keeps the V1 portrait runtime no-sidebar", () => {
+		const portrait = scenario("active-portrait-runtime");
+
+		expect(portrait.dimensions.cols).toBeLessThan(SIDEBAR_MIN_TERMINAL_WIDTH);
+		expect(portrait.crops.map((crop) => crop.id)).toEqual(["full"]);
+	});
+
 	it("keeps required crop gates backed by committed runtime goldens", () => {
 		const requiredCrops = manifest.scenarios.flatMap((item) =>
 			item.crops


### PR DESCRIPTION
## Summary

- Add `docs/SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md` as the P0-F decision record.
- Decision: ship Option A for V1 — hide the sidebar in portrait/narrow layouts and let footer/hint absorb essential context.
- Explicitly defer bottom registry bands and command-toggled portrait overlays to V2/later.
- Link the policy from the consolidation plan, V2 UX spec, visual parity contract, and older parity plan.
- Lock the no-sidebar portrait contract in tests: `active-portrait-runtime` stays `60 × 100` with only the `full` crop, and the sidebar overlay remains hidden at `60 × 100`.

## Verification

- `pnpm test` — 72 files passed, 419 tests passed
- `pnpm test:integration` — 11 files passed, 14 tests passed
- `pnpm visual:ci` — passed; required gates did not fail
- `pnpm exec tsc --noEmit && pnpm build` — passed

Closes #104
