### PR TITLE
feat(testing): add headless SumoTUI backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -190,4 +190,4 @@ Required crops gate against committed approved runtime goldens. Bible diffs rema
 
 `test/integration/` spawns a real Pi inside a `node-pty` PTY (see `spawn-pi-pty.ts`). These tests verify things that cannot be trusted to unit tests alone: altscreen cleanup on signal, mouse scroll routing, cursor visibility, editor boundary behavior, splash centering, and slash-command dispatch.
 
-Keep PTY integration tests as smoke/contract tests. Prefer unit/headless tests for detailed behavior where possible.
+Keep PTY integration tests as smoke/contract tests. Prefer unit/headless tests for detailed behavior where possible. For retained renderer behavior, use `src/sumo-tui/testing/test-backend.ts` and read `docs/SUMO_TUI_TEST_BACKEND.md`.

--- a/docs/SUMO_TUI_CONSOLIDATION_PLAN.md
+++ b/docs/SUMO_TUI_CONSOLIDATION_PLAN.md
@@ -158,6 +158,8 @@ Build frames, tool pills, code blocks, modals, footer, sidebar, and input from s
 
 ### P1-C — Headless TestBackend + Pilot API
 
+Implementation contract: [`docs/SUMO_TUI_TEST_BACKEND.md`](./SUMO_TUI_TEST_BACKEND.md)
+
 Add a Ratatui/Textual-style headless backend with current/previous buffers, cursor state, key/mouse input, resize, and assertions. PTY tests remain smoke tests, not the only integration test layer.
 
 ### P1-D — Structured transcript model

--- a/docs/SUMO_TUI_TEST_BACKEND.md
+++ b/docs/SUMO_TUI_TEST_BACKEND.md
@@ -1,0 +1,78 @@
+# SumoTUI Headless TestBackend
+
+**Status:** active test contract for P1-C / #106  
+**Owner:** SumoTUI consolidation #98  
+**Code:** `src/sumo-tui/testing/test-backend.ts`  
+**Tests:** `src/sumo-tui/testing/test-backend.test.ts`
+
+## Purpose
+
+Use `SumoTuiTestBackend` to test retained SumoTUI behavior without parsing real PTY byte streams.
+
+PTY integration tests remain smoke coverage for the Pi/terminal boundary. Headless tests should carry detailed behavior coverage for retained renderer logic such as layout, cursor state, key routing, mouse dispatch, resize handling, and buffer assertions.
+
+## What it exposes
+
+`SumoTuiTestBackend` owns:
+
+- a Yoga `root` node
+- a `KeyRouter`
+- current and previous `CellBuffer` snapshots
+- current hardware cursor state from the compositor
+- a `pilot` driver for keys, text, mouse events, resize, and explicit render ticks
+
+## Basic usage
+
+```ts
+const backend = await SumoTuiTestBackend.create({ cols: 80, rows: 24 });
+
+try {
+	// Mount retained nodes directly.
+	const node = new SumoNode(backend.yoga.Node.create(), backend.root);
+	node.width = "100%";
+	node.height = "100%";
+
+	const frame = backend.render();
+	expect(frame.current.getDimensions()).toEqual({ rows: 24, cols: 80 });
+} finally {
+	backend.dispose();
+}
+```
+
+## Pilot API
+
+```ts
+backend.pilot.key("x");
+backend.pilot.text("hello");
+backend.pilot.mouse({ type: "scroll", scrollDir: "down", button: 65, row: 4, col: 2 });
+backend.pilot.resize(120, 40);
+backend.pilot.render();
+```
+
+Pilot methods render after each event so tests can immediately inspect `backend.current`, `backend.previous`, or the returned frame.
+
+## Cursor coverage
+
+The first tracer-bullet test ports the PTY cursor-visibility behavior into a headless retained test: a `PiEditorLeaf` is mounted, typed keys update the fake editor text, and the compositor-reported hardware cursor advances without spawning Pi.
+
+That does **not** delete the PTY cursor smoke test. The PTY test still verifies real terminal bytes, while the headless test verifies the retained renderer logic directly.
+
+## When to use this instead of PTY
+
+Prefer the headless backend when testing:
+
+- retained widget layout
+- `CellBuffer` output
+- hardware cursor calculation
+- key routing and focus
+- mouse hit-testing and scroll behavior
+- resize behavior
+- deterministic rendering edge cases
+
+Keep PTY tests for:
+
+- patched Pi startup
+- altscreen/mouse/cursor terminal modes
+- process signal cleanup
+- real stdin/stdout behavior
+- end-to-end wrapper smoke

--- a/src/sumo-tui/testing/test-backend.test.ts
+++ b/src/sumo-tui/testing/test-backend.test.ts
@@ -1,0 +1,104 @@
+import type { CustomEditor } from "@mariozechner/pi-coding-agent";
+import { CURSOR_MARKER } from "@mariozechner/pi-tui";
+import { afterEach, describe, expect, it } from "vitest";
+import { SumoNode } from "../layout/node.js";
+import { PiEditorLeaf } from "../widgets/pi-editor-leaf.js";
+import { SumoTuiTestBackend } from "./test-backend.js";
+
+const backends: SumoTuiTestBackend[] = [];
+
+afterEach(() => {
+	for (const backend of backends.splice(0)) backend.dispose();
+});
+
+async function createBackend(options?: Parameters<typeof SumoTuiTestBackend.create>[0]): Promise<SumoTuiTestBackend> {
+	const backend = await SumoTuiTestBackend.create(options);
+	backends.push(backend);
+	return backend;
+}
+
+class CursorEditor {
+	public text = "";
+
+	public render(width: number): string[] {
+		const row = `> ${this.text}${CURSOR_MARKER}`;
+		return [row.padEnd(Math.max(0, width), " ")];
+	}
+}
+
+describe("SumoTuiTestBackend", () => {
+	it("exposes current and previous buffers plus cursor state", async () => {
+		const backend = await createBackend({ cols: 12, rows: 3 });
+		const node = new SumoNode(backend.yoga.Node.create(), backend.root);
+		node.width = "100%";
+		node.height = 1;
+
+		const first = backend.render();
+		expect(first.current.getDimensions()).toEqual({ rows: 3, cols: 12 });
+		expect(first.previous).toBeUndefined();
+		expect(backend.current?.getDimensions()).toEqual({ rows: 3, cols: 12 });
+		expect(backend.previous).toBeUndefined();
+
+		const second = backend.pilot.resize(10, 4);
+		expect(second.current.getDimensions()).toEqual({ rows: 4, cols: 10 });
+		expect(second.previous?.getDimensions()).toEqual({ rows: 3, cols: 12 });
+		expect(backend.previous?.getDimensions()).toEqual({ rows: 3, cols: 12 });
+	});
+
+	it("drives key, mouse, and resize events through the pilot API", async () => {
+		const backend = await createBackend({ cols: 16, rows: 4 });
+		let keyCount = 0;
+		let scrollCount = 0;
+		const target = new SumoNode(backend.yoga.Node.create(), backend.root, {
+			onScroll: (_node, event) => {
+				scrollCount += (event as { scrollDir?: string }).scrollDir === "down" ? 1 : 0;
+				return true;
+			},
+		});
+		target.width = "100%";
+		target.height = "100%";
+		backend.setFocus({
+			handleKey: (event) => {
+				if (event.key !== "x") return false;
+				keyCount += 1;
+				return true;
+			},
+		});
+		backend.render();
+
+		expect(backend.pilot.key("x")).toBe(true);
+		expect(keyCount).toBe(1);
+		expect(backend.pilot.mouse({ type: "scroll", scrollDir: "down", button: 65, row: 0, col: 0 })).toBe(true);
+		expect(scrollCount).toBe(1);
+		expect(backend.pilot.resize(20, 5).current.getDimensions()).toEqual({ rows: 5, cols: 20 });
+	});
+
+	it("covers cursor advance without a PTY by rendering PiEditorLeaf headlessly", async () => {
+		const backend = await createBackend({ cols: 24, rows: 3 });
+		const editor = new CursorEditor();
+		const leaf = PiEditorLeaf.create(backend.yoga, editor as unknown as CustomEditor, backend.root);
+		leaf.width = "100%";
+
+		backend.setFocus({
+			handleKey: (event) => {
+				if (event.key.length !== 1) return false;
+				editor.text += event.key;
+				leaf.markDirty();
+				return true;
+			},
+		});
+
+		let frame = backend.render();
+		expect(frame.cursor).toEqual({ row: 0, col: 2 });
+		let previousColumn = frame.cursor?.col ?? -1;
+
+		for (const char of "ZQXJW") {
+			expect(backend.pilot.key(char)).toBe(true);
+			frame = backend.pilot.render();
+			expect(frame.cursor?.col).toBeGreaterThan(previousColumn);
+			previousColumn = frame.cursor?.col ?? previousColumn;
+		}
+
+		expect(frame.current.toPlainRow(0).trimEnd()).toBe("> ZQXJW");
+	});
+});

--- a/src/sumo-tui/testing/test-backend.ts
+++ b/src/sumo-tui/testing/test-backend.ts
@@ -1,0 +1,176 @@
+import { dispatchMouseEvent, type HardwareCursor } from "../render/compositor.js";
+import { composite } from "../render/compositor.js";
+import { CellBuffer } from "../render/buffer.js";
+import type { KeyEvent, KeyTarget } from "../input/key-router.js";
+import { KeyRouter } from "../input/key-router.js";
+import type { MouseEvent } from "../input/mouse.js";
+import { SumoNode } from "../layout/node.js";
+import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga, type Yoga } from "../layout/yoga.js";
+
+export interface TestBackendOptions {
+	readonly cols?: number;
+	readonly rows?: number;
+}
+
+export interface TestBackendFrame {
+	readonly current: CellBuffer;
+	readonly previous: CellBuffer | undefined;
+	readonly cursor: HardwareCursor | null;
+	readonly cols: number;
+	readonly rows: number;
+}
+
+export interface PilotMouseOptions extends Omit<MouseEvent, "modifiers"> {
+	readonly modifiers?: MouseEvent["modifiers"];
+}
+
+const DEFAULT_COLS = 80;
+const DEFAULT_ROWS = 24;
+const DEFAULT_MOUSE_MODIFIERS: MouseEvent["modifiers"] = Object.freeze({ shift: false, alt: false, ctrl: false });
+
+/**
+ * Headless retained-renderer backend for unit tests.
+ *
+ * This is intentionally below the Pi compatibility layer: tests mount SumoNode
+ * trees directly, drive them with key/mouse/resize events, and inspect buffers
+ * without parsing PTY byte streams. PTY tests remain smoke coverage for the real
+ * terminal/Pi boundary.
+ */
+export class SumoTuiTestBackend {
+	public readonly yoga: Yoga;
+	public readonly root: SumoNode;
+	public readonly keyRouter = new KeyRouter();
+	public readonly pilot: SumoTuiPilot;
+	private cols: number;
+	private rows: number;
+	private currentBuffer: CellBuffer | undefined;
+	private previousBuffer: CellBuffer | undefined;
+	private currentCursor: HardwareCursor | null = null;
+	private disposed = false;
+
+	private constructor(yoga: Yoga, options: Required<TestBackendOptions>) {
+		this.yoga = yoga;
+		this.cols = options.cols;
+		this.rows = options.rows;
+		this.root = new SumoNode(yoga.Node.create());
+		this.root.flexDirection = FLEX_DIRECTION_COLUMN;
+		this.pilot = new SumoTuiPilot(this);
+	}
+
+	public static async create(options: TestBackendOptions = {}): Promise<SumoTuiTestBackend> {
+		const yoga = await loadYoga();
+		return new SumoTuiTestBackend(yoga, {
+			cols: normalizeDimension(options.cols ?? DEFAULT_COLS, DEFAULT_COLS),
+			rows: normalizeDimension(options.rows ?? DEFAULT_ROWS, DEFAULT_ROWS),
+		});
+	}
+
+	public get dimensions(): { cols: number; rows: number } {
+		return { cols: this.cols, rows: this.rows };
+	}
+
+	public get current(): CellBuffer | undefined {
+		return this.currentBuffer?.clone();
+	}
+
+	public get previous(): CellBuffer | undefined {
+		return this.previousBuffer?.clone();
+	}
+
+	public get cursor(): HardwareCursor | null {
+		return this.currentCursor ? { ...this.currentCursor } : null;
+	}
+
+	public setFocus(target: KeyTarget | undefined): void {
+		this.keyRouter.setFocus(target);
+	}
+
+	public render(): TestBackendFrame {
+		this.assertNotDisposed();
+		this.root.width = this.cols;
+		this.root.height = this.rows;
+		this.root.yogaNode.calculateLayout(this.cols, this.rows, DIRECTION_LTR);
+
+		const previous = this.currentBuffer?.clone();
+		const current = new CellBuffer(this.rows, this.cols);
+		const result = composite(this.root, current);
+
+		this.previousBuffer = previous;
+		this.currentBuffer = current.clone();
+		this.currentCursor = result.hardwareCursor ? { ...result.hardwareCursor } : null;
+
+		return {
+			current: current.clone(),
+			previous,
+			cursor: this.cursor,
+			cols: this.cols,
+			rows: this.rows,
+		};
+	}
+
+	public sendKey(event: string | KeyEvent): boolean {
+		this.assertNotDisposed();
+		return this.keyRouter.dispatch(event);
+	}
+
+	public sendMouse(event: MouseEvent): boolean {
+		this.assertNotDisposed();
+		return dispatchMouseEvent(this.root, event);
+	}
+
+	public resize(cols: number, rows: number): void {
+		this.assertNotDisposed();
+		this.cols = normalizeDimension(cols, this.cols);
+		this.rows = normalizeDimension(rows, this.rows);
+	}
+
+	public dispose(): void {
+		if (this.disposed) return;
+		this.disposed = true;
+		this.root.dispose();
+		this.currentBuffer = undefined;
+		this.previousBuffer = undefined;
+		this.currentCursor = null;
+	}
+
+	private assertNotDisposed(): void {
+		if (this.disposed) throw new Error("SumoTuiTestBackend has been disposed");
+	}
+}
+
+export class SumoTuiPilot {
+	public constructor(private readonly backend: SumoTuiTestBackend) {}
+
+	public key(event: string | KeyEvent): boolean {
+		const consumed = this.backend.sendKey(event);
+		this.backend.render();
+		return consumed;
+	}
+
+	public text(value: string): void {
+		for (const char of value) this.key({ key: char, sequence: char });
+	}
+
+	public mouse(options: PilotMouseOptions): boolean {
+		const consumed = this.backend.sendMouse({
+			...options,
+			modifiers: options.modifiers ?? DEFAULT_MOUSE_MODIFIERS,
+		});
+		this.backend.render();
+		return consumed;
+	}
+
+	public resize(cols: number, rows: number): TestBackendFrame {
+		this.backend.resize(cols, rows);
+		return this.backend.render();
+	}
+
+	public render(): TestBackendFrame {
+		return this.backend.render();
+	}
+}
+
+function normalizeDimension(value: number, fallback: number): number {
+	if (!Number.isFinite(value)) return fallback;
+	return Math.max(1, Math.floor(value));
+}


### PR DESCRIPTION
## Summary

- Add `SumoTuiTestBackend` and `SumoTuiPilot` for headless retained renderer tests.
- Expose current/previous `CellBuffer` snapshots and compositor hardware cursor state.
- Add pilot APIs for key, text, mouse, resize, and explicit render ticks.
- Add a headless tracer-bullet test for cursor advancement through `PiEditorLeaf`, moving detailed cursor behavior coverage out of PTY-only parsing while keeping the existing PTY smoke test.
- Document the headless backend contract in `docs/SUMO_TUI_TEST_BACKEND.md` and link it from the consolidation plan/agent instructions.

## Verification

- `pnpm test` — 74 files passed, 426 tests passed
- `pnpm test:integration` — 11 files passed, 14 tests passed
- `pnpm visual:ci` — passed; required gates did not fail
- `pnpm exec tsc --noEmit && pnpm build` — passed

Closes #106
