### PR TITLE
feat(splash): align runtime invocation parity

### DIFF
--- a/docs/ui/CATHEDRAL_UX_SPEC_V2.md
+++ b/docs/ui/CATHEDRAL_UX_SPEC_V2.md
@@ -262,9 +262,8 @@ SUMOCODE   ║ • auth-flow-refactor ║   │ debug-balance-tx   │ index-iss
 
 
 
-                  "perfection is achieved when there is
-                              nothing left to take away."
-                                  — saint-exupéry
+                          "Meow meow meow... meow meow"
+                                      — SUMO
 
 
 

--- a/docs/visual/parity/README.md
+++ b/docs/visual/parity/README.md
@@ -39,7 +39,15 @@ pnpm visual:review -- --lane runtime
 
 See `CONTRACT.md` for the full contract.
 
-## Initial runtime scenario note
+## Runtime scenario notes
+
+`splash-runtime` invokes the user-facing contract directly:
+
+```bash
+./bin/sumocode.sh --offline --no-extensions --no-session
+```
+
+The scenario rejects known loader/error output (`ERR_MODULE_NOT_FOUND`, terminal-width crashes, dev-checkout extension skips, and raw `Error [` screens) as hard capture failures. #71's original blank/offline splash failure is therefore not hidden by an accepted screenshot: the capture must show the V2 splash or fail before review.
 
 The active runtime scenarios submit a prompt and capture the deterministic offline **active-working** state. They intentionally do not wait for a completed model answer because `--offline --no-session` cannot produce one deterministically. Completed-response scene captures should be fixture-backed in a later slice.
 

--- a/src/cathedral/cathedral-editor.ts
+++ b/src/cathedral/cathedral-editor.ts
@@ -48,6 +48,7 @@ import {
 
 const RESET = "\u001b[0m";
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+const SPLASH_INPUT_FRAME_WIDTH = 60;
 
 function visibleLength(text: string): number {
 	return visibleWidth(text);
@@ -122,6 +123,14 @@ function wrapRow(inner: string, width: number): string {
 	return withFrameBackground(`${DIVIDER_FG}│${RESET}${padded}${DIVIDER_FG}│${RESET}`);
 }
 
+function centerRow(row: string, width: number): string {
+	const visible = visibleLength(row);
+	if (visible >= width) return row;
+	const left = Math.floor((width - visible) / 2);
+	const right = width - visible - left;
+	return `${" ".repeat(left)}${row}${" ".repeat(right)}`;
+}
+
 /**
  * Test whether a row is one of Pi's flat horizontal borders, i.e. a row
  * consisting of nothing but `─` chars (after stripping ANSI), or one of
@@ -150,14 +159,17 @@ class CathedralEditor extends CustomEditor {
 		// Too narrow for our chrome — fall back to Pi's bare render.
 		if (width < 8) return super.render(width);
 
-		// Always defer to Pi's editor for layout. Pi gets `width - 2` so its
+		const splash = this.isSplash();
+		const frameWidth = splash ? Math.min(width, SPLASH_INPUT_FRAME_WIDTH) : width;
+
+		// Always defer to Pi's editor for layout. Pi gets `frameWidth - 2` so its
 		// content fits inside our `│ ... │` side borders. Pi's CURSOR_MARKER
 		// stays in the row, so when we prepend `│` (one visible cell) the
 		// cursor's visual column is correctly offset by 1.
-		const innerRows = super.render(width - 2);
+		const innerRows = super.render(frameWidth - 2);
 		if (innerRows.length === 0) return innerRows;
 
-		const splash = this.isSplash();
+		const fullRow = (row: string): string => splash ? centerRow(row, width) : row;
 		const label = splash ? INPUT_FRAME_LABEL_SPLASH : INPUT_FRAME_LABEL_ACTIVE;
 
 		// Find Pi's bottom border row. Pi's render is structured:
@@ -185,13 +197,13 @@ class CathedralEditor extends CustomEditor {
 				// Without this, TUI.positionHardwareCursor() sees no marker on the
 				// splash empty state and emits \x1b[?25l after every render.
 				const ghost = color(`> ${CURSOR_MARKER}${INPUT_FRAME_PLACEHOLDER}`, CATHEDRAL_TOKENS.colors.foregroundDim);
-				return wrapRow(ghost, width);
+				return fullRow(wrapRow(ghost, frameWidth));
 			}
-			return wrapRow(row, width);
+			return fullRow(wrapRow(row, frameWidth));
 		};
 
-		const result: string[] = [renderTopBorder(width, label)];
-		const paddingRow = wrapRow("", width);
+		const result: string[] = [fullRow(renderTopBorder(frameWidth, label))];
+		const paddingRow = fullRow(wrapRow("", frameWidth));
 		if (splash) result.push(paddingRow);
 
 		const lastContentIdx = bottomIdx === -1 ? innerRows.length : bottomIdx;
@@ -204,7 +216,7 @@ class CathedralEditor extends CustomEditor {
 		// adding active-state bottom padding. In active chat, every extra editor
 		// row steals vertical space from chat and makes the shell feel bouncy.
 		if (splash) result.push(paddingRow);
-		result.push(renderBottomBorder(width));
+		result.push(fullRow(renderBottomBorder(frameWidth)));
 
 		// Autocomplete rows after Pi's bottom border — passed through as-is
 		// at the narrower inner width. They appear as a dropdown directly

--- a/src/cathedral/input-hints.ts
+++ b/src/cathedral/input-hints.ts
@@ -13,14 +13,27 @@
 
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { Component } from "@mariozechner/pi-tui";
+import { visibleWidth } from "@mariozechner/pi-tui";
 import { INPUT_FRAME_HINT_AWAITING, renderInputHints } from "./input-frame.js";
+
+const SPLASH_INPUT_FRAME_WIDTH = 60;
+const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+
+function centerAnsi(line: string, width: number): string {
+	const visible = visibleWidth(line.replace(ANSI_PATTERN, ""));
+	if (visible >= width) return line;
+	const left = Math.floor((width - visible) / 2);
+	const right = width - visible - left;
+	return `${" ".repeat(left)}${line}${" ".repeat(right)}`;
+}
 
 class InputHintsComponent implements Component {
 	constructor(private readonly isSplash: () => boolean) {}
 	invalidate(): void {}
 	render(width: number): string[] {
 		if (this.isSplash()) {
-			return [renderInputHints(width, { leftHint: INPUT_FRAME_HINT_AWAITING })];
+			const frameWidth = Math.min(width, SPLASH_INPUT_FRAME_WIDTH);
+			return [centerAnsi(renderInputHints(frameWidth, { leftHint: INPUT_FRAME_HINT_AWAITING }), width)];
 		}
 		return [renderInputHints(width)];
 	}

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -183,7 +183,7 @@ export function installFooter(pi: ExtensionAPI): void {
 				},
 				invalidate(): void {},
 				render(width: number): string[] {
-					return [formatFooterLine(createSnapshot(pi, ctx, footerData.getGitBranch(), state), width)];
+					return renderFooterBlock(createSnapshot(pi, ctx, footerData.getGitBranch(), state), width);
 				},
 			};
 		});

--- a/src/splash.test.ts
+++ b/src/splash.test.ts
@@ -12,9 +12,8 @@ const stripAnsi = (s: string): string => s.replace(ANSI, "");
 
 function snapshot(overrides: Partial<SplashSnapshot> = {}): SplashSnapshot {
 	return {
-		quote:
-			'"PERFECTION IS ACHIEVED, NOT WHEN THERE IS NOTHING MORE TO ADD, BUT WHEN THERE IS NOTHING LEFT TO TAKE AWAY."',
-		quoteAttribution: "— ANTOINE DE SAINT-EXUPÉRY",
+		quote: '"Meow meow meow... meow meow"',
+		quoteAttribution: "— SUMO",
 		hasMessages: false,
 		...overrides,
 	};
@@ -51,10 +50,8 @@ describe("renderSplash", () => {
 		const lines = renderSplash(snapshot(), 160);
 		const blob = lines.join("\n");
 
-		expect(stripAnsi(blob)).toContain(
-			"PERFECTION IS ACHIEVED, NOT WHEN THERE IS NOTHING MORE TO ADD, BUT WHEN THERE IS NOTHING LEFT TO TAKE AWAY.",
-		);
-		expect(stripAnsi(blob)).toContain("— ANTOINE DE SAINT-EXUPÉRY");
+		expect(stripAnsi(blob)).toContain("Meow meow meow... meow meow");
+		expect(stripAnsi(blob)).toContain("— SUMO");
 		// Dim muted brown #8B7A63 -> 139;122;99
 		expect(blob).toContain("\u001b[38;2;139;122;99m");
 	});

--- a/src/splash.ts
+++ b/src/splash.ts
@@ -9,7 +9,7 @@
  *   - blank rows for vertical centering
  *   - Sumo BSH cat face (chafa-converted from a Gemini-generated PNG)
  *   - SUMOCODE block-letter wordmark in burnt orange
- *   - Saint-Exupéry quote in dim muted brown
+ *   - Visual Bible quote in dim muted brown
  *
  * The Pi-glue lives in `installTabBar` because Pi exposes only ONE setHeader
  * slot. The splash and the tab bar are stacked into a single header render.
@@ -93,12 +93,9 @@ function loadFace(): readonly string[] {
 
 const SUMO_FACE = loadFace();
 
-// Quote text + attribution lifted verbatim from the Stitch HTML mockup
-// (`docs/ui/stitch/cathedral/v1-html/splash.html`). The CSS applies
-// `uppercase` so the rendered string in the terminal is upper-case too.
-export const SUMOCODE_QUOTE =
-	'"PERFECTION IS ACHIEVED, NOT WHEN THERE IS NOTHING MORE TO ADD, BUT WHEN THERE IS NOTHING LEFT TO TAKE AWAY."';
-export const SUMOCODE_QUOTE_ATTRIBUTION = "— ANTOINE DE SAINT-EXUPÉRY";
+// Quote text + attribution locked by the V2 Visual Bible Element 3 splash.
+export const SUMOCODE_QUOTE = '"Meow meow meow... meow meow"';
+export const SUMOCODE_QUOTE_ATTRIBUTION = "— SUMO";
 
 export type SplashSnapshot = {
 	quote: string;
@@ -134,7 +131,7 @@ export function renderSplashContent(snapshot: SplashSnapshot, width: number): st
 	content.push("");
 	content.push("");
 
-	// Saint-Exupéry quote in dim muted brown.
+	// V2 Visual Bible quote in dim muted brown.
 	content.push(center(`${DIM}${MUTED}${snapshot.quote}${RESET}`, width));
 	content.push(center(`${DIM}${MUTED}${snapshot.quoteAttribution}${RESET}`, width));
 

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
@@ -120,12 +120,12 @@ describe("sumo interactive Pi noise filtering", () => {
 		const expectedTop = Math.floor((30 - getSplashContentHeight(defaultSplashSnapshot(false), 100)) / 2);
 		expect(firstNonBlankRow(lines)).toBeGreaterThanOrEqual(expectedTop);
 		expect(lines.join("\n")).toContain("38;2;217;119;6");
-		expect(stripAnsi(lines.join("\n"))).toContain("PERFECTION IS ACHIEVED");
+		expect(stripAnsi(lines.join("\n"))).toContain("Meow meow meow");
 
 		snapshot.chat.addMessage("user", "hello");
 		const chatLines = runtime.renderChatLines(100, 30);
 		expect(stripAnsi(chatLines.join("\n"))).toContain("USER > hello");
-		expect(stripAnsi(chatLines.join("\n"))).not.toContain("PERFECTION IS ACHIEVED");
+		expect(stripAnsi(chatLines.join("\n"))).not.toContain("Meow meow meow");
 		runtime.stop();
 	});
 

--- a/src/visual-parity-contract.test.ts
+++ b/src/visual-parity-contract.test.ts
@@ -25,6 +25,12 @@ type Scenario = {
 		cols: number;
 		rows: number;
 	};
+	runtime?: {
+		command: string;
+		args: string[];
+		env?: Record<string, string>;
+	};
+	rejectIfOutputMatches?: string[];
 	crops: ScenarioCrop[];
 };
 
@@ -61,6 +67,20 @@ describe("V2 visual parity contract", () => {
 		expect(scenario("active-landscape-runtime").dimensions).toEqual({ cols: 160, rows: 45 });
 		expect(scenario("active-portrait-runtime").dimensions).toEqual({ cols: 60, rows: 100 });
 		expect(cropDefinition("sidebar")).toEqual({ x: 130, y: 3, cols: 30, rows: 34 });
+	});
+
+	it("keeps splash runtime capture on the user-facing invocation contract", () => {
+		const splash = scenario("splash-runtime");
+
+		expect(splash.runtime?.command).toBe("./bin/sumocode.sh");
+		expect(splash.runtime?.args).toEqual(["--offline", "--no-extensions", "--no-session"]);
+		expect(splash.runtime?.env).toMatchObject({ SUMO_TUI: "1", PI_OFFLINE: "1" });
+		expect(splash.rejectIfOutputMatches).toEqual(expect.arrayContaining([
+			"ERR_MODULE_NOT_FOUND",
+			"Rendered line .* exceeds terminal width",
+			"Skipping installed SumoCode extension because this session is already inside an active SumoCode dev checkout",
+			"Error \\\[",
+		]));
 	});
 
 	it("keeps the V1 portrait runtime no-sidebar", () => {

--- a/test/integration/splash-centering.test.ts
+++ b/test/integration/splash-centering.test.ts
@@ -20,12 +20,12 @@ describe("sumo-tui splash centering integration", () => {
 			const lines = runtime.renderChatLines(100, 30);
 			const expectedTop = Math.floor((30 - getSplashContentHeight(defaultSplashSnapshot(false), 100)) / 2);
 			expect(firstNonBlankRow(lines)).toBeGreaterThanOrEqual(expectedTop);
-			expect(stripAnsi(lines.join("\n"))).toContain("PERFECTION IS ACHIEVED");
+			expect(stripAnsi(lines.join("\n"))).toContain("Meow meow meow");
 
 			snapshot.chat.addMessage("user", "hello");
 			const chatLines = runtime.renderChatLines(100, 30);
 			expect(stripAnsi(chatLines.join("\n"))).toContain("USER > hello");
-			expect(stripAnsi(chatLines.join("\n"))).not.toContain("PERFECTION IS ACHIEVED");
+			expect(stripAnsi(chatLines.join("\n"))).not.toContain("Meow meow meow");
 		} finally {
 			runtime.stop();
 		}


### PR DESCRIPTION
## Summary

- Align the retained splash runtime with the V2 Bible Element 3 copy and centered invocation treatment.
- Switch the splash quote/signature to the Visual Bible copy (`"Meow meow meow... meow meow"` / `— SUMO`).
- Center the splash `DIVINE INVOCATION` editor frame and hint row at the locked 60-col splash width while keeping the active input frame full-width/label-less.
- Render the splash-only version line through the footer block in the real runtime.
- Lock the `splash-runtime` invocation and hard-error rejection contract in tests/docs so #71-style blank/error captures cannot be accepted as review evidence.

## Visual evidence

- `pnpm visual:review -- --scenario splash-runtime`
- Review pack: `docs/visual/out/parity/index.html`
- Runtime artifact: `docs/visual/out/parity/splash-runtime/runtime-full.png`
- Current full-screen Bible diff remains `review` status, not promoted/gated.

## Verification

- `pnpm test` — 75 files passed, 436 tests passed
- `pnpm test:integration` — 11 files passed, 14 tests passed
- `pnpm visual:ci` — passed; required gates did not fail
- `pnpm exec tsc --noEmit && pnpm build` — passed

Closes #88
