### PR TITLE
fix(runtime): filter Pi skill conflict warnings

### DIFF
--- a/src/sumo-tui/pi-compat/pi-interactive-adapter.test.ts
+++ b/src/sumo-tui/pi-compat/pi-interactive-adapter.test.ts
@@ -17,7 +17,10 @@ class Spacer {}
 
 describe("Pi interactive adapter", () => {
 	it("matches Pi startup noise Text components after ANSI styling", () => {
+		expect(isPiNoiseTextComponent(new TextNode("\x1b[33m[Skill conflicts]\x1b[0m\n  \"use-railway\" collision:"))).toBe(true);
+		expect(isPiNoiseTextComponent(new TextNode("\x1b[33m[Prompt conflicts]\x1b[0m\nconflict"))).toBe(true);
 		expect(isPiNoiseTextComponent(new TextNode("\x1b[33m[Extension issues]\x1b[0m\nshortcut conflict"))).toBe(true);
+		expect(isPiNoiseTextComponent(new TextNode("\x1b[33m[Theme conflicts]\x1b[0m\nconflict"))).toBe(true);
 		expect(isPiNoiseTextComponent(new TextNode("\x1b[33mWarning: Anthropic subscription auth is active. Third-party harness usage draws from extra usage.\x1b[0m"))).toBe(true);
 		expect(isPiNoiseTextComponent(new TextNode("Warning: Wait for the current response to finish before reloading."))).toBe(false);
 	});

--- a/src/sumo-tui/pi-compat/pi-interactive-adapter.ts
+++ b/src/sumo-tui/pi-compat/pi-interactive-adapter.ts
@@ -3,7 +3,10 @@ const FALSE_ENV_VALUES = new Set(["0", "false", "no", "off"]);
 const PI_NOISE_FILTER_INSTALLED = Symbol("sumo-tui.pi-noise-filter-installed");
 
 export const PI_NOISE_TEXT_PATTERNS: readonly RegExp[] = [
+	/\[Skill conflicts\]/i,
+	/\[Prompt conflicts\]/i,
 	/\[Extension issues\]/i,
+	/\[Theme conflicts\]/i,
 	/Warning:\s*Anthropic subscription auth is active/i,
 	/Anthropic subscription auth is active\. Third-party harness usage/i,
 ];

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
@@ -31,7 +31,10 @@ class Spacer {}
 
 describe("sumo interactive Pi noise filtering", () => {
 	it("matches Pi startup noise Text components after ANSI styling", () => {
+		expect(isPiNoiseTextComponent(new TextNode("\x1b[33m[Skill conflicts]\x1b[0m\n  \"use-railway\" collision:"))).toBe(true);
+		expect(isPiNoiseTextComponent(new TextNode("\x1b[33m[Prompt conflicts]\x1b[0m\nconflict"))).toBe(true);
 		expect(isPiNoiseTextComponent(new TextNode("\x1b[33m[Extension issues]\x1b[0m\nshortcut conflict"))).toBe(true);
+		expect(isPiNoiseTextComponent(new TextNode("\x1b[33m[Theme conflicts]\x1b[0m\nconflict"))).toBe(true);
 		expect(isPiNoiseTextComponent(new TextNode("\x1b[33mWarning: Anthropic subscription auth is active. Third-party harness usage draws from extra usage.\x1b[0m"))).toBe(true);
 		expect(isPiNoiseTextComponent(new TextNode("Warning: Wait for the current response to finish before reloading."))).toBe(false);
 	});


### PR DESCRIPTION
## Summary

Filters Pi startup diagnostics that are real warnings but should not render as chat-area content in retained SumoTUI.

### Changes
- Adds `[Skill conflicts]` to the Pi noise filter, fixing the visible `use-railway` duplicate warning leak.
- Also covers sibling diagnostic headings from the same upstream startup path:
  - `[Prompt conflicts]`
  - `[Theme conflicts]`
- Keeps the opt-out behavior: `SUMO_TUI_HIDE_PI_NOISE=0` still disables the filter.

## Manual smoke

Using the user-facing wrapper with the current local duplicate skill setup:

```bash
./bin/sumocode.sh --offline --no-extensions --no-session
```

Observed: output no longer contains `[Skill conflicts]`.

## Verification

- `pnpm test`
- `pnpm test:integration`
- `pnpm visual:ci`
- `pnpm exec tsc --noEmit`
- `pnpm build`

Closes #73
