### PR TITLE
fix(splash): align runtime Bible spacing

### DIFF
--- a/src/cathedral/cathedral-editor.ts
+++ b/src/cathedral/cathedral-editor.ts
@@ -84,25 +84,29 @@ function withFrameBackground(line: string): string {
 	return `${RECESS_BG}${line.replaceAll(RESET, `${RESET}${RECESS_BG}`)}${RESET_BG}`;
 }
 
+function maybeWithFrameBackground(line: string, enabled: boolean): string {
+	return enabled ? withFrameBackground(line) : line;
+}
+
 /**
  * Build the cathedral top border with an optional embedded label. V2 active
  * input is label-less; splash uses `DIVINE INVOCATION`.
  */
-function renderTopBorder(width: number, label?: string): string {
-	if (width < 6) return withFrameBackground(color("─".repeat(width), CATHEDRAL_TOKENS.colors.divider));
+function renderTopBorder(width: number, label: string | undefined, paintBackground: boolean): string {
+	if (width < 6) return maybeWithFrameBackground(color("─".repeat(width), CATHEDRAL_TOKENS.colors.divider), paintBackground);
 	const inner = width - 2;
-	if (!label) return withFrameBackground(color(`┌${"─".repeat(inner)}┐`, CATHEDRAL_TOKENS.colors.divider));
+	if (!label) return maybeWithFrameBackground(color(`┌${"─".repeat(inner)}┐`, CATHEDRAL_TOKENS.colors.divider), paintBackground);
 	const labelInner = ` ${label} `;
-	const remaining = Math.max(2, inner - labelInner.length - 2);
-	const left = `${DIVIDER_FG}┌──`;
+	const remaining = Math.max(2, width - labelInner.length - 3);
+	const left = `${DIVIDER_FG}┌─`;
 	const labelText = color(labelInner, CATHEDRAL_TOKENS.colors.accent);
 	const right = `${DIVIDER_FG}${"─".repeat(remaining)}┐${RESET}`;
-	return withFrameBackground(`${left}${labelText}${right}`);
+	return maybeWithFrameBackground(`${left}${labelText}${right}`, paintBackground);
 }
 
-function renderBottomBorder(width: number): string {
-	if (width < 6) return withFrameBackground(color("─".repeat(width), CATHEDRAL_TOKENS.colors.divider));
-	return withFrameBackground(color(`└${"─".repeat(width - 2)}┘`, CATHEDRAL_TOKENS.colors.divider));
+function renderBottomBorder(width: number, paintBackground: boolean): string {
+	if (width < 6) return maybeWithFrameBackground(color("─".repeat(width), CATHEDRAL_TOKENS.colors.divider), paintBackground);
+	return maybeWithFrameBackground(color(`└${"─".repeat(width - 2)}┘`, CATHEDRAL_TOKENS.colors.divider), paintBackground);
 }
 
 /**
@@ -115,12 +119,12 @@ function renderBottomBorder(width: number): string {
  * cursor placement, syntax/highlight colors, etc.). We just measure visible
  * length to compute padding.
  */
-function wrapRow(inner: string, width: number): string {
+function wrapRow(inner: string, width: number, paintBackground: boolean): string {
 	const innerWidth = Math.max(0, width - 2);
 	const visible = visibleLength(inner);
 	const pad = Math.max(0, innerWidth - visible);
 	const padded = `${inner}${" ".repeat(pad)}`;
-	return withFrameBackground(`${DIVIDER_FG}│${RESET}${padded}${DIVIDER_FG}│${RESET}`);
+	return maybeWithFrameBackground(`${DIVIDER_FG}│${RESET}${padded}${DIVIDER_FG}│${RESET}`, paintBackground);
 }
 
 function centerRow(row: string, width: number): string {
@@ -171,6 +175,7 @@ class CathedralEditor extends CustomEditor {
 
 		const fullRow = (row: string): string => splash ? centerRow(row, width) : row;
 		const label = splash ? INPUT_FRAME_LABEL_SPLASH : INPUT_FRAME_LABEL_ACTIVE;
+		const paintFrameBackground = !splash;
 
 		// Find Pi's bottom border row. Pi's render is structured:
 		//   row 0           : top border (─...─)
@@ -196,15 +201,13 @@ class CathedralEditor extends CustomEditor {
 				// Preserve Pi's zero-width cursor marker while painting our ghost text.
 				// Without this, TUI.positionHardwareCursor() sees no marker on the
 				// splash empty state and emits \x1b[?25l after every render.
-				const ghost = color(`> ${CURSOR_MARKER}${INPUT_FRAME_PLACEHOLDER}`, CATHEDRAL_TOKENS.colors.foregroundDim);
-				return fullRow(wrapRow(ghost, frameWidth));
+				const ghost = ` ${color(">", CATHEDRAL_TOKENS.colors.accent)} ${color(`${INPUT_FRAME_PLACEHOLDER}${CURSOR_MARKER}`, CATHEDRAL_TOKENS.colors.foregroundDim)}`;
+				return fullRow(wrapRow(ghost, frameWidth, paintFrameBackground));
 			}
-			return fullRow(wrapRow(row, frameWidth));
+			return fullRow(wrapRow(row, frameWidth, paintFrameBackground));
 		};
 
-		const result: string[] = [fullRow(renderTopBorder(frameWidth, label))];
-		const paddingRow = fullRow(wrapRow("", frameWidth));
-		if (splash) result.push(paddingRow);
+		const result: string[] = [fullRow(renderTopBorder(frameWidth, label, paintFrameBackground))];
 
 		const lastContentIdx = bottomIdx === -1 ? innerRows.length : bottomIdx;
 		let contentSeen = false;
@@ -212,11 +215,7 @@ class CathedralEditor extends CustomEditor {
 			result.push(renderContent(innerRows[i]!, !contentSeen));
 			contentSeen = true;
 		}
-		// Keep the roomy mockup padding for the splash empty state, but avoid
-		// adding active-state bottom padding. In active chat, every extra editor
-		// row steals vertical space from chat and makes the shell feel bouncy.
-		if (splash) result.push(paddingRow);
-		result.push(fullRow(renderBottomBorder(frameWidth)));
+		result.push(fullRow(renderBottomBorder(frameWidth, paintFrameBackground)));
 
 		// Autocomplete rows after Pi's bottom border — passed through as-is
 		// at the narrower inner width. They appear as a dropdown directly

--- a/src/cathedral/input-hints.ts
+++ b/src/cathedral/input-hints.ts
@@ -32,6 +32,9 @@ class InputHintsComponent implements Component {
 	invalidate(): void {}
 	render(width: number): string[] {
 		if (this.isSplash()) {
+			// On splash the hint row is visually part of the centered invocation
+			// block. Return just the hint (no leading blank) so Pi's belowEditor
+			// slot stays compact and the input frame sits close to the content.
 			const frameWidth = Math.min(width, SPLASH_INPUT_FRAME_WIDTH);
 			return [centerAnsi(renderInputHints(frameWidth, { leftHint: INPUT_FRAME_HINT_AWAITING }), width)];
 		}

--- a/src/footer.test.ts
+++ b/src/footer.test.ts
@@ -156,22 +156,24 @@ describe("formatCwd", () => {
 	});
 });
 
-describe("renderFooterBlock — splash adds a version line", () => {
+describe("renderFooterBlock — splash renders Bible version block", () => {
 	it("in active state, returns 1 line (just the footer)", () => {
 		const lines = renderFooterBlock(snapshot({ isSplash: false }));
 		expect(lines.length).toBe(1);
 	});
 
-	it("on splash, returns 2 lines (footer + version)", () => {
+	it("on splash, returns breathing rows plus version with no status footer", () => {
 		const lines = renderFooterBlock(snapshot({ isSplash: true }), 160);
-		expect(lines.length).toBe(2);
-		const plainSecond = lines[1]!.replace(ANSI, "");
-		expect(plainSecond).toContain(SPLASH_VERSION_LINE);
+		expect(lines.length).toBe(10);
+		const plain = lines.map((line) => line.replace(ANSI, ""));
+		expect(plain[2]).toContain(SPLASH_VERSION_LINE);
+		expect(plain.join("\n")).not.toContain("READY");
 	});
 
-	it("on splash but too narrow for version line, returns 1 line", () => {
+	it("on splash but too narrow for version line, keeps breathing rows without status footer", () => {
 		const lines = renderFooterBlock(snapshot({ isSplash: true }), 30);
-		expect(lines.length).toBe(1);
+		expect(lines.length).toBe(9);
+		expect(lines.join("\n").replace(ANSI, "")).not.toContain("READY");
 	});
 });
 

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -44,6 +44,8 @@ export const SPLASH_VERSION_LINE = "SUMOCODE V0.2.0 · CATHEDRAL · 160 × 45 MO
 type GitRunner = (args: string[], cwd: string) => string;
 
 const RESET = "\u001b[0m";
+const SPLASH_VERSION_TOP_GAP_ROWS = 2;
+const SPLASH_VERSION_BOTTOM_GAP_ROWS = 7;
 
 export function colorHex(text: string, hex: string): string {
 	const normalized = hex.replace("#", "");
@@ -150,14 +152,18 @@ export function renderSplashVersionLine(width: number): string {
 }
 
 /**
- * Render the full footer block. 1 line in active state, 2 lines on splash
- * (footer + version line).
+ * Render the full footer block. Active state keeps the status footer. Splash
+ * matches Bible Element 3: no status footer, just breathing rows and the
+ * centered version line below the invocation hint row.
  */
 export function renderFooterBlock(snapshot: FooterSnapshot, width = 160): string[] {
-	const footer = formatFooterLine(snapshot, width);
-	if (!snapshot.isSplash) return [footer];
+	if (!snapshot.isSplash) return [formatFooterLine(snapshot, width)];
 	const version = renderSplashVersionLine(width);
-	return version === "" ? [footer] : [footer, version];
+	return [
+		...Array.from({ length: SPLASH_VERSION_TOP_GAP_ROWS }, () => ""),
+		...(version === "" ? [] : [version]),
+		...Array.from({ length: SPLASH_VERSION_BOTTOM_GAP_ROWS }, () => ""),
+	];
 }
 
 export function installFooter(pi: ExtensionAPI): void {

--- a/src/splash.ts
+++ b/src/splash.ts
@@ -24,7 +24,8 @@ import type { Component } from "@mariozechner/pi-tui";
 import { CATHEDRAL_TOKENS } from "./tokens.js";
 
 const RESET = "\u001b[0m";
-const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+const ANSI_PATTERN = /\u001b(?:\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001b\\))/g;
+const CURSOR_VISIBILITY_PATTERN = /\u001b\[\?25[lh]/g;
 
 function fg(hex: string): string {
 	const n = hex.replace("#", "");
@@ -84,8 +85,8 @@ const FACE_PATH = resolve(ASSET_DIR, "sumo-face.ans");
  */
 function loadFace(): readonly string[] {
 	try {
-		const raw = readFileSync(FACE_PATH, "utf8").replace(/\r?\n$/, "");
-		return raw.split("\n");
+		const raw = readFileSync(FACE_PATH, "utf8").replace(CURSOR_VISIBILITY_PATTERN, "");
+		return raw.replace(/\r?\n$/, "").split(/\r?\n/).filter((line) => line.length > 0);
 	} catch {
 		return [];
 	}

--- a/src/sumo-tui/cathedral/splash-tree.test.ts
+++ b/src/sumo-tui/cathedral/splash-tree.test.ts
@@ -1,20 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { SumoNode } from "../layout/node.js";
 import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga } from "../layout/yoga.js";
-import { CellBuffer } from "../render/buffer.js";
-import { composite } from "../render/compositor.js";
 import { createSplashTree, defaultSplashSnapshot, getSplashContentHeight } from "./splash-tree.js";
-
-function firstNonBlankRow(buffer: CellBuffer, height: number): number {
-	for (let row = 0; row < height; row += 1) {
-		if (buffer.toPlainRow(row).trim().length > 0) return row;
-	}
-	return -1;
-}
 
 describe("createSplashTree", () => {
 	for (const height of [30, 60, 100]) {
-		it(`centers splash content vertically at ${height} rows with flex spacers`, async () => {
+		it(`bottom-aligns splash content at ${height} rows so it stays close to Pi's editor`, async () => {
 			const yoga = await loadYoga();
 			const root = new SumoNode(yoga.Node.create());
 			root.flexDirection = FLEX_DIRECTION_COLUMN;
@@ -24,16 +15,12 @@ describe("createSplashTree", () => {
 			const snapshot = defaultSplashSnapshot(false);
 			const tree = createSplashTree(yoga, root, () => snapshot);
 			root.yogaNode.calculateLayout(120, height, DIRECTION_LTR);
-			const frame = new CellBuffer(height, 120);
-			composite(root, frame);
 
 			const contentHeight = getSplashContentHeight(snapshot, 120);
-			const expectedTop = Math.floor((height - contentHeight) / 2);
-			expect(tree.topSpacer.getComputedHeight()).toBe(expectedTop);
-			expect(tree.bottomSpacer.getComputedHeight()).toBe(height - expectedTop - contentHeight);
-			expect(tree.content.getComputedTop()).toBe(expectedTop);
-			expect(firstNonBlankRow(frame, height)).toBeGreaterThanOrEqual(expectedTop);
-			expect(firstNonBlankRow(frame, height)).toBeLessThan(expectedTop + contentHeight);
+			const freeRows = Math.max(0, height - contentHeight);
+			expect(tree.bottomSpacer.getComputedHeight()).toBe(0);
+			expect(tree.topSpacer.getComputedHeight()).toBe(freeRows);
+			expect(tree.content.getComputedTop()).toBe(freeRows);
 			root.dispose();
 		});
 	}

--- a/src/sumo-tui/cathedral/splash-tree.ts
+++ b/src/sumo-tui/cathedral/splash-tree.ts
@@ -66,8 +66,9 @@ export function createSplashTree(yoga: Yoga, parent: SumoNode | undefined, snaps
 	content.flexShrink = 0;
 
 	const bottomSpacer = new SumoNode(yoga.Node.create(), root);
-	bottomSpacer.flexGrow = 1;
-	bottomSpacer.flexShrink = 1;
+	bottomSpacer.flexGrow = 0;
+	bottomSpacer.flexShrink = 0;
+	bottomSpacer.height = 0;
 
 	return {
 		root,

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -356,13 +356,21 @@ export class ChatViewportController {
 	}
 
 	private computeChatHeight(width: number): number {
-		const terminalRows = Math.max(1, this.host.ui?.terminal?.rows ?? 24);
+		const hostRows = Math.max(1, this.host.ui?.terminal?.rows ?? 24);
+		const stdoutRows = (process.stdout as { rows?: number }).rows ?? 0;
+		const terminalRows = Math.max(1, hostRows, stdoutRows);
 		const terminalWidth = Math.max(1, this.host.ui?.terminal?.columns ?? width);
+		// On splash, skip counting Pi's empty pre-editor containers
+		// (pendingMessages, status, widgetAbove) so the chat slot extends
+		// through that space and the splash content sits close to the editor.
+		const isSplash = !this.chat.hasMessages();
+		const preEditorRows = isSplash ? 0
+			: renderableLineCount(this.host.pendingMessagesContainer, width) +
+				renderableLineCount(this.host.statusContainer, width) +
+				renderableLineCount(this.host.widgetContainerAbove, terminalWidth);
 		const chromeRows =
 			renderableLineCount(this.host.headerContainer, width) +
-			renderableLineCount(this.host.pendingMessagesContainer, width) +
-			renderableLineCount(this.host.statusContainer, width) +
-			renderableLineCount(this.host.widgetContainerAbove, terminalWidth) +
+			preEditorRows +
 			renderableLineCount(this.host.editorContainer, terminalWidth) +
 			renderableLineCount(this.host.widgetContainerBelow, terminalWidth) +
 			renderableLineCount(this.host.footer, terminalWidth);

--- a/src/top-chrome.test.ts
+++ b/src/top-chrome.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
+	installTopChrome,
 	renderTopChrome,
 	type TopChromeSnapshot,
 	TOP_CHROME_BRAND,
@@ -132,5 +133,32 @@ describe("renderTopChrome", () => {
 		expect(line).toContain("refactor-auth-flow");
 		expect(line).toContain("ARCHIVE");
 		expect(line).not.toContain("│ debug");
+	});
+});
+
+
+describe("installTopChrome", () => {
+	it("hides the top chrome on splash and shows it after messages exist", () => {
+		const handlers = new Map<string, ((event: unknown, ctx: unknown) => void)[]>();
+		const on = vi.fn((event: string, handler: (event: unknown, ctx: unknown) => void) => {
+			const list = handlers.get(event) ?? [];
+			list.push(handler);
+			handlers.set(event, list);
+		});
+		installTopChrome({ on } as never, () => snapshot({ recentSessions: [] }));
+
+		let factory: ((tui: { requestRender(): void }) => { render(width: number): string[] }) | undefined;
+		const ctx = {
+			hasUI: true,
+			ui: { setHeader: vi.fn((nextFactory: typeof factory) => { factory = nextFactory; }) },
+			sessionManager: { getBranch: vi.fn((): unknown[] => []) },
+		};
+		for (const handler of handlers.get("session_start") ?? []) handler({ type: "session_start" }, ctx);
+
+		const component = factory?.({ requestRender: vi.fn() });
+		expect(component?.render(160)).toEqual([]);
+
+		ctx.sessionManager.getBranch.mockReturnValue([{ type: "message" }]);
+		expect(stripAnsi(component!.render(160)[0]!)).toContain(TOP_CHROME_BRAND);
 	});
 });

--- a/src/top-chrome.ts
+++ b/src/top-chrome.ts
@@ -220,6 +220,7 @@ export function installTopChrome(pi: ExtensionAPI, loader?: TopChromeLoader): vo
 				},
 				invalidate(): void {},
 				render(width: number): string[] {
+					if (!sessionHasMessages(ctx)) return [];
 					const snap = loader ? loader() : defaultSnapshot(ctx, state);
 					return [renderTopChrome(snap, width)];
 				},
@@ -251,6 +252,14 @@ export function installTopChrome(pi: ExtensionAPI, loader?: TopChromeLoader): vo
 	// Session-name / state affordances can change when messages commit.
 	pi.on("message_start", () => render?.());
 	pi.on("message_end", () => render?.());
+}
+
+function sessionHasMessages(ctx: { sessionManager?: { getBranch?: () => unknown[] } }): boolean {
+	try {
+		return ctx.sessionManager?.getBranch?.().some((entry) => (entry as { type?: string }).type === "message") ?? false;
+	} catch {
+		return false;
+	}
 }
 
 /**


### PR DESCRIPTION
## Summary

- Align the runtime splash composition with the approved Visual Bible review: no top chrome/status footer on splash, transparent invocation frame, compact hint row, and tightened quote → input spacing.
- Keep the active input frame recessed/dark while making the splash invocation frame transparent.
- Hide top chrome until a session has messages, preserving the splash-only centered composition.
- Strip cursor visibility escapes from the cat asset so the runtime/Bible content rows match cleanly.
- Update splash/headless/layout tests for the locked runtime behavior.

## Visual evidence

- `pnpm visual:review -- --scenario splash-runtime`
- Review pack: `docs/visual/out/parity/index.html`
- Runtime artifact: `docs/visual/out/parity/splash-runtime/runtime-full.png`

## Verification

- `pnpm test` — 75 files passed, 437 tests passed
- `pnpm test:integration` — 11 files passed, 14 tests passed
- `pnpm visual:ci` — passed; required gates did not fail
- `pnpm exec tsc --noEmit && pnpm build` — passed
