### PR TITLE
test(runtime): guard chat viewport against ghost shell UI

### DIFF
--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
@@ -208,6 +208,13 @@ describe("sumo interactive Pi noise filtering", () => {
 		const rendered = upstream.chatContainer.render(60).join("\n");
 		expect(rendered).toContain("USER");
 		expect(rendered).not.toContain("upstream chat");
+		// Regression for #67: chatContainer.render must only return retained
+		// chat/splash content. Pi owns header, editor, and footer as separate
+		// shell slots; if those leak here they stack as ghost UI in scrollback.
+		expect(rendered).not.toContain("header");
+		expect(rendered).not.toContain("editor");
+		expect(rendered).not.toContain("hints");
+		expect(rendered).not.toContain("footer");
 		cleanup?.();
 		runtime.stop();
 	});


### PR DESCRIPTION
## Summary

Adds regression coverage for the retained chat viewport seam so shell UI cannot leak into `chatContainer.render()`.

The current runtime architecture already keeps `renderChatLines()` scoped to the retained chat/splash root. This PR locks that contract down:

- `chatContainer.render()` returns retained chat content
- it does **not** return Pi shell slots (`header`, `editor`, `hints`, `footer`)
- prevents regressions where full-shell frames stack as ghost UI in chat scrollback

## Verification

- `pnpm test`
- `pnpm test:integration`
- `pnpm visual:ci`
- `pnpm exec tsc --noEmit`
- `pnpm build`

Closes #67
