### PR TITLE
feat(render): add typed line primitives

### DIFF
--- a/docs/SUMO_TUI_CONSOLIDATION_PLAN.md
+++ b/docs/SUMO_TUI_CONSOLIDATION_PLAN.md
@@ -144,6 +144,8 @@ Adopt Textual-style reactive properties rather than a full Bubble Tea/Elm rewrit
 
 ### P1-B — Typed style/render primitives
 
+Implementation contract: [`docs/SUMO_TUI_RENDER_PRIMITIVES.md`](./SUMO_TUI_RENDER_PRIMITIVES.md)
+
 Create a boring, typed style layer:
 
 ```ts

--- a/docs/SUMO_TUI_RENDER_PRIMITIVES.md
+++ b/docs/SUMO_TUI_RENDER_PRIMITIVES.md
@@ -1,0 +1,213 @@
+# SumoTUI Render Primitives
+
+**Status:** active implementation contract for P1-B / #105  
+**Owner:** SumoTUI consolidation #98  
+**Code:** `src/sumo-tui/render/primitives.ts`  
+**Tests:** `src/sumo-tui/render/primitives.test.ts`
+
+## Purpose
+
+Use typed render primitives for new Cathedral/Retained SumoTUI surfaces instead of hand-rolling ANSI strings.
+
+The primitives make three things explicit:
+
+1. **Cell width** — padding and truncation use Pi's `visibleWidth` / `truncateToWidth` semantics.
+2. **Style ownership** — foreground, background, and text attrs are typed as `Style`.
+3. **Output target** — a typed `Line` can render to ANSI today and cell output for future retained backends.
+
+This prevents the recurring bug class where a row looks correct as text but leaves unpainted background cells, leaks style resets into the rest of the terminal, or truncates by JavaScript string length instead of terminal cell width.
+
+## Rule for agents
+
+Before adding or substantially changing Cathedral rendering code, read this document and use `src/sumo-tui/render/primitives.ts` unless you are intentionally working in a lower-level ANSI parser/writer.
+
+Do **not** hand-roll new Cathedral ANSI like this:
+
+```ts
+`\u001b[38;2;217;119;6m${text}\u001b[0m`
+```
+
+Prefer typed `Style`, `Span`, and `Line` values:
+
+```ts
+import { lineToAnsi, span, textLine } from "./render/primitives.js";
+
+const row = textLine([
+	span("●", { fg: CATHEDRAL_TOKENS.colors.states.idle }),
+	" ",
+	span("READY", { fg: CATHEDRAL_TOKENS.colors.foreground }),
+], {
+	bg: CATHEDRAL_TOKENS.colors.surface,
+});
+
+return lineToAnsi(row, { width });
+```
+
+Legacy ANSI helpers may remain during migration. New surfaces should use typed primitives by default.
+
+## Core concepts
+
+### `Style`
+
+A typed style object:
+
+```ts
+const surfaceStyle: Style = {
+	fg: CATHEDRAL_TOKENS.colors.foreground,
+	bg: CATHEDRAL_TOKENS.colors.surface,
+	dim: false,
+};
+```
+
+Supported fields:
+
+- `fg`
+- `bg`
+- `bold`
+- `italic`
+- `underline`
+- `dim`
+- `inverse`
+
+### `Span`
+
+A run of text with optional style overrides:
+
+```ts
+span("REGISTRY", { fg: CATHEDRAL_TOKENS.colors.accent })
+```
+
+### `Line`
+
+A row made of spans plus an optional base style. The base style applies to spans that do not override a field and to padding cells when rendered with a width.
+
+```ts
+textLine([
+	span("REGISTRY", { fg: CATHEDRAL_TOKENS.colors.accent }),
+], {
+	fg: CATHEDRAL_TOKENS.colors.foreground,
+	bg: CATHEDRAL_TOKENS.colors.surface,
+});
+```
+
+## Common patterns
+
+### Full-row surface fill
+
+Use a base `bg` and pass `width` to `lineToAnsi()`:
+
+```ts
+const row = textLine(["ready"], {
+	fg: CATHEDRAL_TOKENS.colors.foreground,
+	bg: CATHEDRAL_TOKENS.colors.surface,
+});
+
+return lineToAnsi(row, { width });
+```
+
+This paints the content **and all padding cells** with `surface`.
+
+Tracer bullet: `surfaceLine()` in `src/sumo-tui/cathedral/ansi.ts` now uses this path so existing sidebar rows keep full mahogany background fill while the migration proceeds.
+
+### Styled spans without reset leaks
+
+```ts
+const row = textLine([
+	span("●", { fg: CATHEDRAL_TOKENS.colors.states.tool }),
+	" ",
+	span("ILLUMINATING"),
+], {
+	fg: CATHEDRAL_TOKENS.colors.foreground,
+	bg: CATHEDRAL_TOKENS.colors.background,
+});
+
+return lineToAnsi(row, { width });
+```
+
+`lineToAnsi()` re-applies the base row style after each span and emits a final reset.
+
+### Visible-width truncation
+
+```ts
+const truncated = truncateLine(textLine([
+	span("argent-x", { fg: CATHEDRAL_TOKENS.colors.foreground }),
+	span(" on main", { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+]), width);
+```
+
+Use this instead of `slice()` for user-visible terminal rows.
+
+### Rules
+
+```ts
+const rule = renderRule(width, {
+	indent: "  ",
+	char: "━",
+	style: { fg: CATHEDRAL_TOKENS.colors.divider },
+	lineStyle: { bg: CATHEDRAL_TOKENS.colors.surface },
+});
+
+return lineToAnsi(rule, { width });
+```
+
+### Boxes
+
+```ts
+const lines = renderBox([
+	textLine(["Approve this change?"]),
+], {
+	width,
+	style: { bg: CATHEDRAL_TOKENS.colors.surfaceRecess },
+	borderStyle: { fg: CATHEDRAL_TOKENS.colors.divider },
+	fillStyle: {
+		fg: CATHEDRAL_TOKENS.colors.foreground,
+		bg: CATHEDRAL_TOKENS.colors.surfaceRecess,
+	},
+});
+
+return lines.map((line) => lineToAnsi(line, { width }));
+```
+
+## Migration guidance
+
+Migrate Cathedral surfaces tracer-bullet by tracer-bullet. Do not pause product work to rewrite every ANSI string at once.
+
+Good migration candidates:
+
+- footer row
+- input hints
+- command palette rows
+- approval modal frame
+- chat message frames
+- tool pills
+- code blocks
+- sidebar rows that currently mix nested foreground resets
+
+For each migration:
+
+1. Preserve the existing visual contract first.
+2. Add or update unit tests for width, reset, and background behavior.
+3. Run `pnpm visual:ci` if the surface affects V2 scenarios or required crops.
+4. Promote runtime goldens only after explicit human visual approval.
+
+## Allowed exceptions
+
+It is acceptable to hand-write ANSI in these places:
+
+- low-level ANSI parser/writer code (`src/sumo-tui/render/buffer.ts`, `ansi-writer.ts`, terminal controller escape sequences)
+- compatibility shims that must mirror upstream Pi behavior byte-for-byte
+- old surfaces that have not yet been migrated, as long as new code does not copy the pattern
+- tests that intentionally assert ANSI escape behavior
+
+When adding an exception in production Cathedral rendering, leave a comment explaining why typed primitives are not appropriate yet.
+
+## Verification checklist
+
+For new primitive-backed surfaces, tests should cover the relevant subset of:
+
+- full-row background fill, including padded cells
+- ANSI reset behavior / no leaked bold, dim, fg, or bg
+- visible-width truncation
+- row width equals requested terminal width
+- wide characters where applicable
+- cell output when future retained backends consume typed lines directly

--- a/src/sumo-tui/cathedral/ansi.ts
+++ b/src/sumo-tui/cathedral/ansi.ts
@@ -1,5 +1,6 @@
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { lineToAnsi, span, textLine } from "../render/primitives.js";
 
 export const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
 export const RESET = "\u001b[0m";
@@ -57,8 +58,10 @@ export function padAnsiToWidth(line: string, width: number): string {
 
 /** Wrap a logical sidebar row in the cathedral mahogany surface background. */
 export function surfaceLine(content: string, width: number): string {
-	const line = padAnsiToWidth(content, width);
-	return `${bgHex(CATHEDRAL_TOKENS.colors.surface)}${fgHex(CATHEDRAL_TOKENS.colors.foreground)}${line}${RESET}`;
+	return lineToAnsi(textLine([span(content)], {
+		fg: CATHEDRAL_TOKENS.colors.foreground,
+		bg: CATHEDRAL_TOKENS.colors.surface,
+	}), { width });
 }
 
 /**

--- a/src/sumo-tui/render/primitives.test.ts
+++ b/src/sumo-tui/render/primitives.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { CellBuffer } from "./buffer.js";
+import {
+	lineToAnsi,
+	lineToCells,
+	lineWidth,
+	plainLine,
+	renderBox,
+	renderRule,
+	span,
+	textLine,
+	truncateLine,
+} from "./primitives.js";
+
+function chars(buffer: CellBuffer, width: number): string {
+	return Array.from({ length: width }, (_value, col) => buffer.getCell(0, col).char).join("");
+}
+
+describe("typed render primitives", () => {
+	it("fills the full row background when padding ANSI output", () => {
+		const width = 8;
+		const ansi = lineToAnsi(plainLine("REG", {
+			fg: CATHEDRAL_TOKENS.colors.foreground,
+			bg: CATHEDRAL_TOKENS.colors.surface,
+		}), { width });
+		const buffer = new CellBuffer(1, width);
+
+		buffer.paintRow(0, ansi);
+
+		expect(chars(buffer, width)).toBe("REG     ");
+		for (let col = 0; col < width; col += 1) {
+			expect(buffer.getCell(0, col).bg?.toUpperCase()).toBe(CATHEDRAL_TOKENS.colors.surface.toUpperCase());
+		}
+	});
+
+	it("re-applies row style after styled spans and emits a final reset", () => {
+		const ansi = lineToAnsi(textLine([
+			span("A", { fg: CATHEDRAL_TOKENS.colors.accent, bold: true }),
+			"B",
+		], {
+			fg: CATHEDRAL_TOKENS.colors.foregroundDim,
+			bg: CATHEDRAL_TOKENS.colors.surface,
+		}), { width: 3 });
+		const buffer = new CellBuffer(1, 3);
+
+		buffer.paintRow(0, ansi);
+
+		expect(ansi.endsWith("\u001b[0m")).toBe(true);
+		expect(buffer.getCell(0, 0).fg?.toUpperCase()).toBe(CATHEDRAL_TOKENS.colors.accent.toUpperCase());
+		expect(buffer.getCell(0, 0).attrs.bold).toBe(true);
+		expect(buffer.getCell(0, 1).fg?.toUpperCase()).toBe(CATHEDRAL_TOKENS.colors.foregroundDim.toUpperCase());
+		expect(buffer.getCell(0, 1).attrs.bold).toBe(false);
+		expect(buffer.getCell(0, 1).bg?.toUpperCase()).toBe(CATHEDRAL_TOKENS.colors.surface.toUpperCase());
+		expect(buffer.getCell(0, 2).bg?.toUpperCase()).toBe(CATHEDRAL_TOKENS.colors.surface.toUpperCase());
+	});
+
+	it("truncates typed lines by visible width while preserving span styles", () => {
+		const source = textLine([
+			span("abcd", { fg: CATHEDRAL_TOKENS.colors.accent }),
+			span("ef", { fg: CATHEDRAL_TOKENS.colors.foreground }),
+		]);
+		const truncated = truncateLine(source, 5);
+		const cells = lineToCells(truncated, { width: 5 });
+
+		expect(lineWidth(truncated)).toBe(5);
+		expect(cells.map((cell) => cell.char).join("")).toBe("abcde");
+		expect(cells[0]?.fg).toBe(CATHEDRAL_TOKENS.colors.accent);
+		expect(cells[4]?.fg).toBe(CATHEDRAL_TOKENS.colors.foreground);
+	});
+
+	it("renders shared rule and box helpers as typed lines", () => {
+		const ruleCells = lineToCells(renderRule(6, {
+			indent: "  ",
+			char: "━",
+			style: { fg: CATHEDRAL_TOKENS.colors.divider },
+		}), { width: 6 });
+		expect(ruleCells.map((cell) => cell.char).join("")).toBe("  ━━━━");
+		expect(ruleCells[2]?.fg).toBe(CATHEDRAL_TOKENS.colors.divider);
+
+		const box = renderBox([plainLine("ok")], {
+			width: 6,
+			style: { bg: CATHEDRAL_TOKENS.colors.surfaceRecess },
+			borderStyle: { fg: CATHEDRAL_TOKENS.colors.divider },
+			fillStyle: { fg: CATHEDRAL_TOKENS.colors.foreground, bg: CATHEDRAL_TOKENS.colors.surfaceRecess },
+		});
+
+		expect(box).toHaveLength(3);
+		expect(lineToCells(box[1]!, { width: 6 }).map((cell) => cell.char).join("")).toBe("│ok  │");
+	});
+});

--- a/src/sumo-tui/render/primitives.ts
+++ b/src/sumo-tui/render/primitives.ts
@@ -1,0 +1,220 @@
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import type { Cell } from "./cell.js";
+import { createAttrs } from "./cell.js";
+
+export interface Style {
+	readonly fg?: string;
+	readonly bg?: string;
+	readonly bold?: boolean;
+	readonly italic?: boolean;
+	readonly underline?: boolean;
+	readonly dim?: boolean;
+	readonly inverse?: boolean;
+}
+
+export interface Span {
+	readonly text: string;
+	readonly style?: Style;
+}
+
+export interface Line {
+	readonly spans: readonly Span[];
+	/** Base style for spans that do not override a field, and for padding cells. */
+	readonly style?: Style;
+}
+
+export interface RenderLineOptions {
+	readonly width?: number;
+	readonly style?: Style;
+}
+
+export interface RuleOptions {
+	readonly char?: string;
+	readonly indent?: string;
+	readonly style?: Style;
+	readonly lineStyle?: Style;
+}
+
+export interface BoxOptions {
+	readonly width: number;
+	readonly style?: Style;
+	readonly borderStyle?: Style;
+	readonly fillStyle?: Style;
+	readonly title?: readonly Span[] | string;
+}
+
+const RESET = "\u001b[0m";
+
+function parseHex(hex: string): [number, number, number] | undefined {
+	const normalized = hex.replace("#", "");
+	if (!/^[0-9a-fA-F]{6}$/.test(normalized)) return undefined;
+	return [
+		Number.parseInt(normalized.slice(0, 2), 16),
+		Number.parseInt(normalized.slice(2, 4), 16),
+		Number.parseInt(normalized.slice(4, 6), 16),
+	];
+}
+
+function sgrForStyle(style: Style): string {
+	let output = "";
+	const attrs: string[] = [];
+	if (style.bold) attrs.push("1");
+	if (style.italic) attrs.push("3");
+	if (style.underline) attrs.push("4");
+	if (style.dim) attrs.push("2");
+	if (style.inverse) attrs.push("7");
+	if (attrs.length > 0) output += `\u001b[${attrs.join(";")}m`;
+	const fg = style.fg ? parseHex(style.fg) : undefined;
+	if (fg) output += `\u001b[38;2;${fg[0]};${fg[1]};${fg[2]}m`;
+	const bg = style.bg ? parseHex(style.bg) : undefined;
+	if (bg) output += `\u001b[48;2;${bg[0]};${bg[1]};${bg[2]}m`;
+	return output;
+}
+
+function mergeStyle(base: Style | undefined, override: Style | undefined): Style {
+	if (!base && !override) return {};
+	return {
+		fg: override?.fg ?? base?.fg,
+		bg: override?.bg ?? base?.bg,
+		bold: override?.bold ?? base?.bold,
+		italic: override?.italic ?? base?.italic,
+		underline: override?.underline ?? base?.underline,
+		dim: override?.dim ?? base?.dim,
+		inverse: override?.inverse ?? base?.inverse,
+	};
+}
+
+function hasStyle(style: Style): boolean {
+	return (
+		style.fg !== undefined ||
+		style.bg !== undefined ||
+		style.bold === true ||
+		style.italic === true ||
+		style.underline === true ||
+		style.dim === true ||
+		style.inverse === true
+	);
+}
+
+function toSpan(part: Span | string): Span {
+	return typeof part === "string" ? { text: part } : part;
+}
+
+export function span(text: string, style?: Style): Span {
+	return { text, style };
+}
+
+export function textLine(parts: readonly (Span | string)[] = [], style?: Style): Line {
+	return { spans: parts.map(toSpan), style };
+}
+
+export function plainLine(text: string, style?: Style): Line {
+	return textLine([text], style);
+}
+
+export function lineWidth(line: Line): number {
+	return line.spans.reduce((width, part) => width + visibleWidth(part.text), 0);
+}
+
+export function truncateLine(line: Line, width: number): Line {
+	const safeWidth = Math.max(0, Math.floor(width));
+	if (safeWidth === 0) return { spans: [], style: line.style };
+
+	let remaining = safeWidth;
+	const spans: Span[] = [];
+	for (const part of line.spans) {
+		if (remaining <= 0) break;
+		const partWidth = visibleWidth(part.text);
+		if (partWidth <= remaining) {
+			spans.push(part);
+			remaining -= partWidth;
+			continue;
+		}
+		const truncated = truncateToWidth(part.text, remaining, "");
+		if (truncated.length > 0) spans.push({ ...part, text: truncated });
+		remaining = 0;
+	}
+	return { spans, style: line.style };
+}
+
+export function padLine(line: Line, width: number, style?: Style): Line {
+	const safeWidth = Math.max(0, Math.floor(width));
+	const truncated = truncateLine(line, safeWidth);
+	const padding = Math.max(0, safeWidth - lineWidth(truncated));
+	if (padding === 0) return truncated;
+	return {
+		spans: [...truncated.spans, { text: " ".repeat(padding), style }],
+		style: truncated.style,
+	};
+}
+
+export function renderRule(width: number, options: RuleOptions = {}): Line {
+	const safeWidth = Math.max(0, Math.floor(width));
+	const indent = options.indent ?? "";
+	const char = options.char ?? "─";
+	const count = Math.max(0, safeWidth - visibleWidth(indent));
+	return textLine([indent, span(char.repeat(count), options.style)], options.lineStyle);
+}
+
+export function renderBox(content: readonly Line[], options: BoxOptions): Line[] {
+	const width = Math.max(0, Math.floor(options.width));
+	if (width <= 0) return [];
+	if (width === 1) return content.map(() => plainLine("│", options.borderStyle));
+
+	const innerWidth = Math.max(0, width - 2);
+	const borderStyle = options.borderStyle ?? options.style;
+	const fillStyle = options.fillStyle ?? options.style;
+	const topParts: (Span | string)[] = [span("┌", borderStyle)];
+	if (options.title !== undefined && innerWidth > 0) {
+		const titleParts = typeof options.title === "string" ? [span(` ${options.title} `, borderStyle)] : options.title;
+		const titleWidth = titleParts.reduce((sum, part) => sum + visibleWidth(part.text), 0);
+		const rightRule = Math.max(0, innerWidth - titleWidth);
+		topParts.push(...titleParts, span("─".repeat(rightRule), borderStyle));
+	} else {
+		topParts.push(span("─".repeat(innerWidth), borderStyle));
+	}
+	topParts.push(span("┐", borderStyle));
+
+	const rows = [padLine(textLine(topParts, options.style), width, fillStyle)];
+	for (const row of content) {
+		const inner = padLine(row, innerWidth, fillStyle);
+		const innerSpans = inner.spans.map((part) => ({ ...part, style: mergeStyle(inner.style, part.style) }));
+		rows.push(padLine(textLine([span("│", borderStyle), ...innerSpans, span("│", borderStyle)], options.style), width, fillStyle));
+	}
+	rows.push(padLine(textLine([span("└", borderStyle), span("─".repeat(innerWidth), borderStyle), span("┘", borderStyle)], options.style), width, fillStyle));
+	return rows;
+}
+
+export function lineToAnsi(line: Line, options: RenderLineOptions = {}): string {
+	const prepared = options.width === undefined ? line : padLine(line, options.width, options.style ?? line.style);
+	const baseStyle = mergeStyle(options.style, prepared.style);
+	let output = "";
+	for (const part of prepared.spans) {
+		if (part.text.length === 0) continue;
+		const effectiveStyle = mergeStyle(baseStyle, part.style);
+		if (hasStyle(effectiveStyle)) output += `${RESET}${sgrForStyle(effectiveStyle)}`;
+		else if (output.length > 0) output += RESET;
+		output += part.text;
+	}
+	return output.length === 0 ? "" : `${output}${RESET}`;
+}
+
+export function lineToCells(line: Line, options: RenderLineOptions & { readonly width: number }): Cell[] {
+	const prepared = padLine(line, options.width, options.style ?? line.style);
+	const baseStyle = mergeStyle(options.style, prepared.style);
+	const cells: Cell[] = [];
+
+	for (const part of prepared.spans) {
+		const style = mergeStyle(baseStyle, part.style);
+		for (const char of Array.from(part.text)) {
+			if (cells.length >= options.width) return cells;
+			cells.push({
+				char,
+				fg: style.fg,
+				bg: style.bg,
+				attrs: createAttrs(style),
+			});
+		}
+	}
+	return cells;
+}


### PR DESCRIPTION
## Summary

- Add typed render primitives for `Style`, `Span`, and `Line`.
- Add shared helpers for line padding/truncation, ANSI output, cell output, rules, and boxes.
- Migrate `surfaceLine()` through the typed primitive path as the tracer bullet for Cathedral surfaces.
- Add tests for full-row background fill, reset/style re-application, visible-width truncation, and shared rule/box helpers.
- Add `docs/SUMO_TUI_RENDER_PRIMITIVES.md` as the implementation contract so future agents do not hand-roll new Cathedral ANSI.

## Verification

- `pnpm test` — 73 files passed, 423 tests passed
- `pnpm test:integration` — 11 files passed, 14 tests passed
- `pnpm visual:ci` — passed; required gates did not fail
- `pnpm exec tsc --noEmit && pnpm build` — passed after docs update

Closes #105
