### PR TITLE
feat(portrait): align active scene with Bible

### DIFF
--- a/docs/SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md
+++ b/docs/SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md
@@ -74,7 +74,7 @@ For the canonical `60 × 100` portrait scene:
 
 ### Visual harness
 
-`active-portrait-runtime` remains a no-sidebar scene. It should not add a sidebar crop or bottom-registry crop in V1.
+`active-portrait-runtime` remains a no-sidebar scene. It should not add a sidebar crop or bottom-registry crop in V1. It should include crop-level review evidence for the portrait top bar, chat area, input frame, hint row, and footer so #87 can be reviewed with the same harness ergonomics as landscape.
 
 Future V2 portrait richness must get its own issue, Bible target, scenario manifest update, and human visual approval before becoming required.
 

--- a/docs/visual/parity/CONTRACT.md
+++ b/docs/visual/parity/CONTRACT.md
@@ -51,7 +51,7 @@ The manifest owns scenario dimensions. Current locked V2 dimensions are:
 
 V2 sidebar width is **30 columns**. Legacy 49-column sidebar references are historical V1/mockup material and must not be used for new V2 assertions.
 
-P0-F portrait policy is **Option A**: portrait/narrow layouts hide the sidebar and let the footer/hint row absorb essential context. The canonical `60 × 100` portrait runtime scene is therefore a no-sidebar scene; it must not add a sidebar crop, bottom-registry crop, or portrait overlay crop in V1.
+P0-F portrait policy is **Option A**: portrait/narrow layouts hide the sidebar and let the footer/hint row absorb essential context. The canonical `60 × 100` portrait runtime scene is therefore a no-sidebar scene; it must not add a sidebar crop, bottom-registry crop, or portrait overlay crop in V1. It may still define crop-level evidence for the top bar, chat area, input frame, hint row, and footer.
 
 For 160-column full-screen crops, the sidebar crop starts at `x=130` and spans `30` columns. Chat/runtime content should reserve the matching right-side space only when the runtime sidebar policy says the sidebar is visible.
 
@@ -67,7 +67,7 @@ Splash/empty-state captures may show `DIVINE INVOCATION`; active typed component
 
 Hardware cursor visibility is a Pi/TUI runtime preference. PTY integration tests that assert hardware cursor behavior must opt in with `PI_HARDWARE_CURSOR=1` and wait for the stable post-render cursor state, not the first incidental `?25h` emitted during startup.
 
-Visual parity screenshots should not rely on terminal cursor color. The V2 terminal ownership contract is: terminal cursor color remains the user's preference unless an explicit future SumoCode cursor command changes it. `TerminalSessionOwner` therefore does not emit OSC 12 during normal startup; cursor color overrides are opt-in only.
+Visual parity screenshots should not rely on browser-rendered cursor color: the harness renders a fixed cursor cell, while real terminals honor cursor-color escape sequences. The V2 terminal ownership contract now applies the Cathedral accent cursor (`OSC 12 #D97706`) when retained mode starts, and resets it on terminal cleanup so the host shell regains its default. `/sumo:cursor reset` remains the explicit opt-out path during a session.
 
 ## 5. Crop status semantics
 

--- a/docs/visual/parity/PORTRAIT_REVIEW.md
+++ b/docs/visual/parity/PORTRAIT_REVIEW.md
@@ -1,0 +1,52 @@
+# Active Portrait Runtime Review
+
+Issue: #87
+Parent: #80
+Policy: `docs/SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md`
+Scenario: `active-portrait-runtime`
+
+## Decision captured
+
+The canonical V1 portrait scene remains a `60 × 100` no-sidebar runtime capture. It composes the approved V2 primitives full-width and follows the Bible vertical rhythm:
+
+- blank breathing row above the compact top chrome
+- compact top chrome
+- blank breathing row before chat
+- boxed chat message frames
+- full-width active input frame
+- portrait hint row with sidebar-hidden context
+- footer/status row
+
+Per the accepted portrait policy, this PR does **not** add a sidebar crop, bottom registry band, or portrait overlay. Sidebar richness stays deferred.
+
+## Review evidence
+
+The scenario now emits crop-level evidence in addition to the full-screen comparison:
+
+- `full`
+- `top-bar`
+- `chat-area`
+- `input-frame`
+- `hint-row`
+- `footer`
+
+All portrait crops remain `review` status. No portrait runtime golden is promoted and no portrait crop is marked `required` in #87.
+
+Generate the local review pack with:
+
+```bash
+pnpm visual:review -- --scenario active-portrait-runtime
+```
+
+Review locally at:
+
+```txt
+http://127.0.0.1:7781/bible-verify/ → active-portrait-runtime
+```
+
+## Known deferrals
+
+- Completed assistant/tool transcript content remains fixture-backed follow-up work (#90).
+- Portrait registry richness remains deferred by the V1 Option A policy.
+- The Pi working/status loader row is suppressed at compact portrait widths so the bottom stack aligns with the scene target.
+- Strict portrait pixel gating requires later explicit visual approval plus a committed runtime golden.

--- a/docs/visual/parity/scenarios.json
+++ b/docs/visual/parity/scenarios.json
@@ -46,6 +46,36 @@
 			"cols": 160,
 			"rows": 1
 		},
+		"portrait-top-bar": {
+			"x": 0,
+			"y": 1,
+			"cols": 60,
+			"rows": 1
+		},
+		"portrait-chat-area": {
+			"x": 0,
+			"y": 3,
+			"cols": 60,
+			"rows": 89
+		},
+		"portrait-input-frame": {
+			"x": 0,
+			"y": 93,
+			"cols": 60,
+			"rows": 3
+		},
+		"portrait-hint-row": {
+			"x": 0,
+			"y": 96,
+			"cols": 60,
+			"rows": 1
+		},
+		"portrait-footer": {
+			"x": 0,
+			"y": 98,
+			"cols": 60,
+			"rows": 1
+		},
 		"input-component-frame": {
 			"x": 0,
 			"y": 0,
@@ -313,7 +343,9 @@
 					"SUMO_TUI": "1",
 					"TERM": "xterm-256color",
 					"COLORTERM": "truecolor",
-					"FORCE_COLOR": "3"
+					"FORCE_COLOR": "3",
+					"COLUMNS": "60",
+					"LINES": "100"
 				},
 				"inputs": [
 					{
@@ -339,6 +371,32 @@
 					"id": "full",
 					"targetCrop": "full",
 					"runtimeCrop": "full"
+				},
+				{
+					"id": "top-bar",
+					"targetCrop": "portrait-top-bar",
+					"runtimeCrop": "portrait-top-bar"
+				},
+				{
+					"id": "chat-area",
+					"targetCrop": "portrait-chat-area",
+					"runtimeCrop": "portrait-chat-area"
+				},
+				{
+					"id": "input-frame",
+					"targetImage": "04-active-input-empty-portrait.png",
+					"targetCrop": "full",
+					"runtimeCrop": "portrait-input-frame"
+				},
+				{
+					"id": "hint-row",
+					"targetCrop": "portrait-hint-row",
+					"runtimeCrop": "portrait-hint-row"
+				},
+				{
+					"id": "footer",
+					"targetCrop": "portrait-footer",
+					"runtimeCrop": "portrait-footer"
 				}
 			]
 		}

--- a/src/cathedral/input-frame.test.ts
+++ b/src/cathedral/input-frame.test.ts
@@ -140,6 +140,27 @@ describe("renderInputHints", () => {
 		expect(line).not.toContain("AWAITING");
 	});
 
+	it("can truncate active left context instead of dropping it", () => {
+		const line = stripAnsi(renderInputHints(60, {
+			leftHint: "sumocode (feat/issue-87-active-portrait-scene)",
+			leftHintOverflow: "truncate",
+			leftHintStyle: "project-branch",
+		}));
+		expect(line).toHaveLength(60);
+		expect(line).toContain("sumocode (");
+		expect(line).toContain("…");
+		expect(line).toContain(INPUT_FRAME_HINT_KEYBINDS);
+	});
+
+	it("colors project context foreground and branch dim", () => {
+		const line = renderInputHints(80, {
+			leftHint: "sumocode (main)",
+			leftHintStyle: "project-branch",
+		});
+		expect(line).toContain("\u001b[38;2;245;230;200msumocode");
+		expect(line).toContain("\u001b[38;2;139;122;99m (main)");
+	});
+
 	it("colors CTRL+/ modifier key in accent (#D97706)", () => {
 		const line = renderInputHints(80);
 		expect(line).not.toContain("TAB");

--- a/src/cathedral/input-frame.ts
+++ b/src/cathedral/input-frame.ts
@@ -79,6 +79,13 @@ function padToWidth(line: string, width: number): string {
 	return `${line}${" ".repeat(width - len)}`;
 }
 
+function ellipsize(text: string, max: number): string {
+	if (max <= 0) return "";
+	if (text.length <= max) return text;
+	if (max === 1) return "…";
+	return `${text.slice(0, max - 1)}…`;
+}
+
 export type InputFrameOptions = {
 	/** Optional top-border label. V2 active input passes an empty label; splash uses "DIVINE INVOCATION". */
 	label?: string;
@@ -157,10 +164,14 @@ export function renderInputFrame(input: string, width: number, options: InputFra
 
 export type InputHintsOptions = {
 	/**
-	 * Left-side dim hint, e.g. `└─ AWAITING DIVINE INVOCATION` (splash only).
-	 * Element 4 (active state) omits this and shows only the right-side keybinds.
+	 * Left-side hint. Splash uses `╰─ AWAITING PROMPT`; portrait active state
+	 * uses project/branch context when the sidebar is hidden.
 	 */
 	leftHint?: string;
+	/** When set, truncate the left hint instead of dropping it at narrow widths. */
+	leftHintOverflow?: "drop" | "truncate";
+	/** Project context renders project in foreground and branch in dim. */
+	leftHintStyle?: "dim" | "project-branch";
 };
 
 /**
@@ -184,13 +195,32 @@ export function renderInputHints(width: number, options: InputHintsOptions = {})
 
 	// Build the colored right-hand string: CTRL+/ in accent, label in dim.
 	const rightColored = `${accent}CTRL+/${RESET} ${dimFg}· COMMANDS${RESET}`;
+	const colorLeftHint = (text: string): string => {
+		if (options.leftHintStyle !== "project-branch") return `${dimFg}${text}${RESET}`;
+		const branchStart = text.indexOf(" (");
+		if (branchStart === -1) return color(text, CATHEDRAL_TOKENS.colors.foreground);
+		const project = text.slice(0, branchStart);
+		const branch = text.slice(branchStart);
+		return `${color(project, CATHEDRAL_TOKENS.colors.foreground)}${dimFg}${branch}${RESET}`;
+	};
 
-	// At narrow widths, drop the left hint first.
-	const leftFitsAlongside = left !== undefined && rightLen + 4 + left.length <= width;
+	// At narrow widths, drop the left hint first unless the caller explicitly
+	// asks for truncation (portrait active context path).
+	const minGap = 4;
+	const leftFitsAlongside = left !== undefined && rightLen + minGap + left.length <= width;
 
 	if (leftFitsAlongside) {
 		const gap = width - rightLen - left!.length;
-		return `${dimFg}${left!}${RESET}${" ".repeat(gap)}${rightColored}`;
+		return `${colorLeftHint(left!)}${" ".repeat(gap)}${rightColored}`;
+	}
+
+	if (left !== undefined && options.leftHintOverflow === "truncate" && width > rightLen + minGap) {
+		const maxLeft = width - rightLen - minGap;
+		const truncatedLeft = ellipsize(left, maxLeft);
+		if (truncatedLeft.length > 0) {
+			const gap = width - rightLen - truncatedLeft.length;
+			return `${colorLeftHint(truncatedLeft)}${" ".repeat(gap)}${rightColored}`;
+		}
 	}
 
 	// Right-only path. Right-align if there's room.

--- a/src/cathedral/input-hints.test.ts
+++ b/src/cathedral/input-hints.test.ts
@@ -64,6 +64,7 @@ describe("installInputHints", () => {
 		// Active state: branch contains a real message entry
 		const ctx = {
 			hasUI: true,
+			cwd: "/tmp/sumocode",
 			ui: { setWidget },
 			sessionManager: { getBranch: () => [{ type: "message" }] },
 		} as unknown;
@@ -74,9 +75,18 @@ describe("installInputHints", () => {
 		const lines = component!.render(80);
 		expect(lines.length).toBe(1);
 		const stripped = lines[0]!.replace(/\u001b\[[0-9;]*m/g, "");
+		expect(stripped).toContain("sumocode");
 		expect(stripped).toContain("CTRL+/ · COMMANDS");
 		expect(stripped).not.toContain("TAB · AGENTS");
 		expect(stripped).not.toContain("AWAITING PROMPT");
+
+		const portraitLines = component!.render(60).map((line) => line.replace(/\u001b\[[0-9;]*m/g, ""));
+		expect(portraitLines).toHaveLength(2);
+		expect(portraitLines[0]).toHaveLength(60);
+		expect(portraitLines[0]!.startsWith(" ")).toBe(true);
+		expect(portraitLines[0]!.endsWith(" ")).toBe(true);
+		expect(portraitLines[0]).toContain("CTRL+/ · COMMANDS");
+		expect(portraitLines[1]).toBe(" ".repeat(60));
 	});
 
 	it("widget factory renders BOTH hints on splash (no messages yet)", () => {

--- a/src/cathedral/input-hints.ts
+++ b/src/cathedral/input-hints.ts
@@ -14,9 +14,11 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { Component } from "@mariozechner/pi-tui";
 import { visibleWidth } from "@mariozechner/pi-tui";
+import { formatCwd, resolveGitBranch } from "../footer.js";
 import { INPUT_FRAME_HINT_AWAITING, renderInputHints } from "./input-frame.js";
 
 const SPLASH_INPUT_FRAME_WIDTH = 60;
+const PORTRAIT_HINT_BREATHING_WIDTH = 80;
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
 
 function centerAnsi(line: string, width: number): string {
@@ -28,7 +30,10 @@ function centerAnsi(line: string, width: number): string {
 }
 
 class InputHintsComponent implements Component {
-	constructor(private readonly isSplash: () => boolean) {}
+	constructor(
+		private readonly isSplash: () => boolean,
+		private readonly activeLeftHint: () => string | undefined,
+	) {}
 	invalidate(): void {}
 	render(width: number): string[] {
 		if (this.isSplash()) {
@@ -38,8 +43,20 @@ class InputHintsComponent implements Component {
 			const frameWidth = Math.min(width, SPLASH_INPUT_FRAME_WIDTH);
 			return [centerAnsi(renderInputHints(frameWidth, { leftHint: INPUT_FRAME_HINT_AWAITING }), width)];
 		}
-		return [renderInputHints(width)];
+		if (width > 2 && width < PORTRAIT_HINT_BREATHING_WIDTH) {
+			const hint = renderInputHints(width - 2, { leftHint: this.activeLeftHint(), leftHintOverflow: "truncate", leftHintStyle: "project-branch" });
+			return [` ${hint} `, " ".repeat(width)];
+		}
+		return [renderInputHints(width, { leftHint: this.activeLeftHint(), leftHintOverflow: "truncate", leftHintStyle: "project-branch" })];
 	}
+}
+
+function activeContextHint(ctx: ExtensionContext): string | undefined {
+	const cwd = ctx.cwd;
+	if (!cwd) return undefined;
+	const project = formatCwd(cwd);
+	const branch = resolveGitBranch(cwd);
+	return branch ? `${project} (${branch})` : project;
 }
 
 function sessionHasMessages(ctx: ExtensionContext): boolean {
@@ -55,7 +72,7 @@ export function installInputHints(pi: ExtensionAPI): void {
 		if (!ctx.hasUI) return;
 		ctx.ui.setWidget(
 			"sumocode-input-hints",
-			() => new InputHintsComponent(() => !sessionHasMessages(ctx)),
+			() => new InputHintsComponent(() => !sessionHasMessages(ctx), () => activeContextHint(ctx)),
 			{ placement: "belowEditor" },
 		);
 	});

--- a/src/footer.test.ts
+++ b/src/footer.test.ts
@@ -117,6 +117,14 @@ describe("formatFooterLine — F1 two-zone layout", () => {
 		expect(line).toContain(VOICE.status.idle);
 		expect(line.length).toBeLessThanOrEqual(50);
 	});
+
+	it("adds one-cell side padding for portrait footer rhythm", () => {
+		const line = withoutAnsi(formatFooterLine(snapshot(), 60));
+		expect(line).toHaveLength(60);
+		expect(line.startsWith(" ")).toBe(true);
+		expect(line.endsWith(" ")).toBe(true);
+		expect(line.trim()).toContain(VOICE.status.idle);
+	});
 });
 
 describe("formatFooterLine — cathedral coloring", () => {

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -46,6 +46,7 @@ type GitRunner = (args: string[], cwd: string) => string;
 const RESET = "\u001b[0m";
 const SPLASH_VERSION_TOP_GAP_ROWS = 2;
 const SPLASH_VERSION_BOTTOM_GAP_ROWS = 7;
+const PORTRAIT_FOOTER_PAD_WIDTH = 80;
 
 export function colorHex(text: string, hex: string): string {
 	const normalized = hex.replace("#", "");
@@ -97,6 +98,20 @@ export function resolveGitBranch(cwd: string, runGit: GitRunner = defaultGitRunn
  * when the sidebar is hidden.
  */
 export function formatFooterLine(snapshot: FooterSnapshot, width = 160): string {
+	const compactPad = width > 2 && width < PORTRAIT_FOOTER_PAD_WIDTH;
+	const contentWidth = compactPad ? width - 2 : width;
+	const inner = formatFooterLineInner(snapshot, contentWidth);
+	if (!compactPad) return inner;
+	return ` ${padAnsiToWidth(inner, contentWidth)} `;
+}
+
+function padAnsiToWidth(line: string, width: number): string {
+	const visible = visibleWidth(line);
+	if (visible >= width) return truncateToWidth(line, width);
+	return `${line}${" ".repeat(width - visible)}`;
+}
+
+function formatFooterLineInner(snapshot: FooterSnapshot, width: number): string {
 	const dot = colorHex("●", CATHEDRAL_TOKENS.colors.states[snapshot.state]);
 	const stateLabel = colorHex(VOICE.status[snapshot.state], CATHEDRAL_TOKENS.colors.foreground);
 	const model = colorHex(snapshot.modelId, CATHEDRAL_TOKENS.colors.foreground);

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
@@ -6,7 +6,7 @@ import { bufferToAnsiLines } from "../render/ansi-writer.js";
 import { CellBuffer } from "../render/buffer.js";
 import { composite } from "../render/compositor.js";
 import { ChatPager } from "../widgets/chat-pager.js";
-import { ChatViewportController, textFromAgentMessage, type ChatViewportHost, type ChatViewportRuntime } from "./chat-viewport-controller.js";
+import { ChatViewportController, installChatViewportBridge, textFromAgentMessage, type ChatViewportHost, type ChatViewportRuntime } from "./chat-viewport-controller.js";
 
 function rows(count: number): { render(width: number): string[] } {
 	return { render: (_width: number) => Array.from({ length: count }, () => "chrome") };
@@ -72,7 +72,7 @@ describe("ChatViewportController", () => {
 		expect(textFromAgentMessage({ role: "toolResult", content: [{ type: "text", text: "tool output" }] })).toBe("tool output");
 	});
 
-	it("owns chat viewport geometry, including sidebar-aware width", async () => {
+	it("owns chat viewport geometry, including sidebar and portrait gutters", async () => {
 		const { root, chat, runtime, controller } = await makeController({ terminalRows: 16, terminalColumns: 130 });
 
 		controller.render(130);
@@ -82,6 +82,12 @@ describe("ChatViewportController", () => {
 		controller.render(130);
 		expect(runtime.renderCalls.at(-1)).toEqual({ width: 130 - SIDEBAR_WIDTH, height: 12 });
 		root.dispose();
+
+		const portrait = await makeController({ terminalRows: 100, terminalColumns: 60 });
+		portrait.chat.addMessage("user", "hello");
+		portrait.controller.render(60);
+		expect(portrait.runtime.renderCalls.at(-1)).toMatchObject({ width: 59 });
+		portrait.root.dispose();
 	});
 
 	it("translates wheel and jump-to-bottom input into local viewport repaint", async () => {
@@ -116,6 +122,40 @@ describe("ChatViewportController", () => {
 
 		expect(runtime.noteUserMessage).toHaveBeenCalledTimes(1);
 		expect(chat.getRenderedMessages().map((message) => message.text)).toEqual(["hello", "hello back"]);
+		root.dispose();
+	});
+
+	it("suppresses Pi status loader row in portrait while preserving landscape", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const chat = ChatPager.create(yoga, root);
+		const originalStatusRender = vi.fn((_width: number) => ["Working..."]);
+		const statusContainer = { render: originalStatusRender };
+		const host = {
+			ui: { terminal: { rows: 100, columns: 60 }, requestRender: vi.fn() },
+			chatContainer: { render: vi.fn(() => []), clear: vi.fn(), invalidate: vi.fn() },
+			statusContainer,
+		};
+		const runtime = {
+			getSnapshot: () => ({ chat }),
+			setExternalRenderControls: vi.fn(),
+			renderChatLines: vi.fn(() => []),
+			writeChatViewport: vi.fn(() => true),
+			requestRender: vi.fn(),
+			setEmptyChatQuoteState: vi.fn(),
+			noteUserMessage: vi.fn(),
+		};
+
+		const cleanup = installChatViewportBridge(host, runtime);
+		expect(statusContainer.render(60)).toEqual([]);
+		expect(originalStatusRender).not.toHaveBeenCalled();
+
+		host.ui.terminal.columns = 160;
+		expect(statusContainer.render(160)).toEqual(["Working..."]);
+		expect(originalStatusRender).toHaveBeenCalledWith(160);
+
+		cleanup?.();
+		expect(statusContainer.render(60)).toEqual(["Working..."]);
 		root.dispose();
 	});
 });

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -5,6 +5,8 @@ import { chatScrollCommandFromInput } from "../widgets/chat-scroll-command.js";
 import { SIDEBAR_MIN_TERMINAL_WIDTH, SIDEBAR_WIDTH } from "../../sidebar.js";
 
 const CHAT_VIEWPORT_BRIDGE_INSTALLED = Symbol("sumo-tui.chat-viewport-bridge-installed");
+const PORTRAIT_STATUS_MIN_WIDTH = 80;
+const PORTRAIT_CHAT_GUTTER_MIN_WIDTH = 80;
 
 interface PiRenderableComponent {
 	render(width: number): string[];
@@ -189,7 +191,12 @@ export class ChatViewportController {
 		// right-side cols come from Pi's separate widget paint.
 		const terminalWidth = Math.max(1, Math.floor(width));
 		const sidebarVisible = terminalWidth >= SIDEBAR_MIN_TERMINAL_WIDTH && this.chat.hasMessages();
-		const effectiveWidth = sidebarVisible ? Math.max(1, terminalWidth - SIDEBAR_WIDTH) : terminalWidth;
+		const portraitGutterVisible = !sidebarVisible && this.chat.hasMessages() && terminalWidth < PORTRAIT_CHAT_GUTTER_MIN_WIDTH;
+		const effectiveWidth = sidebarVisible
+			? Math.max(1, terminalWidth - SIDEBAR_WIDTH)
+			: portraitGutterVisible
+				? Math.max(1, terminalWidth - 1)
+				: terminalWidth;
 		this.lastChatWidth = effectiveWidth;
 		this.lastChatTop = this.computeChatTop(this.lastChatWidth);
 		this.lastChatHeight = this.computeChatHeight(this.lastChatWidth);
@@ -388,6 +395,8 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 	const originalRender = chatContainer.render?.bind(chatContainer);
 	const originalClear = chatContainer.clear?.bind(chatContainer);
 	const originalInvalidate = chatContainer.invalidate?.bind(chatContainer);
+	const statusContainer = target.statusContainer as (PiRenderableComponent & { render?: (width: number) => string[] }) | undefined;
+	const originalStatusRender = statusContainer?.render?.bind(statusContainer);
 	const originalHandleEvent = target.handleEvent?.bind(target);
 	const originalRenderSessionContext = target.renderSessionContext?.bind(target);
 	const removeInputListener = target.ui?.addInputListener?.((data) => controller.handleInput(data));
@@ -411,6 +420,16 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 		originalInvalidate?.();
 		runtime.requestRender();
 	};
+	if (statusContainer && originalStatusRender) {
+		statusContainer.render = (width: number): string[] => {
+			const terminalWidth = target.ui?.terminal?.columns ?? width;
+			// Portrait V1 Bible rhythm reserves the pre-input row as breathing
+			// space. Suppress Pi's loader/status row at compact widths so the input,
+			// hint, and footer land on the target rows.
+			if (terminalWidth < PORTRAIT_STATUS_MIN_WIDTH) return [];
+			return originalStatusRender(width);
+		};
+	}
 	if (originalHandleEvent) {
 		target.handleEvent = async (event: unknown): Promise<unknown> => {
 			controller.handleAgentEvent(event);
@@ -433,6 +452,7 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 		else delete chatContainer.clear;
 		if (originalInvalidate) chatContainer.invalidate = originalInvalidate;
 		else delete chatContainer.invalidate;
+		if (statusContainer && originalStatusRender) statusContainer.render = originalStatusRender;
 		if (originalHandleEvent) target.handleEvent = originalHandleEvent;
 		if (originalRenderSessionContext) target.renderSessionContext = originalRenderSessionContext;
 		delete target[CHAT_VIEWPORT_BRIDGE_INSTALLED];

--- a/src/top-chrome.test.ts
+++ b/src/top-chrome.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
 	installTopChrome,
 	renderTopChrome,
+	renderTopChromeBlock,
 	type TopChromeSnapshot,
 	TOP_CHROME_BRAND,
 } from "./top-chrome.js";
@@ -27,6 +28,15 @@ describe("renderTopChrome", () => {
 		expect(line).toHaveLength(160);
 		expect(line.startsWith(` ${TOP_CHROME_BRAND}`)).toBe(true);
 		expect(line.endsWith(" ")).toBe(true);
+	});
+
+	it("wraps compact portrait chrome with top/bottom breathing rows", () => {
+		const lines = renderTopChromeBlock(snapshot(), 60).map(stripAnsi);
+		expect(lines).toHaveLength(3);
+		expect(lines[0]).toBe(" ".repeat(60));
+		expect(lines[1]).toContain(TOP_CHROME_BRAND);
+		expect(lines[2]).toBe(" ".repeat(60));
+		expect(renderTopChromeBlock(snapshot(), 160)).toHaveLength(1);
 	});
 
 	it("wraps active session with ║ ║ and includes static active marker + label", () => {
@@ -80,20 +90,21 @@ describe("renderTopChrome", () => {
 		expect(line).not.toContain("\uF423");
 	});
 
-	it("at narrow width drops icons first, then ARCHIVE, then recents", () => {
-		// Wide enough for everything
+	it("at compact portrait width drops recents and ARCHIVE but keeps icons", () => {
+		// Wide enough for everything.
 		const wide = stripAnsi(renderTopChrome(snapshot(), 160));
 		expect(wide).toContain("\uF423");
+		expect(wide).toContain("ARCHIVE");
+		expect(wide).toContain("debug-balance-tx");
 
-		// Narrow: 80 cols — should drop icons but keep brand + active + maybe some recents
-		const narrow = stripAnsi(renderTopChrome(snapshot(), 80));
-		expect(narrow).toContain(TOP_CHROME_BRAND);
-		expect(narrow).toContain("refactor-auth-flow");
-
-		// Very narrow: 50 cols — only brand + active session
-		const veryNarrow = stripAnsi(renderTopChrome(snapshot(), 50));
-		expect(veryNarrow).toContain(TOP_CHROME_BRAND);
-		expect(veryNarrow).toContain("refactor-auth-flow");
+		// Portrait: keep brand + active + right icons, but collapse tab/archive text.
+		const portrait = stripAnsi(renderTopChrome(snapshot(), 60));
+		expect(portrait).toContain(TOP_CHROME_BRAND);
+		expect(portrait).toContain("refactor-auth-flow");
+		expect(portrait).toContain("\uF489");
+		expect(portrait).toContain("\uF423");
+		expect(portrait).not.toContain("ARCHIVE");
+		expect(portrait).not.toContain("debug-balance-tx");
 	});
 
 	it("truncates very long session labels with ellipsis", () => {
@@ -160,5 +171,6 @@ describe("installTopChrome", () => {
 
 		ctx.sessionManager.getBranch.mockReturnValue([{ type: "message" }]);
 		expect(stripAnsi(component!.render(160)[0]!)).toContain(TOP_CHROME_BRAND);
+		expect(component!.render(60)).toHaveLength(3);
 	});
 });

--- a/src/top-chrome.ts
+++ b/src/top-chrome.ts
@@ -13,8 +13,8 @@
  *
  * When `hidden` is true (set via /sumo:tabs hide), only SUMOCODE renders.
  *
- * At narrow widths, regions are dropped right-to-left: icons → ARCHIVE → recents.
- * SUMOCODE + active session always survive.
+ * At compact portrait widths, recents + ARCHIVE collapse first and the right
+ * icons survive when space allows. SUMOCODE + active session always survive.
  *
  * Pure render only. Pi-glue is in `installTopChrome` below.
  */
@@ -66,6 +66,8 @@ const ICON_GAP = "  ";
 const ARCHIVE_LABEL = "ARCHIVE";
 const OUTER_PAD = 1;
 const BRAND_ACTIVE_GAP = 2;
+const COMPACT_TOP_CHROME_WIDTH = 80;
+const PORTRAIT_CHROME_BREATHING_WIDTH = 80;
 const DOT_GLYPHS: Record<TopChromeDotSize, string> = {
 	small: "·",
 	medium: "•",
@@ -123,8 +125,8 @@ function padToWidth(text: string, width: number): string {
  *   4. ARCHIVE link
  *   5. Icons block (right-aligned)
  *
- * At narrow widths, regions drop right-to-left in reverse priority order
- * (icons first, then ARCHIVE, then recents).
+ * At compact portrait widths, the chrome keeps brand + active session + icons
+ * and drops recents/ARCHIVE so 60-column scenes remain readable.
  */
 export function renderTopChrome(snapshot: TopChromeSnapshot, width: number): string {
 	if (width <= 0) return "";
@@ -155,23 +157,26 @@ export function renderTopChrome(snapshot: TopChromeSnapshot, width: number): str
 	}
 	let consumed = brandLen + BRAND_ACTIVE_GAP + visibleLength(active);
 	let line = `${brand}${" ".repeat(BRAND_ACTIVE_GAP)}${active}`;
+	const compact = innerWidth < COMPACT_TOP_CHROME_WIDTH;
 
-	// Try to fit recent sessions one at a time.
-	for (const recent of snapshot.recentSessions) {
-		const seg = recentSegment(recent.label);
-		const segLen = visibleLength(seg);
-		if (consumed + segLen > width) break;
-		line += seg;
-		consumed += segLen;
-	}
-
-	// Try to fit ARCHIVE link.
-	{
-		const seg = archiveSegment();
-		const segLen = visibleLength(seg);
-		if (consumed + segLen <= width) {
+	if (!compact) {
+		// Try to fit recent sessions one at a time.
+		for (const recent of snapshot.recentSessions) {
+			const seg = recentSegment(recent.label);
+			const segLen = visibleLength(seg);
+			if (consumed + segLen > width) break;
 			line += seg;
 			consumed += segLen;
+		}
+
+		// Try to fit ARCHIVE link.
+		{
+			const seg = archiveSegment();
+			const segLen = visibleLength(seg);
+			if (consumed + segLen <= width) {
+				line += seg;
+				consumed += segLen;
+			}
 		}
 	}
 
@@ -187,6 +192,20 @@ export function renderTopChrome(snapshot: TopChromeSnapshot, width: number): str
 	}
 
 	return `${outerPad}${padToWidth(line, innerWidth)}${outerPad}`;
+}
+
+/**
+ * Runtime block wrapper. Portrait Bible scenes reserve one blank breathing row
+ * above and below the top chrome, while wider scenes keep the previously
+ * approved one-row landscape chrome.
+ */
+export function renderTopChromeBlock(snapshot: TopChromeSnapshot, width: number): string[] {
+	const line = renderTopChrome(snapshot, width);
+	if (width > 0 && width < PORTRAIT_CHROME_BREATHING_WIDTH) {
+		const blank = " ".repeat(width);
+		return [blank, line, blank];
+	}
+	return [line];
 }
 
 // ============================================================================
@@ -222,7 +241,7 @@ export function installTopChrome(pi: ExtensionAPI, loader?: TopChromeLoader): vo
 				render(width: number): string[] {
 					if (!sessionHasMessages(ctx)) return [];
 					const snap = loader ? loader() : defaultSnapshot(ctx, state);
-					return [renderTopChrome(snap, width)];
+					return renderTopChromeBlock(snap, width);
 				},
 			};
 		});

--- a/src/visual-parity-contract.test.ts
+++ b/src/visual-parity-contract.test.ts
@@ -83,11 +83,22 @@ describe("V2 visual parity contract", () => {
 		]));
 	});
 
-	it("keeps the V1 portrait runtime no-sidebar", () => {
+	it("keeps the V1 portrait runtime no-sidebar with crop-level evidence", () => {
 		const portrait = scenario("active-portrait-runtime");
 
 		expect(portrait.dimensions.cols).toBeLessThan(SIDEBAR_MIN_TERMINAL_WIDTH);
-		expect(portrait.crops.map((crop) => crop.id)).toEqual(["full"]);
+		expect(portrait.crops.map((crop) => crop.id)).toEqual([
+			"full",
+			"top-bar",
+			"chat-area",
+			"input-frame",
+			"hint-row",
+			"footer",
+		]);
+		expect(portrait.crops.map((crop) => crop.id)).not.toContain("sidebar");
+		expect(cropDefinition("portrait-top-bar")).toEqual({ x: 0, y: 1, cols: 60, rows: 1 });
+		expect(cropDefinition("portrait-input-frame")).toEqual({ x: 0, y: 93, cols: 60, rows: 3 });
+		expect(cropDefinition("portrait-footer")).toEqual({ x: 0, y: 98, cols: 60, rows: 1 });
 	});
 
 	it("keeps required crop gates backed by committed runtime goldens", () => {

--- a/src/working-indicator.test.ts
+++ b/src/working-indicator.test.ts
@@ -6,6 +6,7 @@ import {
 	formatSpinnerInspection,
 	indicatorFrameAt,
 	renderIndicator,
+	shouldInstallWorkingIndicator,
 } from "./working-indicator.js";
 
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
@@ -68,6 +69,15 @@ describe("renderIndicator", () => {
 		// half the loop retraces. Every frame must be unique within the cycle.
 		const seen = new Set(CATHEDRAL_INDICATOR_FRAMES);
 		expect(seen.size).toBe(CATHEDRAL_INDICATOR_FRAMES.length);
+	});
+});
+
+describe("shouldInstallWorkingIndicator", () => {
+	it("keeps the working row out of portrait 60-column scenes", () => {
+		expect(shouldInstallWorkingIndicator(60)).toBe(false);
+		expect(shouldInstallWorkingIndicator(79)).toBe(false);
+		expect(shouldInstallWorkingIndicator(80)).toBe(true);
+		expect(shouldInstallWorkingIndicator(160)).toBe(true);
 	});
 });
 

--- a/src/working-indicator.ts
+++ b/src/working-indicator.ts
@@ -72,6 +72,7 @@ export function renderIndicator(
  * reads as scriptorium brushwork rather than a frantic CLI spinner.
  */
 export const CATHEDRAL_INDICATOR_INTERVAL_MS = 150;
+export const WORKING_INDICATOR_MIN_WIDTH = 80;
 
 /**
  * Pre-colorize each Cathedral frame with the accent token so Pi can render the
@@ -79,6 +80,26 @@ export const CATHEDRAL_INDICATOR_INTERVAL_MS = 150;
  */
 export function buildCathedralIndicatorFrames(hex: string = CATHEDRAL_TOKENS.colors.accent): string[] {
 	return CATHEDRAL_INDICATOR_FRAMES.map((_, i) => renderIndicator(i, CATHEDRAL_INDICATOR_FRAMES, hex));
+}
+
+/**
+ * Portrait Bible scenes reserve the pre-input breathing row; the working
+ * indicator is a landscape affordance for V1 so it does not consume that row at
+ * 60 columns.
+ */
+function currentTerminalWidth(): number {
+	// Prefer COLUMNS because the visual harness intentionally pins it to the
+	// scenario width; process.stdout.columns can remain stale at 80 inside the
+	// hybrid Pi/SumoTUI bootstrap.
+	const envColumns = Number.parseInt(process.env.COLUMNS ?? "", 10);
+	if (Number.isFinite(envColumns) && envColumns > 0) return envColumns;
+	const stdoutColumns = process.stdout.columns;
+	if (Number.isFinite(stdoutColumns) && stdoutColumns > 0) return stdoutColumns;
+	return 80;
+}
+
+export function shouldInstallWorkingIndicator(width = currentTerminalWidth()): boolean {
+	return width >= WORKING_INDICATOR_MIN_WIDTH;
 }
 
 /**
@@ -110,6 +131,7 @@ export function formatSpinnerInspection(
 export function installWorkingIndicator(pi: ExtensionAPI): void {
 	pi.on("session_start", (_event, ctx) => {
 		if (!ctx.hasUI) return;
+		if (!shouldInstallWorkingIndicator()) return;
 
 		ctx.ui.setWorkingIndicator({
 			frames: buildCathedralIndicatorFrames(),


### PR DESCRIPTION
## Summary
- Compose the approved V2 active portrait runtime scene with the accepted no-sidebar policy.
- Add portrait crop-level review evidence for top bar, chat area, input frame, hint row, and footer.
- Align portrait spacing and horizontal padding against the Bible: top breathing rows, chat right gutter, hint/footer side padding, bottom footer rhythm.
- Keep project context in the portrait hint/footer context row with project foreground and branch dim.

## Verification
- `pnpm test`
- `pnpm test:integration`
- `pnpm visual:ci`
- `pnpm exec tsc --noEmit && pnpm build`

## Visual review
- Local review pack: `http://127.0.0.1:7781/bible-verify/` → `active-portrait-runtime`
- Dhruv approved the portrait visual pass after side-by-side Bible/runtime review.

Closes #87
