### PR TITLE
feat(landscape): align active scene with Bible

### DIFF
--- a/scripts/visual-v2/terminal-dom-renderer.mjs
+++ b/scripts/visual-v2/terminal-dom-renderer.mjs
@@ -72,6 +72,12 @@ html, body { min-height: 100%; }
   line-height: var(--cell-h);
   white-space: pre;
   vertical-align: top;
+  /* Force exact cell-count width so narrow glyphs (e.g. NARROW NO-BREAK
+     SPACE used by sidebar tracked() headers) cannot collapse a run
+     below its terminal cell footprint. */
+  text-align: left;
+  letter-spacing: 0;
+  flex-shrink: 0;
 }
 </style>
 </head>
@@ -95,7 +101,8 @@ function renderRow(row) {
 	let style = null;
 	function flush() {
 		if (run.length === 0) return;
-		html += `<span class="v2-cell-run" style="${styleToCss(style)}">${escapeHtml(run.join(""))}</span>`;
+		const widthCss = `width: ${run.length}ch; min-width: ${run.length}ch`;
+		html += `<span class="v2-cell-run" style="${styleToCss(style)};${widthCss}">${escapeHtml(run.join(""))}</span>`;
 		run = [];
 	}
 	for (const cell of row) {

--- a/src/cathedral/cathedral-editor.ts
+++ b/src/cathedral/cathedral-editor.ts
@@ -127,6 +127,24 @@ function wrapRow(inner: string, width: number, paintBackground: boolean): string
 	return maybeWithFrameBackground(`${DIVIDER_FG}│${RESET}${padded}${DIVIDER_FG}│${RESET}`, paintBackground);
 }
 
+/**
+ * Wrap a Pi editor row with the V2 active prompt: `│ > <content>│`. The
+ * `>` is accent-colored on the first content row and replaced with three
+ * spaces on continuation rows so multi-line input keeps cursor columns aligned.
+ */
+function wrapActiveRow(inner: string, width: number, paintBackground: boolean, isFirstRow: boolean): string {
+	const innerWidth = Math.max(0, width - 2);
+	const promptCells = 3; // " > " or "   "
+	const contentWidth = Math.max(0, innerWidth - promptCells);
+	const visible = visibleLength(inner);
+	const pad = Math.max(0, contentWidth - visible);
+	const padded = `${inner}${" ".repeat(pad)}`;
+	const prompt = isFirstRow
+		? ` ${color(">", CATHEDRAL_TOKENS.colors.accent)} `
+		: "   ";
+	return maybeWithFrameBackground(`${DIVIDER_FG}│${RESET}${prompt}${padded}${DIVIDER_FG}│${RESET}`, paintBackground);
+}
+
 function centerRow(row: string, width: number): string {
 	const visible = visibleLength(row);
 	if (visible >= width) return row;
@@ -166,11 +184,11 @@ class CathedralEditor extends CustomEditor {
 		const splash = this.isSplash();
 		const frameWidth = splash ? Math.min(width, SPLASH_INPUT_FRAME_WIDTH) : width;
 
-		// Always defer to Pi's editor for layout. Pi gets `frameWidth - 2` so its
-		// content fits inside our `│ ... │` side borders. Pi's CURSOR_MARKER
-		// stays in the row, so when we prepend `│` (one visible cell) the
-		// cursor's visual column is correctly offset by 1.
-		const innerRows = super.render(frameWidth - 2);
+		// Active state reserves 3 inner cols for the V2 `│ > ` prompt so cathedral
+		// chrome owns the prompt arrow + leading space. Splash keeps the historical
+		// budget so the ghost placeholder fits the exact 60-col mockup width.
+		const piContentWidth = splash ? frameWidth - 2 : frameWidth - 5;
+		const innerRows = super.render(Math.max(1, piContentWidth));
 		if (innerRows.length === 0) return innerRows;
 
 		const fullRow = (row: string): string => splash ? centerRow(row, width) : row;
@@ -204,6 +222,7 @@ class CathedralEditor extends CustomEditor {
 				const ghost = ` ${color(">", CATHEDRAL_TOKENS.colors.accent)} ${color(`${INPUT_FRAME_PLACEHOLDER}${CURSOR_MARKER}`, CATHEDRAL_TOKENS.colors.foregroundDim)}`;
 				return fullRow(wrapRow(ghost, frameWidth, paintFrameBackground));
 			}
+			if (!splash) return wrapActiveRow(row, frameWidth, paintFrameBackground, isFirstContent);
 			return fullRow(wrapRow(row, frameWidth, paintFrameBackground));
 		};
 

--- a/src/sidebar-placement.ts
+++ b/src/sidebar-placement.ts
@@ -168,8 +168,8 @@ export function installNonCapturingSidebarOverlay(
 	const overlayOptions: OverlayOptions = {
 		width: SIDEBAR_WIDTH,
 		anchor: "top-right",
-		margin: { top: 1, right: 0, bottom: 4, left: 0 },
-		maxHeight: "90%",
+		margin: { top: 1, right: 0, bottom: 6, left: 0 },
+		maxHeight: "100%",
 		nonCapturing: true,
 		visible: (termWidth) => termWidth >= SIDEBAR_MIN_TERMINAL_WIDTH && shouldShowSidebar(),
 	};

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -28,6 +28,13 @@ export {
 export const SIDEBAR_MEMORY_DEBOUNCE_MS = 200;
 /** Retry cadence while Remnic is unavailable. */
 export const SIDEBAR_MEMORY_RETRY_MS = 5_000;
+/**
+ * Rows the sidebar yields to chrome above (top breathing + top bar) and below
+ * (input frame, hint row, footer, breathing). Tuned to match the V2 Bible
+ * active landscape scene where the registry surface ends just above the input
+ * frame.
+ */
+const ACTIVE_LANDSCAPE_NON_SIDEBAR_ROWS = 7;
 
 /** Static placeholder until Pi exposes MCP server health. */
 export const PLACEHOLDER_MCP: readonly McpServerSnapshot[] = [
@@ -233,10 +240,16 @@ export function installSidebar(pi: ExtensionAPI): void {
 			const sidebarComponent: Component = {
 				invalidate(): void {},
 				render(width: number): string[] {
-					return renderSidebar(
+					const lines = renderSidebar(
 						snapshotFromContext(ctx, memoryCache?.snapshot() ?? { memory: [] }, activeSubTab, metricsHud.snapshot()),
 						width,
 					);
+					const terminalRows = (tui.terminal as { rows?: number } | undefined)?.rows ?? lines.length;
+					const targetRows = Math.max(lines.length, terminalRows - ACTIVE_LANDSCAPE_NON_SIDEBAR_ROWS);
+					return [
+						...lines,
+						...Array.from({ length: Math.max(0, targetRows - lines.length) }, () => surfaceLine("", width)),
+					];
 				},
 			};
 			const overlay = installNonCapturingSidebarOverlay(tui, sidebarComponent, () => sessionHasMessages(ctx));

--- a/src/sumo-tui/pi-compat/region-registry.test.ts
+++ b/src/sumo-tui/pi-compat/region-registry.test.ts
@@ -120,7 +120,8 @@ describe("RegionRegistry", () => {
 		composite(registry.root, frame);
 
 		expect(registry.getSlot("chat").children).toContain(chat);
-		expect(frame.toPlainRow(0)).toContain("USER > hello retained chat");
+		expect(frame.toPlainRow(0)).toContain("╭ USER");
+		expect(frame.toPlainRow(1)).toContain("hello retained chat");
 		registry.dispose();
 	});
 });

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
@@ -124,7 +124,8 @@ describe("sumo interactive Pi noise filtering", () => {
 
 		snapshot.chat.addMessage("user", "hello");
 		const chatLines = runtime.renderChatLines(100, 30);
-		expect(stripAnsi(chatLines.join("\n"))).toContain("USER > hello");
+		expect(stripAnsi(chatLines.join("\n"))).toContain("╭ USER");
+		expect(stripAnsi(chatLines.join("\n"))).toContain("hello");
 		expect(stripAnsi(chatLines.join("\n"))).not.toContain("Meow meow meow");
 		runtime.stop();
 	});
@@ -205,7 +206,7 @@ describe("sumo interactive Pi noise filtering", () => {
 		expect(jumped).toBe(before);
 		expect(upstream.ui.requestRender).toHaveBeenCalledWith(true);
 		const rendered = upstream.chatContainer.render(60).join("\n");
-		expect(rendered).toContain("USER >");
+		expect(rendered).toContain("USER");
 		expect(rendered).not.toContain("upstream chat");
 		cleanup?.();
 		runtime.stop();

--- a/src/sumo-tui/runtime/lifecycle.test.ts
+++ b/src/sumo-tui/runtime/lifecycle.test.ts
@@ -6,7 +6,17 @@ import { join } from "node:path";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { describe, expect, it } from "vitest";
 import { createLifecycleRuntime, useTerminalDimensions, type LifecycleInput, type LifecycleListener, type LifecycleProcess, type LifecycleProcessEvent, type LifecycleSignal } from "./lifecycle.js";
-import { ALTSCREEN_ENTER_SEQUENCE, MOUSE_SGR_ENABLE_SEQUENCE, TERMINAL_BG_RESET, TERMINAL_BG_SET, TERMINAL_CLEANUP_SEQUENCE, TerminalSessionOwner, type TerminalOutput } from "./terminal-controller.js";
+import {
+	ALTSCREEN_ENTER_SEQUENCE,
+	CURSOR_COLOR_RESET,
+	CURSOR_COLOR_SET,
+	MOUSE_SGR_ENABLE_SEQUENCE,
+	TERMINAL_BG_RESET,
+	TERMINAL_BG_SET,
+	TERMINAL_CLEANUP_SEQUENCE,
+	TerminalSessionOwner,
+	type TerminalOutput,
+} from "./terminal-controller.js";
 
 class FakeProcess implements LifecycleProcess {
 	public readonly pid = 4242;
@@ -143,7 +153,12 @@ describe("LifecycleRuntime", () => {
 			handler({ type: "session_shutdown" }, { hasUI: true });
 		}
 
-		expect(output.writes).toEqual([`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`, MOUSE_SGR_ENABLE_SEQUENCE, `${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`]);
+		expect(output.writes).toEqual([
+			`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`,
+			MOUSE_SGR_ENABLE_SEQUENCE,
+			CURSOR_COLOR_SET,
+			`${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`,
+		]);
 	});
 
 	it("session_start ignores non-UI contexts", () => {
@@ -195,7 +210,12 @@ describe("LifecycleRuntime", () => {
 		fakeProcess.emit("SIGTSTP");
 		fakeProcess.emit("SIGCONT");
 
-		expect(output.writes).toEqual([TERMINAL_CLEANUP_SEQUENCE, `${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`, MOUSE_SGR_ENABLE_SEQUENCE]);
+		expect(output.writes).toEqual([
+			TERMINAL_CLEANUP_SEQUENCE,
+			`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`,
+			MOUSE_SGR_ENABLE_SEQUENCE,
+			CURSOR_COLOR_SET,
+		]);
 		expect(fakeInput.rawModes).toEqual([false, true]);
 		expect(fakeProcess.kills).toEqual([{ pid: fakeProcess.pid, signal: "SIGTSTP" }]);
 		expect(fakeProcess.listenerCount("SIGTSTP")).toBe(1);

--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -23,19 +23,22 @@ function outputStub(isTTY = true): TerminalOutput & { writes: string[] } {
 }
 
 describe("TerminalSessionOwner", () => {
-	it("startRetainedSession owns altscreen and mouse mode startup without overriding cursor color", () => {
+	it("startRetainedSession owns altscreen, mouse mode, and accent cursor (Bible Element 4)", () => {
 		const output = outputStub();
 		const terminal = new TerminalSessionOwner({ output });
 
 		terminal.startRetainedSession();
 
-		expect(output.writes).toEqual([`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`, MOUSE_SGR_ENABLE_SEQUENCE]);
-		expect(output.writes.join("")).not.toContain(CURSOR_COLOR_SET);
+		expect(output.writes).toEqual([
+			`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`,
+			MOUSE_SGR_ENABLE_SEQUENCE,
+			CURSOR_COLOR_SET,
+		]);
 		expect(terminal.getState()).toMatchObject({
 			altscreenActive: true,
 			mouseSGREnabled: true,
 			backgroundPainted: true,
-			cursorColorOverridden: false,
+			cursorColorOverridden: true,
 			restored: false,
 		});
 	});
@@ -49,7 +52,11 @@ describe("TerminalSessionOwner", () => {
 		terminal.enterAltscreen();
 		terminal.enableMouseSGR();
 
-		expect(output.writes).toEqual([`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`, MOUSE_SGR_ENABLE_SEQUENCE]);
+		expect(output.writes).toEqual([
+			`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`,
+			MOUSE_SGR_ENABLE_SEQUENCE,
+			CURSOR_COLOR_SET,
+		]);
 	});
 
 	it("enterAltscreen emits altscreen bytes and terminal background only", () => {
@@ -63,11 +70,12 @@ describe("TerminalSessionOwner", () => {
 		expect(output.writes[0]).not.toContain("\x1b]12;");
 	});
 
-	it("explicit cursor color overrides are opt-in and reset on cleanup", () => {
+	it("setCursorColor is idempotent for the active accent and resets on cleanup", () => {
 		const output = outputStub();
 		const terminal = new TerminalSessionOwner({ output });
 
 		terminal.startRetainedSession();
+		// Re-applying the same accent must not duplicate the OSC 12 write.
 		terminal.setCursorColor();
 		terminal.exitTerminal();
 
@@ -120,14 +128,19 @@ describe("TerminalSessionOwner", () => {
 		expect(terminal.restored).toBe(true);
 	});
 
-	it("exitTerminal restores bg after retained mode was active", () => {
+	it("exitTerminal restores bg and accent cursor after retained mode was active", () => {
 		const output = outputStub();
 		const terminal = new TerminalSessionOwner({ output });
 
 		terminal.startRetainedSession();
 		terminal.exitTerminal();
 
-		expect(output.writes).toEqual([`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`, MOUSE_SGR_ENABLE_SEQUENCE, `${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`]);
+		expect(output.writes).toEqual([
+			`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`,
+			MOUSE_SGR_ENABLE_SEQUENCE,
+			CURSOR_COLOR_SET,
+			`${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`,
+		]);
 	});
 
 	it("double cleanup is a no-op after the restored flag is set", () => {

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -90,6 +90,7 @@ export class TerminalSessionOwner {
 	private mouseSGREnabled = false;
 	private backgroundPainted = false;
 	private cursorColorOverridden = false;
+	private lastCursorColor: string | undefined;
 
 	public constructor(options: TerminalSessionOwnerOptions = {}) {
 		this.output = options.output ?? process.stdout;
@@ -114,6 +115,10 @@ export class TerminalSessionOwner {
 	public startRetainedSession(): void {
 		this.enterAltscreen();
 		this.enableMouseSGR();
+		// V2 Bible Element 4 calls for an accent-colored cursor block. Apply OSC 12
+		// at startup so the runtime matches the mockup; users can opt out via
+		// `/sumo:cursor reset` which restores the terminal default.
+		this.setCursorColor();
 	}
 
 	public enterAltscreen(): void {
@@ -140,8 +145,10 @@ export class TerminalSessionOwner {
 	public setCursorColor(hex = "#D97706"): void {
 		if (!this.isTTY()) return;
 		this.restored = false;
+		if (this.cursorColorOverridden && this.lastCursorColor === hex) return;
 		this.write(cursorColorSetSequence(hex));
 		this.cursorColorOverridden = true;
+		this.lastCursorColor = hex;
 	}
 
 	/** Explicit cursor-color reset hook for `/sumo:cursor reset`. */
@@ -149,6 +156,7 @@ export class TerminalSessionOwner {
 		if (!this.isTTY()) return;
 		this.write(CURSOR_COLOR_RESET);
 		this.cursorColorOverridden = false;
+		this.lastCursorColor = undefined;
 	}
 
 	public writeChatViewport(top: number, left: number, lines: readonly string[]): boolean {
@@ -189,6 +197,7 @@ export class TerminalSessionOwner {
 		this.mouseSGREnabled = false;
 		this.backgroundPainted = false;
 		this.cursorColorOverridden = false;
+		this.lastCursorColor = undefined;
 		if (!this.isTTY()) return;
 		let output = "";
 		if (shouldResetCursorColor) output += CURSOR_COLOR_RESET;

--- a/src/sumo-tui/widgets/chat-message.test.ts
+++ b/src/sumo-tui/widgets/chat-message.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { SumoNode } from "../layout/node.js";
+import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga } from "../layout/yoga.js";
+import { CellBuffer } from "../render/buffer.js";
+import { composite } from "../render/compositor.js";
+import { ChatMessage } from "./chat-message.js";
+
+const FIXED_TIME = new Date("2026-04-30T11:42:00.000");
+
+describe("ChatMessage", () => {
+	it("renders V2 rounded transparent message frames", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		root.width = 42;
+		root.height = 5;
+		ChatMessage.create(yoga, "user", "review src/auth/session.ts", root, FIXED_TIME);
+
+		root.yogaNode.calculateLayout(42, 5, DIRECTION_LTR);
+		const buffer = new CellBuffer(5, 42);
+		composite(root, buffer);
+
+		expect(buffer.toPlainRow(0)).toMatch(/^╭ USER ─+╮$/);
+		expect(buffer.toPlainRow(1)).toBe("│ review src/auth/session.ts             │");
+		expect(buffer.toPlainRow(2)).toMatch(/^╰─+╯$/);
+		root.dispose();
+	});
+
+	it("wraps content inside the frame width", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		root.width = 18;
+		root.height = 8;
+		ChatMessage.create(yoga, "sumo", "hello from a very long assistant response", root, FIXED_TIME);
+
+		root.yogaNode.calculateLayout(18, 8, DIRECTION_LTR);
+		const buffer = new CellBuffer(8, 18);
+		composite(root, buffer);
+
+		expect(buffer.toPlainRow(0)).toMatch(/^╭ SUMO ─+ 11:42 ─╮$/);
+		expect(buffer.toPlainRow(1)).toBe("│ hello from a v │");
+		expect(buffer.toPlainRow(2)).toBe("│ ery long assis │");
+		root.dispose();
+	});
+});

--- a/src/sumo-tui/widgets/chat-message.ts
+++ b/src/sumo-tui/widgets/chat-message.ts
@@ -3,6 +3,7 @@ import { CATHEDRAL_TOKENS } from "../../tokens.js";
 import { SumoNode } from "../layout/node.js";
 import { MEASURE_MODE_EXACTLY, type MeasureMode, type Yoga, type YogaNode } from "../layout/yoga.js";
 import type { CellBuffer, Rect } from "../render/buffer.js";
+import { lineToAnsi, span, textLine, type Span } from "../render/primitives.js";
 
 export type ChatMessageRole = "user" | "sumo" | "system" | "tool" | string;
 
@@ -17,17 +18,7 @@ export interface ChatMessageSnapshot {
 	timestamp: Date;
 }
 
-const RESET = "\x1b[0m";
-
-function hexToRgb(hexColor: string): [number, number, number] {
-	const hex = hexColor.startsWith("#") ? hexColor.slice(1) : hexColor;
-	return [Number.parseInt(hex.slice(0, 2), 16), Number.parseInt(hex.slice(2, 4), 16), Number.parseInt(hex.slice(4, 6), 16)];
-}
-
-function fg(hexColor: string): string {
-	const [red, green, blue] = hexToRgb(hexColor);
-	return `\x1b[38;2;${red};${green};${blue}m`;
-}
+const MIN_BOX_WIDTH = 8;
 
 function normalizeWidth(width: number): number {
 	if (!Number.isFinite(width)) return 0;
@@ -35,15 +26,15 @@ function normalizeWidth(width: number): number {
 }
 
 function roleLabel(role: ChatMessageRole): string {
-	if (role === "user") return "USER >";
-	if (role === "sumo" || role === "assistant") return "SUMO >";
-	if (role === "tool") return "TOOL >";
-	return `${String(role).toUpperCase()} >`;
+	if (role === "user") return "USER";
+	if (role === "sumo" || role === "assistant") return "SUMO";
+	if (role === "tool") return "TOOL";
+	return String(role).toUpperCase();
 }
 
 function roleColor(role: ChatMessageRole): string {
-	if (role === "user") return CATHEDRAL_TOKENS.colors.accent;
-	if (role === "sumo" || role === "assistant") return CATHEDRAL_TOKENS.colors.states.idle;
+	if (role === "user") return CATHEDRAL_TOKENS.colors.foreground;
+	if (role === "sumo" || role === "assistant") return CATHEDRAL_TOKENS.colors.accent;
 	if (role === "tool") return CATHEDRAL_TOKENS.colors.states.tool;
 	return CATHEDRAL_TOKENS.colors.foregroundDim;
 }
@@ -84,7 +75,69 @@ function wrapPlainText(input: string, width: number): string[] {
 	return rows.length === 0 ? [""] : rows;
 }
 
-/** One role-prefixed chat row group. Markdown parsing is deferred to Phase 5. */
+function textWidth(parts: readonly (Span | string)[]): number {
+	return parts.reduce((sum, part) => sum + visibleWidth(typeof part === "string" ? part : part.text), 0);
+}
+
+function fitCellText(text: string, width: number): string {
+	const visible = visibleWidth(text);
+	return visible >= width ? takeVisible(text, width).head : `${text}${" ".repeat(width - visible)}`;
+}
+
+function formatTime(timestamp: Date): string {
+	const hours = String(timestamp.getHours()).padStart(2, "0");
+	const minutes = String(timestamp.getMinutes()).padStart(2, "0");
+	return `${hours}:${minutes}`;
+}
+
+function frameTop(role: ChatMessageRole, timestamp: Date | undefined, width: number): string {
+	const label = roleLabel(role);
+	const leftParts: (Span | string)[] = [
+		span("╭ ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span(label, { fg: roleColor(role) }),
+		span(" ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+	];
+
+	const showTime = (role === "sumo" || role === "assistant") && timestamp !== undefined;
+	const rightParts: (Span | string)[] = showTime
+		? [
+			span(" ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+			span(formatTime(timestamp), { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+			span(" \u2500", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		]
+		: [];
+
+	const used = textWidth(leftParts) + textWidth(rightParts) + 1; // right corner
+	const rule = Math.max(0, width - used);
+	return lineToAnsi(textLine([
+		...leftParts,
+		span("─".repeat(rule), { fg: CATHEDRAL_TOKENS.colors.divider }),
+		...rightParts,
+		span("╮", { fg: CATHEDRAL_TOKENS.colors.divider }),
+	]), { width });
+}
+
+function frameBody(row: string, width: number): string {
+	const inner = Math.max(0, width - 4);
+	const text = fitCellText(row, inner);
+	return lineToAnsi(textLine([
+		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		" ",
+		span(text, { fg: CATHEDRAL_TOKENS.colors.foreground }),
+		" ",
+		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+	]), { width });
+}
+
+function frameBottom(width: number): string {
+	return lineToAnsi(textLine([
+		span("╰", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("─".repeat(Math.max(0, width - 2)), { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("╯", { fg: CATHEDRAL_TOKENS.colors.divider }),
+	]), { width });
+}
+
+/** One V2 framed chat message. Markdown block parsing lands in #89/#90. */
 export class ChatMessage extends SumoNode {
 	public readonly timestamp: Date;
 	private measuring = false;
@@ -93,6 +146,7 @@ export class ChatMessage extends SumoNode {
 	public constructor(yogaNode: YogaNode, public role: ChatMessageRole, public text: string, parent?: SumoNode, timestamp = new Date()) {
 		super(yogaNode, parent);
 		this.timestamp = timestamp;
+		this.marginBottom = 1;
 		this.setMeasureFunc((width, widthMode, height, heightMode) => this.measure(width, widthMode, height, heightMode));
 	}
 
@@ -117,7 +171,7 @@ export class ChatMessage extends SumoNode {
 	}
 
 	public getEstimatedHeight(width = this.getComputedWidth()): number {
-		return this.renderRows(width).length;
+		return this.renderRows(width).length + 1;
 	}
 
 	public render(buffer: CellBuffer, rect: Rect): void {
@@ -131,19 +185,15 @@ export class ChatMessage extends SumoNode {
 	private renderRows(width: number): string[] {
 		const renderWidth = normalizeWidth(width);
 		if (renderWidth <= 0) return [""];
-		const label = roleLabel(this.role);
-		const prefix = `${label} `;
-		const prefixWidth = visibleWidth(prefix);
-		const firstLineWidth = Math.max(1, renderWidth - prefixWidth);
-		const continuationWidth = Math.max(1, renderWidth - prefixWidth);
-		const contentRows = wrapPlainText(this.text, firstLineWidth);
-		const labelStyle = fg(roleColor(this.role));
-		const textStyle = fg(CATHEDRAL_TOKENS.colors.foreground);
-		return contentRows.map((row, index) => {
-			const content = index === 0 ? row : takeVisible(row, continuationWidth).head;
-			if (index === 0) return `${labelStyle}${prefix}${RESET}${textStyle}${content}${RESET}`;
-			return `${" ".repeat(prefixWidth)}${textStyle}${content}${RESET}`;
-		});
+		if (renderWidth < MIN_BOX_WIDTH) return [fitCellText(this.text, renderWidth)];
+
+		const bodyWidth = Math.max(1, renderWidth - 4);
+		const bodyRows = wrapPlainText(this.text, bodyWidth);
+		return [
+			frameTop(this.role, this.timestamp, renderWidth),
+			...bodyRows.map((row) => frameBody(row, renderWidth)),
+			frameBottom(renderWidth),
+		];
 	}
 
 	private measure(width: number, widthMode: MeasureMode, _height: number, _heightMode: MeasureMode): ChatMessageMeasure {

--- a/test/integration/altscreen-cleanup.test.ts
+++ b/test/integration/altscreen-cleanup.test.ts
@@ -23,8 +23,10 @@ describe("sumo-tui altscreen cleanup integration", () => {
 
 		const output = app.getOutput();
 		const state = app.getCurrentTerminalState();
-		expect(output).not.toContain(CURSOR_COLOR_SET);
-		expect(output).not.toContain(CURSOR_COLOR_RESET);
+		// V2 Bible Element 4: accent cursor is applied on retained start and
+		// must be reset on exit so the host shell regains its preferred cursor.
+		expect(output).toContain(CURSOR_COLOR_SET);
+		expect(output).toContain(CURSOR_COLOR_RESET);
 		expect(state.cleanupSequenceSeen).toBe(true);
 		expect(state.altscreenActive).toBe(false);
 		expect(state.kittyKeyboardPopped).toBe(true);

--- a/test/integration/chat-history-scroll.test.ts
+++ b/test/integration/chat-history-scroll.test.ts
@@ -24,8 +24,8 @@ describe("Phase 3 chat history scroll integration", () => {
 		const pageUpFrame = new CellBuffer(8, 48);
 		composite(root, pageUpFrame);
 
-		expect(bottomFrame.toPlainRow(0)).toContain("message 192");
-		expect(pageUpFrame.toPlainRow(0)).toContain("message 188");
+		expect(Array.from({ length: 8 }, (_, row) => bottomFrame.toPlainRow(row)).join("\n")).toContain("message 199");
+		expect(Array.from({ length: 8 }, (_, row) => pageUpFrame.toPlainRow(row)).join("\n")).toContain("message 197");
 		root.dispose();
 	});
 

--- a/test/integration/splash-centering.test.ts
+++ b/test/integration/splash-centering.test.ts
@@ -24,7 +24,8 @@ describe("sumo-tui splash centering integration", () => {
 
 			snapshot.chat.addMessage("user", "hello");
 			const chatLines = runtime.renderChatLines(100, 30);
-			expect(stripAnsi(chatLines.join("\n"))).toContain("USER > hello");
+			expect(stripAnsi(chatLines.join("\n"))).toContain("╭ USER");
+			expect(stripAnsi(chatLines.join("\n"))).toContain("hello");
 			expect(stripAnsi(chatLines.join("\n"))).not.toContain("Meow meow meow");
 		} finally {
 			runtime.stop();


### PR DESCRIPTION
## Summary
- Adds V2 boxed chat message frames for active landscape runtime, including SUMO timestamp in the top border and spacing between messages.
- Extends the landscape sidebar surface to fill the active scene down to the input frame and fixes browser capture NNBSP width artifacts.
- Aligns active input with the Bible by rendering the accent `>` prompt and applying the accent cursor via OSC 12 on retained startup.

## Verification
- `pnpm test`
- `pnpm test:integration`
- `pnpm visual:ci`
- `pnpm exec tsc --noEmit && pnpm build`

## Visual review
- Local review pack: `http://127.0.0.1:7781/bible-verify/` → `active-landscape-runtime`
- Dhruv approved active landscape visual pass in agent session.

Closes #86
