### PR TITLE
feat(transcript): add structured chat model

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -184,6 +184,8 @@ Required crops gate against committed approved runtime goldens. Bible diffs rema
 - `docs/SUMO_TUI_PI_PATCH_STRATEGY.md` — private Pi patch maintenance contract.
 - `docs/SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md` — V1 portrait/no-sidebar policy.
 - `docs/SUMO_TUI_RENDER_PRIMITIVES.md` — typed render primitive contract.
+- `docs/SUMO_TUI_TEST_BACKEND.md` — headless retained-renderer test backend contract.
+- `docs/SUMO_TUI_TRANSCRIPT_MODEL.md` — structured transcript view-model contract.
 - `docs/prd.md` / `docs/prd.html` — formal product spec.
 
 ## Integration tests

--- a/docs/SUMO_TUI_CONSOLIDATION_PLAN.md
+++ b/docs/SUMO_TUI_CONSOLIDATION_PLAN.md
@@ -164,6 +164,8 @@ Add a Ratatui/Textual-style headless backend with current/previous buffers, curs
 
 ### P1-D — Structured transcript model
 
+Implementation contract: [`docs/SUMO_TUI_TRANSCRIPT_MODEL.md`](./SUMO_TUI_TRANSCRIPT_MODEL.md)
+
 Introduce typed chat blocks for markdown, code, tools, skills, questions, and delegation. This unblocks #89 and robust fixture-backed #90 states.
 
 ### P1-E — Focus/modal/input router

--- a/docs/SUMO_TUI_TRANSCRIPT_MODEL.md
+++ b/docs/SUMO_TUI_TRANSCRIPT_MODEL.md
@@ -1,0 +1,102 @@
+# SumoTUI Structured Transcript Model
+
+**Status:** active view-model contract for P1-D / #107  
+**Owner:** SumoTUI consolidation #98  
+**Code:** `src/sumo-tui/transcript/view-model.ts`  
+**Tests:** `src/sumo-tui/transcript/view-model.test.ts`
+
+## Purpose
+
+SumoTUI needs a deterministic transcript model before V2 chat frames and fixture runtime states can become durable.
+
+Before this slice, retained chat rendering mostly flattened Pi/session messages into plain strings. That is enough for scroll smoke tests, but it cannot reliably render or fixture:
+
+- boxed user/Sumo chat frames (#89)
+- code blocks
+- tool calls/results and future tool ledgers
+- inline skill pills
+- Divine Query/question blocks
+- scroll/scribe delegation blocks
+- deterministic completed-response states (#90)
+
+The structured transcript model separates **message identity/role** from **typed renderable blocks**.
+
+## Core types
+
+```ts
+type ChatBlock =
+	| { type: "markdown"; text: string }
+	| { type: "code"; lang: string; source: string; collapsed?: boolean }
+	| { type: "tool"; tool: ToolCallViewModel }
+	| { type: "skill"; name: string; expanded: boolean }
+	| { type: "question"; question: QuestionViewModel }
+	| { type: "delegation"; delegation: DelegationViewModel };
+
+type ChatMessageViewModel = {
+	id: string;
+	role: "user" | "sumo" | "system";
+	displayName: string;
+	timestamp?: Date;
+	blocks: ChatBlock[];
+};
+```
+
+Source of truth lives in `src/sumo-tui/transcript/view-model.ts`.
+
+## Conversion boundary
+
+Use:
+
+```ts
+chatMessageViewModelFromPiMessage(message, index)
+transcriptFromSessionContext(sessionContext)
+```
+
+The converter accepts current Pi/session message shapes as `unknown` and normalizes known forms:
+
+- Pi `user` / `assistant` text content → `markdown` / `code` blocks
+- assistant `toolCall` content parts → `tool` block with `pending` status
+- `toolResult` messages → `tool` block with `success` / `error` status
+- `bashExecution` messages → `tool` block named `bash`
+- custom/explicit `skill` parts → `skill` block
+- custom/explicit `question` parts → `question` block
+- custom/explicit `delegation` / `scroll` / `subagent` parts → `delegation` block
+
+Hidden custom messages (`role: "custom", display: false`) are filtered out at the session transcript boundary.
+
+## Fixture use
+
+#90 fixture-backed runtime states should build `TranscriptViewModel` objects directly instead of replaying nondeterministic live Pi output. This keeps completed-response, tool, skill, code, question, and delegation states deterministic.
+
+Example fixture shape:
+
+```ts
+const transcript: TranscriptViewModel = {
+	messages: [
+		{
+			id: "m1",
+			role: "sumo",
+			displayName: "SUMO",
+			blocks: [
+				{ type: "markdown", text: "I will inspect the failing test." },
+				{ type: "tool", tool: { name: "bash", status: "success", output: "1 passed" } },
+			],
+		},
+	],
+};
+```
+
+## How this unblocks #89
+
+#89 can render chat frames from `ChatMessageViewModel` rather than guessing from plain text. The renderer can switch on block type:
+
+- `markdown` → wrapped prose inside the message frame
+- `code` → Element 10 code block
+- `tool` → Element 9 tool pill/ledger
+- `skill` → Element 9a inline skill pill
+- `question` → Element 11 Divine Query affordance
+- `delegation` → Element 12 scroll/scribe delegation row
+
+## Legacy bridge
+
+`chatMessageViewModelToPlainText()` exists only as a bridge for the current `ChatPager` string renderer. New V2 chat renderers should consume `ChatMessageViewModel` and `ChatBlock` directly.

--- a/src/sumo-tui/transcript/view-model.test.ts
+++ b/src/sumo-tui/transcript/view-model.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from "vitest";
+import {
+	chatMessageViewModelFromPiMessage,
+	chatMessageViewModelToPlainText,
+	markdownAndCodeBlocksFromText,
+	transcriptFromSessionContext,
+} from "./view-model.js";
+
+describe("structured transcript view model", () => {
+	it("maps markdown text messages", () => {
+		const message = chatMessageViewModelFromPiMessage({
+			id: "u1",
+			role: "user",
+			content: "hello **sumo**",
+			timestamp: 1_700_000_000_000,
+		});
+
+		expect(message).toMatchObject({
+			id: "u1",
+			role: "user",
+			displayName: "YOU",
+			blocks: [{ type: "markdown", text: "hello **sumo**" }],
+		});
+		expect(message?.timestamp?.getTime()).toBe(1_700_000_000_000);
+	});
+
+	it("splits fenced code blocks out of markdown", () => {
+		const blocks = markdownAndCodeBlocksFromText("before\n```ts\nconst x = 1;\n```\nafter");
+
+		expect(blocks).toEqual([
+			{ type: "markdown", text: "before\n" },
+			{ type: "code", lang: "ts", source: "const x = 1;" },
+			{ type: "markdown", text: "\nafter" },
+		]);
+	});
+
+	it("maps assistant tool call blocks", () => {
+		const message = chatMessageViewModelFromPiMessage({
+			id: "a1",
+			role: "assistant",
+			content: [
+				{ type: "text", text: "I will run the tests." },
+				{ type: "toolCall", id: "tc1", name: "bash", arguments: { command: "pnpm test" } },
+			],
+		});
+
+		expect(message?.role).toBe("sumo");
+		expect(message?.blocks).toEqual([
+			{ type: "markdown", text: "I will run the tests." },
+			{ type: "tool", tool: { id: "tc1", name: "bash", status: "pending", input: { command: "pnpm test" }, output: undefined, details: undefined, error: undefined } },
+		]);
+	});
+
+	it("maps tool result messages", () => {
+		const message = chatMessageViewModelFromPiMessage({
+			role: "toolResult",
+			toolCallId: "tc1",
+			toolName: "bash",
+			content: [{ type: "text", text: "passed" }],
+			isError: false,
+		});
+
+		expect(message).toMatchObject({
+			id: "tc1",
+			role: "system",
+			blocks: [{ type: "tool", tool: { id: "tc1", name: "bash", status: "success", output: "passed" } }],
+		});
+	});
+
+	it("maps skill blocks", () => {
+		const message = chatMessageViewModelFromPiMessage({
+			role: "assistant",
+			content: [{ type: "skill", name: "frontend-design", expanded: true }],
+		});
+
+		expect(message?.blocks).toEqual([{ type: "skill", name: "frontend-design", expanded: true }]);
+	});
+
+	it("maps question blocks", () => {
+		const message = chatMessageViewModelFromPiMessage({
+			role: "assistant",
+			content: [{ type: "question", id: "q1", prompt: "Proceed?", choices: ["yes", "no"], selected: "yes", required: true }],
+		});
+
+		expect(message?.blocks).toEqual([
+			{ type: "question", question: { id: "q1", prompt: "Proceed?", choices: ["yes", "no"], selected: "yes", required: true } },
+		]);
+	});
+
+	it("maps delegation blocks", () => {
+		const message = chatMessageViewModelFromPiMessage({
+			role: "assistant",
+			content: [{ type: "delegation", id: "d1", agent: "scribe", status: "running", summary: "scrolling the long transcript" }],
+		});
+
+		expect(message?.blocks).toEqual([
+			{ type: "delegation", delegation: { id: "d1", title: "scribe", agent: "scribe", status: "running", summary: "scrolling the long transcript" } },
+		]);
+	});
+
+	it("converts session contexts into transcript view models and skips hidden custom messages", () => {
+		const transcript = transcriptFromSessionContext({
+			messages: [
+				{ role: "custom", customType: "notification", display: false, content: "hidden" },
+				{ role: "user", content: "visible" },
+				{ role: "bashExecution", command: "pnpm test", output: "ok", exitCode: 0 },
+			],
+		});
+
+		expect(transcript.messages).toHaveLength(2);
+		expect(transcript.messages[0]?.blocks).toEqual([{ type: "markdown", text: "visible" }]);
+		expect(transcript.messages[1]?.blocks[0]).toMatchObject({ type: "tool", tool: { name: "bash", status: "success", output: "ok" } });
+	});
+
+	it("can flatten structured blocks for the legacy ChatPager bridge", () => {
+		const message = chatMessageViewModelFromPiMessage({
+			role: "assistant",
+			content: [
+				{ type: "text", text: "Using a skill." },
+				{ type: "skill", name: "tdd", expanded: false },
+			],
+		});
+
+		expect(message ? chatMessageViewModelToPlainText(message) : "").toContain("[skill] tdd");
+	});
+});

--- a/src/sumo-tui/transcript/view-model.ts
+++ b/src/sumo-tui/transcript/view-model.ts
@@ -1,0 +1,304 @@
+export type ChatMessageRole = "user" | "sumo" | "system";
+
+export type ToolStatus = "pending" | "running" | "success" | "error" | "cancelled";
+export type DelegationStatus = "queued" | "running" | "success" | "error" | "cancelled";
+
+export interface ToolCallViewModel {
+	readonly id?: string;
+	readonly name: string;
+	readonly status: ToolStatus;
+	readonly input?: unknown;
+	readonly output?: string;
+	readonly details?: unknown;
+	readonly error?: string;
+}
+
+export interface QuestionViewModel {
+	readonly id?: string;
+	readonly prompt: string;
+	readonly choices: readonly string[];
+	readonly selected?: string;
+	readonly required?: boolean;
+}
+
+export interface DelegationViewModel {
+	readonly id?: string;
+	readonly title: string;
+	readonly agent?: string;
+	readonly status: DelegationStatus;
+	readonly summary?: string;
+}
+
+export type ChatBlock =
+	| { readonly type: "markdown"; readonly text: string }
+	| { readonly type: "code"; readonly lang: string; readonly source: string; readonly collapsed?: boolean }
+	| { readonly type: "tool"; readonly tool: ToolCallViewModel }
+	| { readonly type: "skill"; readonly name: string; readonly expanded: boolean }
+	| { readonly type: "question"; readonly question: QuestionViewModel }
+	| { readonly type: "delegation"; readonly delegation: DelegationViewModel };
+
+export interface ChatMessageViewModel {
+	readonly id: string;
+	readonly role: ChatMessageRole;
+	readonly displayName: string;
+	readonly timestamp?: Date;
+	readonly blocks: readonly ChatBlock[];
+}
+
+export interface TranscriptViewModel {
+	readonly messages: readonly ChatMessageViewModel[];
+}
+
+const FENCED_CODE_PATTERN = /```([^\n`]*)\n?([\s\S]*?)```/g;
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === "string" ? value : undefined;
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+	return typeof value === "boolean" ? value : undefined;
+}
+
+function asStringArray(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.filter((item): item is string => typeof item === "string");
+}
+
+function firstString(...values: unknown[]): string | undefined {
+	for (const value of values) {
+		if (typeof value === "string" && value.length > 0) return value;
+	}
+	return undefined;
+}
+
+function timestampFrom(value: unknown): Date | undefined {
+	if (value instanceof Date) return value;
+	if (typeof value === "number" && Number.isFinite(value)) return new Date(value);
+	if (typeof value === "string") {
+		const timestamp = Date.parse(value);
+		if (Number.isFinite(timestamp)) return new Date(timestamp);
+	}
+	return undefined;
+}
+
+function messageId(record: Record<string, unknown>, fallbackIndex: number): string {
+	return firstString(record.id, record.messageId, record.responseId, record.toolCallId) ?? `message-${fallbackIndex}`;
+}
+
+function roleFromMessage(record: Record<string, unknown>): ChatMessageRole {
+	if (record.role === "user") return "user";
+	if (record.role === "assistant") return "sumo";
+	return "system";
+}
+
+function displayName(role: ChatMessageRole): string {
+	if (role === "user") return "YOU";
+	if (role === "sumo") return "SUMO";
+	return "SYSTEM";
+}
+
+function normalizeStatus(value: unknown, fallback: ToolStatus): ToolStatus {
+	if (value === "pending" || value === "running" || value === "success" || value === "error" || value === "cancelled") return value;
+	if (value === "ok" || value === "done") return "success";
+	if (value === "failed" || value === "failure") return "error";
+	return fallback;
+}
+
+function normalizeDelegationStatus(value: unknown): DelegationStatus {
+	if (value === "queued" || value === "running" || value === "success" || value === "error" || value === "cancelled") return value;
+	if (value === "ok" || value === "done") return "success";
+	if (value === "failed" || value === "failure") return "error";
+	return "running";
+}
+
+export function markdownAndCodeBlocksFromText(text: string): ChatBlock[] {
+	if (text.length === 0) return [];
+
+	const blocks: ChatBlock[] = [];
+	let cursor = 0;
+	for (const match of text.matchAll(FENCED_CODE_PATTERN)) {
+		const index = match.index ?? 0;
+		const before = text.slice(cursor, index);
+		if (before.length > 0) blocks.push({ type: "markdown", text: before });
+		blocks.push({
+			type: "code",
+			lang: (match[1] ?? "").trim(),
+			source: (match[2] ?? "").replace(/\n$/, ""),
+		});
+		cursor = index + match[0].length;
+	}
+
+	const after = text.slice(cursor);
+	if (after.length > 0) blocks.push({ type: "markdown", text: after });
+	return blocks.length > 0 ? blocks : [{ type: "markdown", text }];
+}
+
+function textFromContent(content: unknown): string {
+	if (typeof content === "string") return content;
+	if (!Array.isArray(content)) return "";
+	return content
+		.map((part) => {
+			const record = asRecord(part);
+			if (!record || record.type !== "text") return undefined;
+			return asString(record.text);
+		})
+		.filter((part): part is string => part !== undefined)
+		.join("");
+}
+
+function toolBlockFromRecord(record: Record<string, unknown>, fallbackStatus: ToolStatus): ChatBlock {
+	const name = firstString(record.name, record.toolName, record.command) ?? "tool";
+	const output = textFromContent(record.content) || asString(record.output);
+	const error = asString(record.errorMessage) ?? asString(record.error);
+	const isError = record.isError === true || error !== undefined;
+	return {
+		type: "tool",
+		tool: {
+			id: firstString(record.id, record.toolCallId),
+			name,
+			status: normalizeStatus(record.status, isError ? "error" : fallbackStatus),
+			input: record.arguments ?? record.input ?? (record.command ? { command: record.command } : undefined),
+			output,
+			details: record.details,
+			error,
+		},
+	};
+}
+
+function skillBlockFromRecord(record: Record<string, unknown>): ChatBlock {
+	return {
+		type: "skill",
+		name: firstString(record.name, record.skill, record.skillName) ?? "unknown-skill",
+		expanded: asBoolean(record.expanded) ?? false,
+	};
+}
+
+function questionBlockFromRecord(record: Record<string, unknown>): ChatBlock {
+	return {
+		type: "question",
+		question: {
+			id: firstString(record.id, record.questionId),
+			prompt: firstString(record.prompt, record.question, record.title, record.message) ?? "question",
+			choices: asStringArray(record.choices).length > 0 ? asStringArray(record.choices) : asStringArray(record.options),
+			selected: firstString(record.selected, record.defaultChoice),
+			required: asBoolean(record.required),
+		},
+	};
+}
+
+function delegationBlockFromRecord(record: Record<string, unknown>): ChatBlock {
+	return {
+		type: "delegation",
+		delegation: {
+			id: firstString(record.id, record.delegationId),
+			title: firstString(record.title, record.name, record.agent, record.target) ?? "delegation",
+			agent: firstString(record.agent, record.target),
+			status: normalizeDelegationStatus(record.status),
+			summary: firstString(record.summary, record.text, record.description),
+		},
+	};
+}
+
+function blocksFromContentPart(part: unknown): ChatBlock[] {
+	const record = asRecord(part);
+	if (!record) return [];
+	switch (record.type) {
+		case "text":
+			return markdownAndCodeBlocksFromText(asString(record.text) ?? "");
+		case "toolCall":
+		case "tool_call":
+		case "tool":
+			return [toolBlockFromRecord(record, record.status === "running" ? "running" : "pending")];
+		case "toolResult":
+		case "tool_result":
+			return [toolBlockFromRecord(record, "success")];
+		case "skill":
+		case "skill_invocation":
+			return [skillBlockFromRecord(record)];
+		case "question":
+		case "confirm":
+		case "select":
+			return [questionBlockFromRecord(record)];
+		case "delegation":
+		case "scroll":
+		case "subagent":
+			return [delegationBlockFromRecord(record)];
+		default:
+			return [];
+	}
+}
+
+function blocksFromContent(content: unknown): ChatBlock[] {
+	if (typeof content === "string") return markdownAndCodeBlocksFromText(content);
+	if (!Array.isArray(content)) return [];
+	return content.flatMap((part) => blocksFromContentPart(part));
+}
+
+function blocksFromMessage(record: Record<string, unknown>): ChatBlock[] {
+	if (record.role === "bashExecution") {
+		const status = record.cancelled === true ? "cancelled" : record.exitCode === 0 || record.exitCode === undefined ? "success" : "error";
+		return [toolBlockFromRecord({ ...record, type: "tool", name: "bash", status }, status)];
+	}
+	if (record.role === "toolResult") return [toolBlockFromRecord(record, "success")];
+	if (record.role === "custom" && typeof record.customType === "string") {
+		if (record.customType === "skill") return [skillBlockFromRecord(asRecord(record.details) ?? record)];
+		if (record.customType === "question") return [questionBlockFromRecord(asRecord(record.details) ?? record)];
+		if (record.customType === "delegation") return [delegationBlockFromRecord(asRecord(record.details) ?? record)];
+	}
+
+	const blocks = blocksFromContent(record.content);
+	if (blocks.length > 0) return blocks;
+	const errorMessage = asString(record.errorMessage);
+	return errorMessage ? [{ type: "markdown", text: errorMessage }] : [];
+}
+
+export function chatMessageViewModelFromPiMessage(message: unknown, index = 0): ChatMessageViewModel | undefined {
+	const record = asRecord(message);
+	if (!record) return undefined;
+	if (record.role === "custom" && record.display === false) return undefined;
+
+	const role = roleFromMessage(record);
+	const blocks = blocksFromMessage(record);
+	return {
+		id: messageId(record, index),
+		role,
+		displayName: displayName(role),
+		timestamp: timestampFrom(record.timestamp),
+		blocks: blocks.length > 0 ? blocks : [{ type: "markdown", text: "" }],
+	};
+}
+
+export function transcriptFromSessionContext(sessionContext: unknown): TranscriptViewModel {
+	const messages = asRecord(sessionContext)?.messages;
+	if (!Array.isArray(messages)) return { messages: [] };
+	return {
+		messages: messages
+			.map((message, index) => chatMessageViewModelFromPiMessage(message, index))
+			.filter((message): message is ChatMessageViewModel => message !== undefined),
+	};
+}
+
+export function chatMessageViewModelToPlainText(message: ChatMessageViewModel): string {
+	return message.blocks
+		.map((block) => {
+			switch (block.type) {
+				case "markdown":
+					return block.text;
+				case "code":
+					return `\`\`\`${block.lang}\n${block.source}\n\`\`\``;
+				case "tool":
+					return [`[tool] ${block.tool.name} · ${block.tool.status}`, block.tool.output, block.tool.error].filter(Boolean).join("\n");
+				case "skill":
+					return `[skill] ${block.name}${block.expanded ? " (expanded)" : " (⌘O to expand)"}`;
+				case "question":
+					return [`[question] ${block.question.prompt}`, ...block.question.choices.map((choice) => `- ${choice}`)].join("\n");
+				case "delegation":
+					return [`[delegation] ${block.delegation.title} · ${block.delegation.status}`, block.delegation.summary].filter(Boolean).join("\n");
+			}
+		})
+		.join("\n");
+}


### PR DESCRIPTION
## Summary

- Add `ChatMessageViewModel` plus typed chat block variants for markdown, code, tool, skill, question, and delegation blocks.
- Add conversion helpers for current Pi/session messages:
  - `chatMessageViewModelFromPiMessage()`
  - `transcriptFromSessionContext()`
  - `chatMessageViewModelToPlainText()` as a temporary legacy bridge for string-only `ChatPager` rendering.
- Add mapping tests for markdown, code fences, tool calls/results, skills, questions, delegations, bash execution, hidden custom messages, and legacy flattening.
- Document the transcript contract in `docs/SUMO_TUI_TRANSCRIPT_MODEL.md`, including how it unblocks #89 chat frames and #90 fixture-backed runtime states.
- Link the doc from the consolidation plan and agent instructions.

## Verification

- `pnpm test` — 75 files passed, 435 tests passed
- `pnpm test:integration` — 11 files passed, 14 tests passed
- `pnpm visual:ci` — passed; required gates did not fail
- `pnpm exec tsc --noEmit && pnpm build` — passed

Closes #107
