### PR TITLE
fix(ui): clamp cathedral input at narrow widths

### DIFF
--- a/src/cathedral/cathedral-editor.ts
+++ b/src/cathedral/cathedral-editor.ts
@@ -38,7 +38,7 @@ import type {
 	KeybindingsManager,
 } from "@mariozechner/pi-coding-agent";
 import { CustomEditor } from "@mariozechner/pi-coding-agent";
-import { CURSOR_MARKER, visibleWidth, type EditorTheme, type TUI } from "@mariozechner/pi-tui";
+import { CURSOR_MARKER, truncateToWidth, visibleWidth, type EditorTheme, type TUI } from "@mariozechner/pi-tui";
 import { CATHEDRAL_TOKENS } from "../tokens.js";
 import {
 	INPUT_FRAME_LABEL_ACTIVE,
@@ -52,6 +52,18 @@ const SPLASH_INPUT_FRAME_WIDTH = 60;
 
 function visibleLength(text: string): number {
 	return visibleWidth(text);
+}
+
+function ellipsize(text: string, max: number): string {
+	if (max <= 0) return "";
+	if (text.length <= max) return text;
+	if (max === 1) return "…";
+	return `${text.slice(0, max - 1)}…`;
+}
+
+function fitAnsiToWidth(text: string, width: number): string {
+	if (width <= 0) return "";
+	return visibleLength(text) > width ? truncateToWidth(text, width, "…") : text;
 }
 
 function fg(hex: string): string {
@@ -96,12 +108,15 @@ function renderTopBorder(width: number, label: string | undefined, paintBackgrou
 	if (width < 6) return maybeWithFrameBackground(color("─".repeat(width), CATHEDRAL_TOKENS.colors.divider), paintBackground);
 	const inner = width - 2;
 	if (!label) return maybeWithFrameBackground(color(`┌${"─".repeat(inner)}┐`, CATHEDRAL_TOKENS.colors.divider), paintBackground);
-	const labelInner = ` ${label} `;
-	const remaining = Math.max(2, width - labelInner.length - 3);
-	const left = `${DIVIDER_FG}┌─`;
-	const labelText = color(labelInner, CATHEDRAL_TOKENS.colors.accent);
-	const right = `${DIVIDER_FG}${"─".repeat(remaining)}┐${RESET}`;
-	return maybeWithFrameBackground(`${left}${labelText}${right}`, paintBackground);
+	const leftDashes = "─".repeat(Math.min(1, inner));
+	const maxLabelText = Math.max(0, inner - leftDashes.length - 2); // 2 = spaces around label
+	const labelText = ellipsize(label, maxLabelText);
+	const labelInner = labelText.length > 0 ? ` ${labelText} ` : "";
+	const rightDashes = "─".repeat(Math.max(0, inner - leftDashes.length - labelInner.length));
+	const left = `${DIVIDER_FG}┌${leftDashes}`;
+	const labelSegment = color(labelInner, CATHEDRAL_TOKENS.colors.accent);
+	const right = `${DIVIDER_FG}${rightDashes}┐${RESET}`;
+	return maybeWithFrameBackground(`${left}${labelSegment}${right}`, paintBackground);
 }
 
 function renderBottomBorder(width: number, paintBackground: boolean): string {
@@ -121,9 +136,10 @@ function renderBottomBorder(width: number, paintBackground: boolean): string {
  */
 function wrapRow(inner: string, width: number, paintBackground: boolean): string {
 	const innerWidth = Math.max(0, width - 2);
-	const visible = visibleLength(inner);
+	const fitted = fitAnsiToWidth(inner, innerWidth);
+	const visible = visibleLength(fitted);
 	const pad = Math.max(0, innerWidth - visible);
-	const padded = `${inner}${" ".repeat(pad)}`;
+	const padded = `${fitted}${" ".repeat(pad)}`;
 	return maybeWithFrameBackground(`${DIVIDER_FG}│${RESET}${padded}${DIVIDER_FG}│${RESET}`, paintBackground);
 }
 
@@ -136,9 +152,10 @@ function wrapActiveRow(inner: string, width: number, paintBackground: boolean, i
 	const innerWidth = Math.max(0, width - 2);
 	const promptCells = 3; // " > " or "   "
 	const contentWidth = Math.max(0, innerWidth - promptCells);
-	const visible = visibleLength(inner);
+	const fitted = fitAnsiToWidth(inner, contentWidth);
+	const visible = visibleLength(fitted);
 	const pad = Math.max(0, contentWidth - visible);
-	const padded = `${inner}${" ".repeat(pad)}`;
+	const padded = `${fitted}${" ".repeat(pad)}`;
 	const prompt = isFirstRow
 		? ` ${color(">", CATHEDRAL_TOKENS.colors.accent)} `
 		: "   ";
@@ -147,7 +164,8 @@ function wrapActiveRow(inner: string, width: number, paintBackground: boolean, i
 
 function centerRow(row: string, width: number): string {
 	const visible = visibleLength(row);
-	if (visible >= width) return row;
+	if (visible > width) return truncateToWidth(row, width, "…");
+	if (visible === width) return row;
 	const left = Math.floor((width - visible) / 2);
 	const right = width - visible - left;
 	return `${" ".repeat(left)}${row}${" ".repeat(right)}`;
@@ -219,7 +237,10 @@ class CathedralEditor extends CustomEditor {
 				// Preserve Pi's zero-width cursor marker while painting our ghost text.
 				// Without this, TUI.positionHardwareCursor() sees no marker on the
 				// splash empty state and emits \x1b[?25l after every render.
-				const ghost = ` ${color(">", CATHEDRAL_TOKENS.colors.accent)} ${color(`${INPUT_FRAME_PLACEHOLDER}${CURSOR_MARKER}`, CATHEDRAL_TOKENS.colors.foregroundDim)}`;
+				const prompt = ` ${color(">", CATHEDRAL_TOKENS.colors.accent)} `;
+				const maxPlaceholder = Math.max(0, frameWidth - 2 - visibleLength(prompt));
+				const placeholder = ellipsize(INPUT_FRAME_PLACEHOLDER, maxPlaceholder);
+				const ghost = `${prompt}${color(`${placeholder}${CURSOR_MARKER}`, CATHEDRAL_TOKENS.colors.foregroundDim)}`;
 				return fullRow(wrapRow(ghost, frameWidth, paintFrameBackground));
 			}
 			if (!splash) return wrapActiveRow(row, frameWidth, paintFrameBackground, isFirstContent);

--- a/src/cathedral/input-frame.test.ts
+++ b/src/cathedral/input-frame.test.ts
@@ -69,6 +69,13 @@ describe("renderInputFrame — active state (no label, no placeholder)", () => {
 		const lines = renderInputFrame("hello", 50, { promptColor: "accent" });
 		expect(lines.join("\n")).toContain("\u001b[38;2;217;119;6m>");
 	});
+
+	for (const width of [40, 30, 20, 6, 5, 4]) {
+		it(`never exceeds ${width} cols when active input must truncate`, () => {
+			const lines = renderInputFrame("a very long pasted active input line that must not overflow", width, { promptColor: "accent" });
+			for (const line of lines) expect(stripAnsi(line).length).toBe(width);
+		});
+	}
 });
 
 describe("renderInputFrame — splash state (with label + placeholder)", () => {
@@ -105,6 +112,16 @@ describe("renderInputFrame — splash state (with label + placeholder)", () => {
 		expect(output).toContain("\u001b[38;2;139;122;99m");
 		expect(output).not.toContain("\u001b[2m");
 	});
+
+	for (const width of [40, 30, 20, 6, 5, 4]) {
+		it(`never exceeds ${width} cols when splash label/placeholder must truncate`, () => {
+			const lines = renderInputFrame("", width, {
+				label: "DIVINE INVOCATION",
+				placeholder: 'Ask anything... "Refactor the auth flow."',
+			});
+			for (const line of lines) expect(stripAnsi(line).length).toBe(width);
+		});
+	}
 });
 
 describe("renderInputHints", () => {

--- a/src/cathedral/input-frame.ts
+++ b/src/cathedral/input-frame.ts
@@ -120,10 +120,12 @@ export function renderInputFrame(input: string, width: number, options: InputFra
 	// accent foreground over recess background so it reads as a notch.
 	let top: string;
 	if (options.label) {
-		const labelInner = ` ${options.label} `;
-		const remaining = Math.max(2, inner - labelInner.length - 2); // 2 = leading "─" before label
-		const leftDashes = "─".repeat(2);
-		const rightDashes = "─".repeat(remaining);
+		const leftDashCount = Math.min(2, inner);
+		const leftDashes = "─".repeat(leftDashCount);
+		const maxLabelText = Math.max(0, inner - leftDashCount - 2); // 2 = spaces around label
+		const labelText = ellipsize(options.label, maxLabelText);
+		const labelInner = labelText.length > 0 ? ` ${labelText} ` : "";
+		const rightDashes = "─".repeat(Math.max(0, inner - leftDashes.length - labelInner.length));
 		top = `${dividerCh("┌")}${dividerCh(leftDashes)}${color(labelInner, CATHEDRAL_TOKENS.colors.accent)}${dividerCh(rightDashes)}${dividerCh("┐")}`;
 	} else {
 		top = `${dividerCh("┌")}${dividerCh("─".repeat(inner))}${dividerCh("┐")}`;
@@ -139,13 +141,21 @@ export function renderInputFrame(input: string, width: number, options: InputFra
 			: CATHEDRAL_TOKENS.colors.foregroundDim;
 	const promptArrow = color(">", promptHex);
 	const cursor = color("█", CATHEDRAL_TOKENS.colors.accent);
-	let textPart: string;
-	if (showPlaceholder) {
-		textPart = color(options.placeholder!, CATHEDRAL_TOKENS.colors.foregroundDim);
+	const rawText = showPlaceholder ? options.placeholder! : input;
+	const textColor = showPlaceholder ? CATHEDRAL_TOKENS.colors.foregroundDim : CATHEDRAL_TOKENS.colors.foreground;
+	let innerContent: string;
+	if (inner >= 4) {
+		const maxText = Math.max(0, inner - 4); // leading space + prompt + separator + cursor
+		const text = ellipsize(rawText, maxText);
+		const textPart = text.length > 0 ? color(text, textColor) : "";
+		innerContent = ` ${promptArrow} ${textPart}${cursor}`;
+	} else if (inner === 3) {
+		innerContent = `${promptArrow} ${cursor}`;
+	} else if (inner === 2) {
+		innerContent = `${promptArrow}${cursor}`;
 	} else {
-		textPart = color(input, CATHEDRAL_TOKENS.colors.foreground);
+		innerContent = cursor;
 	}
-	const innerContent = ` ${promptArrow} ${textPart}${cursor}`;
 	const innerVisible = visibleLength(innerContent);
 	const padding = Math.max(0, inner - innerVisible);
 	const contentInner = `${innerContent}${" ".repeat(padding)}`;

--- a/test/integration/narrow-width.test.ts
+++ b/test/integration/narrow-width.test.ts
@@ -1,0 +1,61 @@
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { spawnPiPty, type SpawnedPiPty } from "./spawn-pi-pty.js";
+
+const ANSI_PATTERN = /\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07]*(?:\x07|\x1b\\)|_[^\x07]*(?:\x07|\x1b\\))/g;
+
+let app: SpawnedPiPty | undefined;
+
+afterEach(() => {
+	app?.cleanup();
+	app = undefined;
+});
+
+function stripAnsi(text: string): string {
+	return text.replace(ANSI_PATTERN, "");
+}
+
+function visibleOutputLines(output: string): string[] {
+	return stripAnsi(output)
+		.replaceAll("\r", "")
+		.split("\n")
+		.filter((line) => line.length > 0);
+}
+
+async function expectNarrowBoot(cols: number, rows: number): Promise<void> {
+	const agentDir = await mkdtemp(join(tmpdir(), "sumocode-pi-agent-"));
+	app = spawnPiPty({
+		cols,
+		rows,
+		env: {
+			PI_CODING_AGENT_DIR: agentDir,
+			SUMO_TUI: "1",
+			SUMO_TUI_HIDE_PI_NOISE: "1",
+			SUMO_TUI_MODULE: pathToFileURL(join(process.cwd(), "sumo-interactive-mode.js")).href,
+		},
+	});
+
+	await app.waitForOutput("DIVINE INVOCATION", 10_000);
+	await new Promise((resolve) => setTimeout(resolve, 250));
+
+	const output = app.getOutput();
+	expect(output).not.toMatch(/Rendered line \d+ exceeds terminal width/);
+	const overflowing = visibleOutputLines(output).filter((line) => line.length > cols);
+	expect(overflowing).toEqual([]);
+
+	app.cleanup();
+	app = undefined;
+}
+
+describe("sumo-tui narrow-width boot integration", () => {
+	it("renders cleanly at Mac mini portrait width (40×100)", async () => {
+		await expectNarrowBoot(40, 100);
+	}, 20_000);
+
+	it("renders cleanly at extreme narrow width (30×24)", async () => {
+		await expectNarrowBoot(30, 24);
+	}, 20_000);
+});


### PR DESCRIPTION
## Summary

Fixes the narrow-width boot crash / overflow path by clamping Cathedral input chrome to the render width.

### Changes
- Truncates splash placeholder text before injecting Pi's zero-width cursor marker.
- Clamps wrapped Pi editor rows with `truncateToWidth()` before adding Cathedral borders.
- Truncates narrow input labels instead of allowing fixed label text to overflow.
- Keeps active/splash input-frame pure renderer exact-width at 40, 30, and extreme narrow widths.
- Adds an integration regression for:
  - 40×100 Mac mini portrait width
  - 30×24 extreme narrow width

## Verification

- `pnpm test`
- `pnpm test:integration`
- `pnpm visual:ci`
- `pnpm exec tsc --noEmit`
- `pnpm build`

Closes #72
