### PR TITLE
feat(runtime): render structured tool pills

### DIFF
--- a/docs/ui/bible/_assets/tokens.css
+++ b/docs/ui/bible/_assets/tokens.css
@@ -33,19 +33,14 @@
   --background:        #1A1511;
   --surface:           #241D17;
   --surface-recess:    #120D0A;
-  /* SURFACE-LIFTED: locked at #3A342F in v1 spec but reads as cool grey on
-   * dark monitor. Bumped to #3D3024 in bible — warmer (more orange-amber)
-   * to read as 'aged parchment lifted above the surface' rather than grey.
-   * Will propagate this to runtime palette + cathedral.json after we lock
-   * Element 13. Original was: #3A342F. */
+  /* SURFACE-LIFTED: unified at #3D3024 (warmer amber, not cool grey).
+   * Matches runtime tokens.ts. */
   --surface-lifted:    #3D3024;
-  /* DIVIDER: locked at #3A2F25 in runtime palette. For mockup legibility
-   * (PNG export viewed on bright monitor / IDE), bump contrast slightly. The
-   * subtle aesthetic is preserved in actual terminal use where ambient light
-   * is low and eyes are dark-adapted. Only the bible mockups use the bumped
-   * value via --divider-mockup. */
-  --divider:           #3A2F25;
-  --divider-mockup:    #5A4D3C;
+  /* DIVIDER: canonical value shared by runtime tokens.ts and Bible CSS.
+   * Previously split into --divider (#3A2F25) + --divider-mockup (#5A4D3C)
+   * which caused persistent styled-cell-diff mismatches. Unified to #5A4D3C
+   * as of 2026-04-30. */
+  --divider:           #5A4D3C;
   --foreground:        #F5E6C8;
   --foreground-dim:    #8B7A63;
   --accent:            #D97706;
@@ -224,7 +219,7 @@ html, body {
 /* ── color helpers ────────────────────────────────────────────── */
 .fg-accent   { color: var(--accent); }
 .fg-dim      { color: var(--foreground-dim); }
-.fg-divider  { color: var(--divider-mockup); }
+.fg-divider  { color: var(--divider); }
 .fg-fg       { color: var(--foreground); }
 .fg-comment  { color: var(--syntax-comment); }
 

--- a/scripts/visual-v2/fixture-capture.mjs
+++ b/scripts/visual-v2/fixture-capture.mjs
@@ -8,38 +8,6 @@ const jiti = createJiti(import.meta.url, {
 	tryNative: false,
 });
 
-// ── Bible-matching tool pill formatter ─────────────────────────────
-const RESET = "\u001b[0m";
-function fgAnsi(hex) {
-	const n = hex.replace("#", "");
-	const r = parseInt(n.slice(0, 2), 16);
-	const g = parseInt(n.slice(2, 4), 16);
-	const b = parseInt(n.slice(4, 6), 16);
-	return `\u001b[38;2;${r};${g};${b}m`;
-}
-const TOOL_GLYPHS = { success: "✓", error: "✗", running: "⚡", pending: "○" };
-const TOOL_COLORS = { success: "#22C55E", error: "#C1443E", running: "#E8B339", pending: "#8B7A63" };
-
-/** Format a tool block as Bible-matching pill: `✓ [name]  target  · note` */
-function formatToolPill(tool) {
-	const glyph = TOOL_GLYPHS[tool.status] ?? "○";
-	const color = TOOL_COLORS[tool.status] ?? "#8B7A63";
-	const target = tool.output ?? "";
-	return `${fgAnsi(color)}${glyph}${RESET} ${fgAnsi("#D97706")}[${tool.name}]${RESET}${fgAnsi("#F5E6C8")}  ${target}${RESET}`;
-}
-
-/** Convert a ChatMessageViewModel to text matching the Bible chat content. */
-function fixtureMessageToText(message) {
-	return message.blocks.map(block => {
-		switch (block.type) {
-			case "markdown": return block.text;
-			case "tool": return formatToolPill(block.tool);
-			case "code": return `\`\`\`${block.lang}\n${block.source}\n\`\`\``;
-			default: return "";
-		}
-	}).filter(Boolean).join("\n\n");
-}
-
 const FIXTURE_TIMES = {
 	userOne: new Date("2026-04-30T11:41:00"),
 	sumoOne: new Date("2026-04-30T11:42:00"),
@@ -65,8 +33,8 @@ const FIXTURES = {
 					timestamp: FIXTURE_TIMES.sumoOne,
 					blocks: [
 						{ type: "markdown", text: "Reading the auth flow." },
-						{ type: "tool", tool: { id: "read-session", name: "read", status: "success", output: "src/auth/session.ts" } },
-						{ type: "tool", tool: { id: "edit-session", name: "edit", status: "success", output: "src/auth/session.ts" } },
+						{ type: "tool", tool: { id: "read-session", name: "read", status: "success", input: { path: "src/auth/session.ts" } } },
+						{ type: "tool", tool: { id: "edit-session", name: "edit", status: "success", input: { path: "src/auth/session.ts" }, output: "+14 -6 session flow updated" } },
 						{ type: "markdown", text: "Done. Updated 14 lines, deleted 6 stale helpers." },
 					],
 				},
@@ -84,7 +52,7 @@ const FIXTURES = {
 					timestamp: FIXTURE_TIMES.sumoTwo,
 					blocks: [
 						{ type: "markdown", text: "Running tests now." },
-						{ type: "tool", tool: { id: "bash-test", name: "bash", status: "success", output: "pnpm test src/auth · 22 tests, 1.2s" } },
+						{ type: "tool", tool: { id: "bash-test", name: "bash", status: "success", input: { command: "pnpm test src/auth" }, output: "✓ src/auth/session.test.ts (22 tests)\n22 passed in 1.2s", details: { summary: "22 tests, 1.2s" } } },
 						{ type: "markdown", text: "All 22 tests pass." },
 					],
 				},
@@ -99,7 +67,7 @@ const FIXTURES = {
 					role: "user",
 					displayName: "USER",
 					timestamp: FIXTURE_TIMES.userOne,
-					blocks: [{ type: "markdown", text: "inspect auth session and run focused tests" }],
+					blocks: [{ type: "markdown", text: "hello, refactor the auth flow to use the new session pattern." }],
 				},
 				{
 					id: "s1",
@@ -107,11 +75,28 @@ const FIXTURES = {
 					displayName: "SUMO",
 					timestamp: FIXTURE_TIMES.sumoOne,
 					blocks: [
-						{ type: "markdown", text: "I’ll inspect the session boundary, patch it, then run focused tests." },
-						{ type: "tool", tool: { id: "read", name: "read", status: "success", output: "src/auth/session.ts" } },
-						{ type: "tool", tool: { id: "edit", name: "edit", status: "success", output: "+14 -6 session flow updated" } },
-						{ type: "tool", tool: { id: "bash", name: "bash", status: "success", output: "22 passed in 1.2s" } },
-						{ type: "markdown", text: "The focused path is green." },
+						{ type: "markdown", text: "Reading the auth flow." },
+						{ type: "tool", tool: { id: "read", name: "read", status: "success", input: { path: "src/auth/session.ts" }, expanded: true } },
+						{ type: "tool", tool: { id: "edit", name: "edit", status: "success", input: { path: "src/auth/session.ts" }, output: "+14 -6 session flow updated", expanded: true } },
+						{ type: "markdown", text: "Done. Updated 14 lines, deleted 6 stale helpers." },
+					],
+				},
+				{
+					id: "u2",
+					role: "user",
+					displayName: "USER",
+					timestamp: FIXTURE_TIMES.userTwo,
+					blocks: [{ type: "markdown", text: "run tests" }],
+				},
+				{
+					id: "s2",
+					role: "sumo",
+					displayName: "SUMO",
+					timestamp: FIXTURE_TIMES.sumoTwo,
+					blocks: [
+						{ type: "markdown", text: "Running tests now." },
+						{ type: "tool", tool: { id: "bash", name: "bash", status: "success", input: { command: "pnpm test src/auth" }, output: "✓ src/auth/session.test.ts (22 tests)\n22 passed in 1.2s", details: { summary: "22 tests, 1.2s" }, expanded: true } },
+						{ type: "markdown", text: "All 22 tests pass." },
 					],
 				},
 			],
@@ -145,7 +130,7 @@ async function renderFixtureScene(scenario, fixture) {
 	const sidebarWidth = sidebarVisible ? 30 : 0;
 	const chatWidth = Math.max(1, cols - sidebarWidth - gutter);
 
-	const [topChrome, inputFrame, footer, sidebar, chatPager, yogaMod, layoutNodeMod, bufferMod, compositorMod, writerMod, transcriptMod] = await Promise.all([
+	const [topChrome, inputFrame, footer, sidebar, chatPager, yogaMod, layoutNodeMod, bufferMod, compositorMod, writerMod] = await Promise.all([
 		jiti.import(`${repoRoot}/src/top-chrome.ts`),
 		jiti.import(`${repoRoot}/src/cathedral/input-frame.ts`),
 		jiti.import(`${repoRoot}/src/footer.ts`),
@@ -156,7 +141,6 @@ async function renderFixtureScene(scenario, fixture) {
 		jiti.import(`${repoRoot}/src/sumo-tui/render/buffer.ts`),
 		jiti.import(`${repoRoot}/src/sumo-tui/render/compositor.ts`),
 		jiti.import(`${repoRoot}/src/sumo-tui/render/ansi-writer.ts`),
-		jiti.import(`${repoRoot}/src/sumo-tui/transcript/view-model.ts`),
 	]);
 
 	// Bible always has blank / topbar / blank regardless of width.
@@ -193,7 +177,7 @@ async function renderFixtureScene(scenario, fixture) {
 	chatRoot.flexDirection = yogaMod.FLEX_DIRECTION_COLUMN;
 	const chat = chatPager.ChatPager.create(yoga, chatRoot, { stickyBottom: false });
 	for (const message of transcript.messages) {
-		chat.addMessage(message.role, fixtureMessageToText(message), message.timestamp);
+		chat.addViewModel(message);
 	}
 	chatRoot.width = chatWidth;
 	chatRoot.height = chatHeight;

--- a/scripts/visual-v2/fixture-capture.mjs
+++ b/scripts/visual-v2/fixture-capture.mjs
@@ -130,7 +130,7 @@ async function renderFixtureScene(scenario, fixture) {
 	const sidebarWidth = sidebarVisible ? 30 : 0;
 	const chatWidth = Math.max(1, cols - sidebarWidth - gutter);
 
-	const [topChrome, inputFrame, footer, sidebar, chatPager, yogaMod, layoutNodeMod, bufferMod, compositorMod, writerMod] = await Promise.all([
+	const [topChrome, inputFrame, footer, sidebar, chatPager, yogaMod, layoutNodeMod, bufferMod, compositorMod, writerMod, ansiMod] = await Promise.all([
 		jiti.import(`${repoRoot}/src/top-chrome.ts`),
 		jiti.import(`${repoRoot}/src/cathedral/input-frame.ts`),
 		jiti.import(`${repoRoot}/src/footer.ts`),
@@ -141,6 +141,7 @@ async function renderFixtureScene(scenario, fixture) {
 		jiti.import(`${repoRoot}/src/sumo-tui/render/buffer.ts`),
 		jiti.import(`${repoRoot}/src/sumo-tui/render/compositor.ts`),
 		jiti.import(`${repoRoot}/src/sumo-tui/render/ansi-writer.ts`),
+		jiti.import(`${repoRoot}/src/sumo-tui/cathedral/ansi.ts`),
 	]);
 
 	// Bible always has blank / topbar / blank regardless of width.
@@ -204,7 +205,7 @@ async function renderFixtureScene(scenario, fixture) {
 	const scene = [...topRows];
 	for (let row = 0; row < chatHeight; row += 1) {
 		const chatLine = padAnsiToWidth(chatLines[row] ?? "", chatWidth);
-		if (sidebarVisible) scene.push(`${chatLine}${" ".repeat(gutter)}${sidebarLines[row] ?? " ".repeat(sidebarWidth)}`);
+		if (sidebarVisible) scene.push(`${chatLine}${" ".repeat(gutter)}${sidebarLines[row] ?? ansiMod.surfaceLine("", sidebarWidth)}`);
 		else scene.push(`${chatLine}${" ".repeat(gutter)}`);
 	}
 	scene.push(...bottomRows);

--- a/src/cathedral/input-frame.test.ts
+++ b/src/cathedral/input-frame.test.ts
@@ -41,10 +41,10 @@ describe("renderInputFrame — active state (no label, no placeholder)", () => {
 		}
 	});
 
-	it("colors frame chars in divider color (#3A2F25)", () => {
+	it("colors frame chars in divider color (#5A4D3C)", () => {
 		const lines = renderInputFrame("hi", 40);
-		// divider #3A2F25 -> 58;47;37
-		expect(lines.join("\n")).toContain("\u001b[38;2;58;47;37m");
+		// divider #5A4D3C -> 90;77;60
+		expect(lines.join("\n")).toContain("\u001b[38;2;90;77;60m");
 	});
 
 	it("colors cursor █ in accent (#D97706)", () => {

--- a/src/cathedral/input-frame.ts
+++ b/src/cathedral/input-frame.ts
@@ -19,7 +19,7 @@
  *   ╰─ AWAITING PROMPT                         CTRL+/ · COMMANDS
  *
  * Token map (from Stitch CSS variables):
- *   border       → divider  (#3A2F25)  — dim, not accent
+ *   border       → divider  (#5A4D3C)  — dim, not accent
  *   inner bg     → recess   (#120D0A)  — painted on every row
  *   `>` prompt   → oxidized (#8B7A63)  — splash | accent (#D97706) — active
  *   cursor `█`   → accent   (#D97706)

--- a/src/command-palette.ts
+++ b/src/command-palette.ts
@@ -54,9 +54,7 @@ export const COMMAND_PALETTE_MODE_ROWS: readonly PaletteRow[] = [
 const RESET = "\u001b[0m";
 const FG_RESET = "\u001b[39m";
 const PANEL_BG = CATHEDRAL_TOKENS.colors.surfaceLifted;
-// Bible `fg-divider` intentionally uses the higher-contrast mockup divider
-// (#5A4D3C) so ornament rules stay visible on the warm lifted panel.
-const PALETTE_DIVIDER = "#5A4D3C";
+const PALETTE_DIVIDER = CATHEDRAL_TOKENS.colors.divider;
 
 function ansiColor(hex: string, channel: 38 | 48): string {
 	const normalized = hex.replace("#", "");

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -115,6 +115,25 @@ describe("StaticSidebarDock", () => {
 		expect(lines).toEqual(["full width chat"]);
 	});
 
+	it("fills blank sidebar rows with surface bg when chat is taller than sidebar content", () => {
+		const chatRows = Array.from({ length: 30 }, (_, i) => `chat row ${i}`);
+		const left = component(chatRows);
+		const sidebarContent = ["SIDE 1", "SIDE 2"];
+		const right = component(sidebarContent);
+		const dock = new StaticSidebarDock([left.node], right.node, () => true);
+
+		const lines = dock.render(160);
+
+		expect(lines).toHaveLength(30);
+		// Row beyond sidebar content should still have surface bg (#241D17 → 36;29;23)
+		const lastRow = lines[29]!;
+		expect(lastRow).toContain("\u001b[48;2;36;29;23m");
+		// And should be padded to sidebar width
+		const sidebarPart = stripAnsi(lastRow).slice(-SIDEBAR_WIDTH);
+		expect(sidebarPart.length).toBe(SIDEBAR_WIDTH);
+		expect(sidebarPart.trim()).toBe("");
+	});
+
 	it("clips tall sidebar content to the main column height so editor/footer stay pinned", () => {
 		const left = component(["chat row"]);
 		const right = component(["SIDE 1", "SIDE 2", "SIDE 3"]);

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -134,6 +134,30 @@ describe("StaticSidebarDock", () => {
 		expect(sidebarPart.trim()).toBe("");
 	});
 
+	it("sidebar stays identical when chat content changes (scroll independence)", () => {
+		const sidebarNode = component(["REGISTRY", "CONTEXT", "MEMORY"]).node;
+
+		// First render: short chat
+		const chatShort = component(["msg 1", "msg 2"]);
+		const dockA = new StaticSidebarDock([chatShort.node], sidebarNode, () => true);
+		const linesA = dockA.render(160);
+
+		// Second render: long chat (simulates scrolling to more messages)
+		const chatLong = component(["msg 1", "msg 2", "msg 3", "msg 4", "msg 5", "msg 6", "msg 7"]);
+		const dockB = new StaticSidebarDock([chatLong.node], sidebarNode, () => true);
+		const linesB = dockB.render(160);
+
+		// Sidebar occupies cols 130-159 in a 160-col terminal (128 chat + 2 gutter + 30 sidebar)
+		const sidebarColsA = linesA.map((l) => stripAnsi(l).slice(-SIDEBAR_WIDTH));
+		const sidebarColsB = linesB.slice(0, linesA.length).map((l) => stripAnsi(l).slice(-SIDEBAR_WIDTH));
+
+		// Sidebar content in the overlapping rows must be identical regardless of chat changes
+		expect(sidebarColsA).toEqual(sidebarColsB);
+		// Chat grew but sidebar content stays the same
+		expect(linesB).toHaveLength(7);
+		expect(linesA).toHaveLength(2);
+	});
+
 	it("clips tall sidebar content to the main column height so editor/footer stay pinned", () => {
 		const left = component(["chat row"]);
 		const right = component(["SIDE 1", "SIDE 2", "SIDE 3"]);

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
@@ -8,6 +8,8 @@ import { composite } from "../render/compositor.js";
 import { ChatPager } from "../widgets/chat-pager.js";
 import { ChatViewportController, installChatViewportBridge, textFromAgentMessage, type ChatViewportHost, type ChatViewportRuntime } from "./chat-viewport-controller.js";
 
+const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+
 function rows(count: number): { render(width: number): string[] } {
 	return { render: (_width: number) => Array.from({ length: count }, () => "chrome") };
 }
@@ -69,7 +71,7 @@ describe("ChatViewportController", () => {
 	it("extracts streamed assistant text from Pi message shapes", () => {
 		expect(textFromAgentMessage({ role: "user", content: "hello" })).toBe("hello");
 		expect(textFromAgentMessage({ role: "assistant", content: [{ type: "thinking", thinking: "hidden" }, { type: "text", text: "visible" }] })).toBe("visible");
-		expect(textFromAgentMessage({ role: "toolResult", content: [{ type: "text", text: "tool output" }] })).toBe("tool output");
+		expect(textFromAgentMessage({ role: "toolResult", content: [{ type: "text", text: "tool output" }] }).replace(ANSI_PATTERN, "")).toBe("✓ [tool]  tool output  · ⌘O expand");
 	});
 
 	it("owns chat viewport geometry, including sidebar and portrait gutters", async () => {
@@ -122,6 +124,41 @@ describe("ChatViewportController", () => {
 
 		expect(runtime.noteUserMessage).toHaveBeenCalledTimes(1);
 		expect(chat.getRenderedMessages().map((message) => message.text)).toEqual(["hello", "hello back"]);
+		root.dispose();
+	});
+
+	it("mirrors Pi tool expansion state into retained chat tool blocks", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const chat = ChatPager.create(yoga, root);
+		chat.addViewModel({
+			id: "s1",
+			role: "sumo",
+			displayName: "SUMO",
+			blocks: [{ type: "tool", tool: { name: "read", status: "success", input: { path: "src/auth/session.ts" } } }],
+		});
+		const originalSetToolsExpanded = vi.fn();
+		const host = {
+			ui: { terminal: { rows: 24, columns: 120 }, requestRender: vi.fn() },
+			chatContainer: { render: vi.fn(() => []), clear: vi.fn(), invalidate: vi.fn() },
+			setToolsExpanded: originalSetToolsExpanded,
+		};
+		const runtime = {
+			getSnapshot: () => ({ chat }),
+			setExternalRenderControls: vi.fn(),
+			renderChatLines: vi.fn(() => []),
+			writeChatViewport: vi.fn(() => true),
+			requestRender: vi.fn(),
+			setEmptyChatQuoteState: vi.fn(),
+			noteUserMessage: vi.fn(),
+		};
+
+		const cleanup = installChatViewportBridge(host, runtime);
+		host.setToolsExpanded(true);
+
+		expect(originalSetToolsExpanded).toHaveBeenCalledWith(true);
+		expect(chat.getRenderedMessages()[0]?.toSnapshot().blocks?.[0]).toMatchObject({ type: "tool", tool: { expanded: true } });
+		cleanup?.();
 		root.dispose();
 	});
 

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -1,5 +1,6 @@
 import { parseSgrMouseStream, type MouseEvent } from "../input/mouse.js";
 import { logDiagnostic } from "../runtime/diagnostics.js";
+import { chatMessageViewModelFromPiMessage, chatMessageViewModelToPlainText, transcriptFromSessionContext, type ChatMessageViewModel } from "../transcript/view-model.js";
 import { ChatPager } from "../widgets/chat-pager.js";
 import { chatScrollCommandFromInput } from "../widgets/chat-scroll-command.js";
 import { SIDEBAR_MIN_TERMINAL_WIDTH, SIDEBAR_WIDTH } from "../../sidebar.js";
@@ -33,6 +34,8 @@ export interface ChatViewportHost {
 	readonly widgetContainerBelow?: PiRenderableComponent;
 	readonly editorContainer?: PiRenderableComponent;
 	readonly footer?: PiRenderableComponent;
+	setToolsExpanded?(expanded: boolean): void;
+	getToolsExpanded?(): boolean;
 }
 
 export interface ChatViewportRuntime {
@@ -103,38 +106,13 @@ function asRecord(value: unknown): Record<string, unknown> | undefined {
 	return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
 }
 
-function textFromContent(content: unknown): string {
-	if (typeof content === "string") return content;
-	if (!Array.isArray(content)) return "";
-	return content
-		.map((part) => {
-			const record = asRecord(part);
-			if (!record || record.type !== "text") return undefined;
-			return typeof record.text === "string" ? record.text : undefined;
-		})
-		.filter((part): part is string => typeof part === "string")
-		.join("");
-}
-
 export function textFromAgentMessage(message: unknown): string {
-	const record = asRecord(message);
-	if (!record) return "";
-	if (record.role === "bashExecution") {
-		const command = typeof record.command === "string" ? record.command : "bash";
-		const output = typeof record.output === "string" ? record.output : "";
-		return output ? `$ ${command}\n${output}` : `$ ${command}`;
-	}
-	const text = textFromContent(record.content);
-	if (text.length > 0) return text;
-	return typeof record.errorMessage === "string" ? record.errorMessage : "";
+	const viewModel = chatMessageViewModelFromPiMessage(message);
+	return viewModel ? chatMessageViewModelToPlainText(viewModel) : "";
 }
 
-function chatRoleFromAgentMessage(message: unknown): string {
-	const role = asRecord(message)?.role;
-	if (role === "assistant") return "sumo";
-	if (role === "toolResult" || role === "bashExecution") return "tool";
-	if (typeof role === "string") return role;
-	return "system";
+function addViewModel(chat: ChatPager, message: ChatMessageViewModel): void {
+	chat.addViewModel(message);
 }
 
 function renderableLineCount(component: PiRenderableComponent | undefined, width: number): number {
@@ -295,10 +273,9 @@ export class ChatViewportController {
 		this.clear();
 		const messages = sessionMessages(sessionContext);
 		this.runtime.setEmptyChatQuoteState({ active: messages.length === 0, userMessageCount: countUserMessages(messages) });
-		for (const message of messages) {
-			const text = textFromAgentMessage(message);
-			if (text.length === 0) continue;
-			this.chat.addMessage(chatRoleFromAgentMessage(message), text);
+		for (const message of transcriptFromSessionContext(sessionContext).messages) {
+			if (chatMessageViewModelToPlainText(message).length === 0) continue;
+			addViewModel(this.chat, message);
 		}
 	}
 
@@ -310,9 +287,9 @@ export class ChatViewportController {
 			this.chat.addMessage("sumo", "");
 			return;
 		}
-		const text = textFromAgentMessage(message);
-		if (text.length === 0) return;
-		this.chat.addMessage(chatRoleFromAgentMessage(message), text);
+		const viewModel = chatMessageViewModelFromPiMessage(message);
+		if (!viewModel || chatMessageViewModelToPlainText(viewModel).length === 0) return;
+		addViewModel(this.chat, viewModel);
 	}
 
 	private handleMessageUpdate(message: unknown, assistantMessageEvent: unknown): void {
@@ -323,17 +300,21 @@ export class ChatViewportController {
 			this.lastAssistantText += streamEvent.delta;
 			return;
 		}
-		const text = textFromAgentMessage(message);
+		const viewModel = chatMessageViewModelFromPiMessage(message);
+		const text = viewModel ? chatMessageViewModelToPlainText(viewModel) : textFromAgentMessage(message);
 		if (text.length === 0 || text === this.lastAssistantText) return;
-		this.chat.replaceLast(text);
+		if (viewModel) this.chat.replaceLastWithViewModel(viewModel);
+		else this.chat.replaceLast(text);
 		this.lastAssistantText = text;
 	}
 
 	private handleMessageEnd(message: unknown): void {
 		if (asRecord(message)?.role === "assistant") {
-			const text = textFromAgentMessage(message);
+			const viewModel = chatMessageViewModelFromPiMessage(message);
+			const text = viewModel ? chatMessageViewModelToPlainText(viewModel) : textFromAgentMessage(message);
 			if (text.length > 0 && text !== this.lastAssistantText) {
-				this.chat.replaceLast(text);
+				if (viewModel) this.chat.replaceLastWithViewModel(viewModel);
+				else this.chat.replaceLast(text);
 				this.lastAssistantText = text;
 			}
 			this.chat.endStreaming();
@@ -399,6 +380,7 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 	const originalStatusRender = statusContainer?.render?.bind(statusContainer);
 	const originalHandleEvent = target.handleEvent?.bind(target);
 	const originalRenderSessionContext = target.renderSessionContext?.bind(target);
+	const originalSetToolsExpanded = target.setToolsExpanded?.bind(target);
 	const removeInputListener = target.ui?.addInputListener?.((data) => controller.handleInput(data));
 
 	runtime.setExternalRenderControls({
@@ -430,6 +412,12 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 			return originalStatusRender(width);
 		};
 	}
+	if (originalSetToolsExpanded) {
+		target.setToolsExpanded = (expanded: boolean): void => {
+			snapshot.chat.setToolExpansion(expanded);
+			originalSetToolsExpanded(expanded);
+		};
+	}
 	if (originalHandleEvent) {
 		target.handleEvent = async (event: unknown): Promise<unknown> => {
 			controller.handleAgentEvent(event);
@@ -453,6 +441,7 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 		if (originalInvalidate) chatContainer.invalidate = originalInvalidate;
 		else delete chatContainer.invalidate;
 		if (statusContainer && originalStatusRender) statusContainer.render = originalStatusRender;
+		if (originalSetToolsExpanded) target.setToolsExpanded = originalSetToolsExpanded;
 		if (originalHandleEvent) target.handleEvent = originalHandleEvent;
 		if (originalRenderSessionContext) target.renderSessionContext = originalRenderSessionContext;
 		delete target[CHAT_VIEWPORT_BRIDGE_INSTALLED];

--- a/src/sumo-tui/render/primitives.ts
+++ b/src/sumo-tui/render/primitives.ts
@@ -45,6 +45,19 @@ export interface BoxOptions {
 
 const RESET = "\u001b[0m";
 
+/**
+ * Inject persistent fg + bg into pre-rendered ANSI text.
+ * Every SGR reset (\x1b[0m) inside the text is followed by the restore
+ * codes so both colors survive through nested ANSI-formatted content.
+ */
+export function withPersistentStyle(ansiText: string, fgHex: string, bgHex: string): string {
+	const fg = parseHex(fgHex);
+	const bg = parseHex(bgHex);
+	if (!fg || !bg) return ansiText;
+	const styleCode = `\u001b[38;2;${fg[0]};${fg[1]};${fg[2]}m\u001b[48;2;${bg[0]};${bg[1]};${bg[2]}m`;
+	return `${styleCode}${ansiText.replace(/\u001b\[0m/g, `${RESET}${styleCode}`)}${RESET}`;
+}
+
 function parseHex(hex: string): [number, number, number] | undefined {
 	const normalized = hex.replace("#", "");
 	if (!/^[0-9a-fA-F]{6}$/.test(normalized)) return undefined;

--- a/src/sumo-tui/transcript/tool-renderer.test.ts
+++ b/src/sumo-tui/transcript/tool-renderer.test.ts
@@ -21,7 +21,7 @@ describe("tool renderer", () => {
 
 		expect(rows.map(stripAnsi)).toEqual([
 			"╭─ [edit]  src/auth/session.ts ────────────────── ✓ +14 -6 session flow updated ",
-			"│    1  +14 -6 session flow updated                                             ",
+			"│ +14 -6 session flow updated                                                   ",
 			"╰───────────────────────────────────────────────────────────────────────────────",
 		]);
 		expect(rows.every((row) => stripAnsi(row).length === 80)).toBe(true);

--- a/src/sumo-tui/transcript/tool-renderer.test.ts
+++ b/src/sumo-tui/transcript/tool-renderer.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { stripAnsi } from "../cathedral/ansi.js";
+import { renderCompactToolPill, renderToolLedgerRows } from "./tool-renderer.js";
+
+describe("tool renderer", () => {
+	it("renders compact Cathedral tool pills", () => {
+		const line = renderCompactToolPill({ name: "read", status: "success", input: { path: "src/auth/session.ts" } });
+
+		expect(stripAnsi(line)).toBe("✓ [read]  src/auth/session.ts  · ⌘O expand");
+		expect(line).toContain("\u001b[38;2;127;176;105m✓");
+		expect(line).toContain("\u001b[38;2;217;119;6m[read]");
+	});
+
+	it("renders ledger rows for tool blocks at the available body width", () => {
+		const rows = renderToolLedgerRows({
+			name: "edit",
+			status: "success",
+			input: { path: "src/auth/session.ts" },
+			output: "+14 -6 session flow updated",
+		}, 80);
+
+		expect(rows.map(stripAnsi)).toEqual([
+			"╭─ [edit]  src/auth/session.ts ────────────────── ✓ +14 -6 session flow updated ",
+			"│    1  +14 -6 session flow updated                                             ",
+			"╰───────────────────────────────────────────────────────────────────────────────",
+		]);
+		expect(rows.every((row) => stripAnsi(row).length === 80)).toBe(true);
+	});
+
+	it("covers compact read/edit/write/bash status variants", () => {
+		const cases = [
+			[{ name: "read", status: "success", input: { path: "src/auth/session.ts" }, details: { lineCount: 184 } }, "✓ [read]  src/auth/session.ts  · 184 lines  · ⌘O expand"],
+			[{ name: "edit", status: "success", input: { path: "src/auth/session.ts" }, output: "+14 -6" }, "✓ [edit]  src/auth/session.ts  · +14 -6  · ⌘O diff"],
+			[{ name: "write", status: "success", input: { path: "src/auth/new.ts" }, details: { lineCount: 47 } }, "✓ [write]  src/auth/new.ts  · 47 lines  · ⌘O expand"],
+			[{ name: "bash", status: "success", input: { command: "pnpm test" }, details: { summary: "22 tests, 1.2s" } }, "✓ [bash]  pnpm test  · 22 tests, 1.2s  · ⌘O output"],
+			[{ name: "bash", status: "error", input: { command: "pnpm test" }, error: "1 failed" }, "✗ [bash]  pnpm test  · 1 failed  · ⌘O error"],
+			[{ name: "bash", status: "running", input: { command: "pnpm test" } }, "▶ [bash]  pnpm test  · ⌘O output"],
+		] as const;
+
+		for (const [tool, expected] of cases) {
+			expect(stripAnsi(renderCompactToolPill(tool))).toBe(expected);
+		}
+	});
+
+	it("renders expanded read ledgers with line gutter and collapsed marker", () => {
+		const rows = renderToolLedgerRows({
+			name: "read",
+			status: "success",
+			input: { path: "src/auth/session.ts" },
+			details: { excerpt: ["import { Session } from './session';", "export async function getUser() {}"], totalLines: 184 },
+		}, 90).map(stripAnsi);
+
+		expect(rows[1]).toContain("   1  import { Session }");
+		expect(rows[2]).toContain("   2  export async function");
+		expect(rows[3]).toContain("… 182 lines collapsed");
+	});
+
+	it("renders expanded edit ledgers with diff colors and collapsed marker", () => {
+		const rows = renderToolLedgerRows({
+			name: "edit",
+			status: "success",
+			input: { path: "src/auth/session.ts" },
+			details: { diff: ["- old session", "+ new session", "  return session", "+ emit event"], collapsedLines: 8 },
+		}, 90);
+		const plain = rows.map(stripAnsi).join("\n");
+
+		expect(plain).toContain("- old session");
+		expect(plain).toContain("+ new session");
+		expect(plain).toContain("… 8 lines collapsed");
+		expect(rows.join("\n")).toContain("\u001b[38;2;193;68;62m- old session");
+		expect(rows.join("\n")).toContain("\u001b[38;2;127;176;105m+ new session");
+	});
+
+	it("uses tool color for running bash rows", () => {
+		const rows = renderToolLedgerRows({ name: "bash", status: "running", input: { command: "pnpm test" } }, 60);
+		const plain = rows.map(stripAnsi).join("\n");
+
+		expect(plain).toContain("[bash]  pnpm test");
+		expect(plain).toContain("▶");
+		expect(rows.join("\n")).toContain("\u001b[38;2;91;155;213m▶");
+	});
+});

--- a/src/sumo-tui/transcript/tool-renderer.test.ts
+++ b/src/sumo-tui/transcript/tool-renderer.test.ts
@@ -20,7 +20,7 @@ describe("tool renderer", () => {
 		}, 80);
 
 		expect(rows.map(stripAnsi)).toEqual([
-			"╭─ [edit]  src/auth/session.ts ────────────────── ✓ +14 -6 session flow updated ",
+			"╭─ [edit]  src/auth/session.ts ────────────────────────────────────────────── ✓ ",
 			"│ +14 -6 session flow updated                                                   ",
 			"╰───────────────────────────────────────────────────────────────────────────────",
 		]);

--- a/src/sumo-tui/transcript/tool-renderer.ts
+++ b/src/sumo-tui/transcript/tool-renderer.ts
@@ -108,8 +108,14 @@ function padAnsi(line: string, width: number): string {
 	return `${line}${" ".repeat(width - visible)}`;
 }
 
+/** Header note: only explicit summary from details (bash summary etc). */
+function headerNote(tool: ToolCallViewModel): string | undefined {
+	const details = asRecord(tool.details);
+	return firstString(details?.summary, details?.note);
+}
+
 function renderHeader(tool: ToolCallViewModel, width: number): string {
-	const note = toolNote(tool);
+	const note = headerNote(tool);
 	const target = toolTarget(tool);
 	const right: Span[] = [
 		span(" "),

--- a/src/sumo-tui/transcript/tool-renderer.ts
+++ b/src/sumo-tui/transcript/tool-renderer.ts
@@ -1,0 +1,244 @@
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { lineToAnsi, span, textLine, type Span } from "../render/primitives.js";
+import type { ToolCallViewModel, ToolStatus } from "./view-model.js";
+
+const STATUS_GLYPH: Record<ToolStatus, string> = {
+	pending: "○",
+	running: "▶",
+	success: "✓",
+	error: "✗",
+	cancelled: "✗",
+};
+
+const STATUS_COLOR: Record<ToolStatus, string> = {
+	pending: CATHEDRAL_TOKENS.colors.foregroundDim,
+	running: CATHEDRAL_TOKENS.colors.states.tool,
+	success: CATHEDRAL_TOKENS.colors.states.idle,
+	error: CATHEDRAL_TOKENS.colors.states.approval,
+	cancelled: CATHEDRAL_TOKENS.colors.foregroundDim,
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+	return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
+}
+
+function firstString(...values: unknown[]): string | undefined {
+	for (const value of values) {
+		if (typeof value === "string" && value.trim().length > 0) return value.trim();
+	}
+	return undefined;
+}
+
+function compactWhitespace(value: string): string {
+	return value.replace(/\s+/g, " ").trim();
+}
+
+export function toolStatusGlyph(status: ToolStatus): string {
+	return STATUS_GLYPH[status] ?? "○";
+}
+
+export function toolStatusColor(status: ToolStatus): string {
+	return STATUS_COLOR[status] ?? CATHEDRAL_TOKENS.colors.foregroundDim;
+}
+
+export function toolTarget(tool: ToolCallViewModel): string {
+	const input = asRecord(tool.input);
+	const details = asRecord(tool.details);
+	const target = firstString(
+		input?.path,
+		input?.filePath,
+		input?.target,
+		input?.command,
+		details?.path,
+		details?.filePath,
+		details?.target,
+		details?.command,
+	);
+	if (target) return compactWhitespace(target);
+
+	const outputLine = firstString(tool.output?.split("\n")[0], tool.error?.split("\n")[0]);
+	if (outputLine) return compactWhitespace(outputLine.split(" · ")[0] ?? outputLine);
+	return tool.name;
+}
+
+export function toolNote(tool: ToolCallViewModel): string | undefined {
+	const details = asRecord(tool.details);
+	const explicit = firstString(details?.summary, details?.note, details?.description, details?.lineCount ? `${details.lineCount} lines` : undefined);
+	if (explicit) return compactWhitespace(explicit);
+
+	const outputLine = firstString(tool.output?.split("\n")[0], tool.error?.split("\n")[0]);
+	if (!outputLine) return undefined;
+	const note = outputLine.split(" · ").slice(1).join(" · ");
+	if (note.trim().length > 0) return compactWhitespace(note);
+	if (tool.status === "error" || tool.name === "edit" || tool.name === "write") return compactWhitespace(outputLine);
+	return undefined;
+}
+
+function styledToolHeaderParts(tool: ToolCallViewModel): Span[] {
+	return [
+		span(toolStatusGlyph(tool.status), { fg: toolStatusColor(tool.status) }),
+		span(" "),
+		span(`[${tool.name}]`, { fg: CATHEDRAL_TOKENS.colors.accent }),
+		span("  "),
+		span(toolTarget(tool), { fg: CATHEDRAL_TOKENS.colors.foreground }),
+	];
+}
+
+function compactHint(tool: ToolCallViewModel): string {
+	if (tool.status === "error") return "⌘O error";
+	if (tool.name === "edit") return "⌘O diff";
+	if (tool.name === "bash") return "⌘O output";
+	return "⌘O expand";
+}
+
+export function renderCompactToolPill(tool: ToolCallViewModel): string {
+	const note = toolNote(tool);
+	return lineToAnsi(textLine([
+		...styledToolHeaderParts(tool),
+		...(note ? [span("  · ", { fg: CATHEDRAL_TOKENS.colors.foregroundDim }), span(note, { fg: CATHEDRAL_TOKENS.colors.foregroundDim })] : []),
+		span("  · ", { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+		span(compactHint(tool), { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+	]));
+}
+
+function padAnsi(line: string, width: number): string {
+	const visible = visibleWidth(line);
+	if (visible > width) return truncateToWidth(line, width, "");
+	return `${line}${" ".repeat(width - visible)}`;
+}
+
+function renderHeader(tool: ToolCallViewModel, width: number): string {
+	const note = toolNote(tool);
+	const target = toolTarget(tool);
+	const right: Span[] = [
+		span(" "),
+		span(toolStatusGlyph(tool.status), { fg: toolStatusColor(tool.status) }),
+		...(note ? [span(" "), span(note, { fg: CATHEDRAL_TOKENS.colors.foregroundDim })] : []),
+		span(" "),
+	];
+	const left: Span[] = [
+		span("╭─ ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span(`[${tool.name}]`, { fg: CATHEDRAL_TOKENS.colors.accent }),
+		span("  "),
+		span(target, { fg: CATHEDRAL_TOKENS.colors.foreground }),
+		span(" "),
+	];
+	const used = [...left, ...right].reduce((sum, part) => sum + visibleWidth(part.text), 0);
+	const rule = Math.max(1, width - used);
+	return lineToAnsi(textLine([...left, span("─".repeat(rule), { fg: CATHEDRAL_TOKENS.colors.divider }), ...right]), { width });
+}
+
+function renderBodyLine(parts: readonly (Span | string)[], width: number): string {
+	return lineToAnsi(textLine([
+		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span(" "),
+		...parts.map((part) => typeof part === "string" ? span(part, { fg: CATHEDRAL_TOKENS.colors.foreground }) : part),
+	]), { width });
+}
+
+function renderBottom(width: number): string {
+	return lineToAnsi(textLine([
+		span("╰", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("─".repeat(Math.max(0, width - 1)), { fg: CATHEDRAL_TOKENS.colors.divider }),
+	]), { width });
+}
+
+function outputLines(tool: ToolCallViewModel): string[] {
+	const text = tool.status === "error" ? tool.error ?? tool.output ?? "" : tool.output ?? "";
+	return text.split("\n").map((line) => line.trimEnd()).filter((line) => line.length > 0);
+}
+
+function arrayFromDetails(details: Record<string, unknown> | undefined, key: string): string[] {
+	const value = details?.[key];
+	if (!Array.isArray(value)) return [];
+	return value.filter((item): item is string => typeof item === "string");
+}
+
+function collapsedMarker(details: Record<string, unknown> | undefined, fallback = 0): string | undefined {
+	const count = typeof details?.collapsedLines === "number" ? details.collapsedLines : fallback;
+	return count > 0 ? `… ${count} lines collapsed` : undefined;
+}
+
+function renderGutterLine(lineNumber: number | undefined, text: string, width: number, style: string = CATHEDRAL_TOKENS.colors.foreground): string {
+	const gutter = lineNumber === undefined ? "      " : `${String(lineNumber).padStart(4)}  `;
+	return renderBodyLine([
+		span(gutter, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+		span(text, { fg: style }),
+	], width);
+}
+
+function renderReadLikeBody(tool: ToolCallViewModel, width: number): string[] {
+	const details = asRecord(tool.details);
+	const excerpt = arrayFromDetails(details, "excerpt").length > 0 ? arrayFromDetails(details, "excerpt") : outputLines(tool).slice(0, 5);
+	const startLine = typeof details?.startLine === "number" ? details.startLine : 1;
+	const rows = excerpt.slice(0, 5).map((line, index) => renderGutterLine(startLine + index, line, width));
+	const collapsed = collapsedMarker(details, typeof details?.totalLines === "number" ? Math.max(0, details.totalLines - excerpt.length) : 0);
+	if (collapsed) rows.push(renderBodyLine([span("      ", { fg: CATHEDRAL_TOKENS.colors.foregroundDim }), span(collapsed, { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width));
+	if (rows.length === 0) rows.push(renderBodyLine([span("preview collapsed", { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width));
+	return rows;
+}
+
+function renderEditBody(tool: ToolCallViewModel, width: number): string[] {
+	const details = asRecord(tool.details);
+	const diff = arrayFromDetails(details, "diff").length > 0 ? arrayFromDetails(details, "diff") : outputLines(tool);
+	if (diff.length === 0) {
+		const note = toolNote(tool) ?? "diff collapsed";
+		const additions = note.match(/\+(\d+)/)?.[0];
+		const removals = note.match(/-(\d+)/)?.[0];
+		const rest = note.replace(/\+\d+|-\d+/g, "").trim();
+		return [renderBodyLine([
+			...(additions ? [span(additions, { fg: CATHEDRAL_TOKENS.colors.states.idle }), span(" ")] : []),
+			...(removals ? [span(removals, { fg: CATHEDRAL_TOKENS.colors.states.approval }), span(" ")] : []),
+			span(rest || "diff collapsed", { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+		], width)];
+	}
+	const startLine = typeof details?.startLine === "number" ? details.startLine : 1;
+	const rows = diff.slice(0, 6).map((line, index) => {
+		const color = line.trimStart().startsWith("+") ? CATHEDRAL_TOKENS.colors.states.idle
+			: line.trimStart().startsWith("-") ? CATHEDRAL_TOKENS.colors.states.approval
+			: CATHEDRAL_TOKENS.colors.foreground;
+		return renderGutterLine(startLine + index, line, width, color);
+	});
+	const collapsed = collapsedMarker(details, Math.max(0, diff.length - rows.length));
+	if (collapsed) rows.push(renderBodyLine([span("      ", { fg: CATHEDRAL_TOKENS.colors.foregroundDim }), span(collapsed, { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width));
+	return rows;
+}
+
+function renderBashBody(tool: ToolCallViewModel, width: number): string[] {
+	const details = asRecord(tool.details);
+	const target = toolTarget(tool);
+	const lines = outputLines(tool).slice(0, 5);
+	const body = [renderBodyLine([`> ${target}`], width)];
+	const collapsed = collapsedMarker(details, Math.max(0, outputLines(tool).length - lines.length));
+	if (collapsed) body.push(renderBodyLine([span(`  ${collapsed}`, { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width));
+	for (const line of lines) {
+		const color = line.trimStart().startsWith("✗") ? CATHEDRAL_TOKENS.colors.states.approval
+			: line.trimStart().startsWith("✓") ? CATHEDRAL_TOKENS.colors.states.idle
+			: CATHEDRAL_TOKENS.colors.foreground;
+		body.push(renderBodyLine([span(line, { fg: color })], width));
+	}
+	if (lines.length === 0 && tool.status === "running") body.push(renderBodyLine([span("watching stdout…", { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width));
+	return body;
+}
+
+function renderToolBody(tool: ToolCallViewModel, width: number): string[] {
+	if (tool.name === "edit") return renderEditBody(tool, width);
+	if (tool.name === "read" || tool.name === "write") return renderReadLikeBody(tool, width);
+	if (tool.name === "bash") return renderBashBody(tool, width);
+	return [renderBodyLine([span("preview collapsed", { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width)];
+}
+
+export function renderToolLedgerRows(tool: ToolCallViewModel, width: number): string[] {
+	const safeWidth = Math.max(1, Math.floor(width));
+	if (safeWidth < 20) return [padAnsi(renderCompactToolPill(tool), safeWidth)];
+	return [
+		renderHeader(tool, safeWidth),
+		...renderToolBody(tool, safeWidth),
+		renderBottom(safeWidth),
+	];
+}
+
+export function renderToolBlockRows(tool: ToolCallViewModel, width: number): string[] {
+	return tool.expanded ? renderToolLedgerRows(tool, width) : [renderCompactToolPill(tool)];
+}

--- a/src/sumo-tui/transcript/tool-renderer.ts
+++ b/src/sumo-tui/transcript/tool-renderer.ts
@@ -179,30 +179,55 @@ function renderReadLikeBody(tool: ToolCallViewModel, width: number): string[] {
 	return rows;
 }
 
+function renderEditSummary(text: string, width: number): string[] {
+	const additions = text.match(/\+(\d+)/)?.[0];
+	const removals = text.match(/-(\d+)/)?.[0];
+	const rest = text.replace(/\+\d+|-\d+/g, "").trim();
+	return [renderBodyLine([
+		...(additions ? [span(additions, { fg: CATHEDRAL_TOKENS.colors.states.idle }), span(" ")] : []),
+		...(removals ? [span(removals, { fg: CATHEDRAL_TOKENS.colors.states.approval }), span(" ")] : []),
+		span(rest || "diff collapsed", { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+	], width)];
+}
+
 function renderEditBody(tool: ToolCallViewModel, width: number): string[] {
 	const details = asRecord(tool.details);
-	const diff = arrayFromDetails(details, "diff").length > 0 ? arrayFromDetails(details, "diff") : outputLines(tool);
-	if (diff.length === 0) {
+	const diffLines = arrayFromDetails(details, "diff");
+
+	// No explicit diff array → render summary from output/note
+	if (diffLines.length === 0) {
 		const note = toolNote(tool) ?? "diff collapsed";
-		const additions = note.match(/\+(\d+)/)?.[0];
-		const removals = note.match(/-(\d+)/)?.[0];
-		const rest = note.replace(/\+\d+|-\d+/g, "").trim();
-		return [renderBodyLine([
-			...(additions ? [span(additions, { fg: CATHEDRAL_TOKENS.colors.states.idle }), span(" ")] : []),
-			...(removals ? [span(removals, { fg: CATHEDRAL_TOKENS.colors.states.approval }), span(" ")] : []),
-			span(rest || "diff collapsed", { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
-		], width)];
+		return renderEditSummary(note, width);
 	}
+
+	// Render actual diff lines with gutter
 	const startLine = typeof details?.startLine === "number" ? details.startLine : 1;
-	const rows = diff.slice(0, 6).map((line, index) => {
+	const rows = diffLines.slice(0, 6).map((line, index) => {
 		const color = line.trimStart().startsWith("+") ? CATHEDRAL_TOKENS.colors.states.idle
 			: line.trimStart().startsWith("-") ? CATHEDRAL_TOKENS.colors.states.approval
 			: CATHEDRAL_TOKENS.colors.foreground;
 		return renderGutterLine(startLine + index, line, width, color);
 	});
-	const collapsed = collapsedMarker(details, Math.max(0, diff.length - rows.length));
+	const collapsed = collapsedMarker(details, Math.max(0, diffLines.length - rows.length));
 	if (collapsed) rows.push(renderBodyLine([span("      ", { fg: CATHEDRAL_TOKENS.colors.foregroundDim }), span(collapsed, { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width));
 	return rows;
+}
+
+function renderBashLine(line: string): (Span | string)[] {
+	const trimmed = line.trimStart();
+	const indent = line.slice(0, line.length - trimmed.length);
+	// Lines starting with ✓ or ✗: color only the glyph, rest stays foreground
+	if (trimmed.startsWith("✓")) {
+		return [span(`${indent}✓`, { fg: CATHEDRAL_TOKENS.colors.states.idle }), span(trimmed.slice(1))];
+	}
+	if (trimmed.startsWith("✗")) {
+		return [span(`${indent}✗`, { fg: CATHEDRAL_TOKENS.colors.states.approval }), span(trimmed.slice(1))];
+	}
+	// Summary / result lines (no leading > or glyph): dim
+	if (!trimmed.startsWith(">")) {
+		return [span(line, { fg: CATHEDRAL_TOKENS.colors.foregroundDim })];
+	}
+	return [line];
 }
 
 function renderBashBody(tool: ToolCallViewModel, width: number): string[] {
@@ -213,10 +238,7 @@ function renderBashBody(tool: ToolCallViewModel, width: number): string[] {
 	const collapsed = collapsedMarker(details, Math.max(0, outputLines(tool).length - lines.length));
 	if (collapsed) body.push(renderBodyLine([span(`  ${collapsed}`, { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width));
 	for (const line of lines) {
-		const color = line.trimStart().startsWith("✗") ? CATHEDRAL_TOKENS.colors.states.approval
-			: line.trimStart().startsWith("✓") ? CATHEDRAL_TOKENS.colors.states.idle
-			: CATHEDRAL_TOKENS.colors.foreground;
-		body.push(renderBodyLine([span(line, { fg: color })], width));
+		body.push(renderBodyLine(renderBashLine(line), width));
 	}
 	if (lines.length === 0 && tool.status === "running") body.push(renderBodyLine([span("watching stdout…", { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width));
 	return body;

--- a/src/sumo-tui/transcript/view-model.ts
+++ b/src/sumo-tui/transcript/view-model.ts
@@ -1,3 +1,5 @@
+import { renderCompactToolPill } from "./tool-renderer.js";
+
 export type ChatMessageRole = "user" | "sumo" | "system";
 
 export type ToolStatus = "pending" | "running" | "success" | "error" | "cancelled";
@@ -11,6 +13,7 @@ export interface ToolCallViewModel {
 	readonly output?: string;
 	readonly details?: unknown;
 	readonly error?: string;
+	readonly expanded?: boolean;
 }
 
 export interface QuestionViewModel {
@@ -155,6 +158,7 @@ function toolBlockFromRecord(record: Record<string, unknown>, fallbackStatus: To
 	const output = textFromContent(record.content) || asString(record.output);
 	const error = asString(record.errorMessage) ?? asString(record.error);
 	const isError = record.isError === true || error !== undefined;
+	const expanded = asBoolean(record.expanded) ?? asBoolean(asRecord(record.details)?.expanded);
 	return {
 		type: "tool",
 		tool: {
@@ -165,6 +169,7 @@ function toolBlockFromRecord(record: Record<string, unknown>, fallbackStatus: To
 			output,
 			details: record.details,
 			error,
+			...(expanded === undefined ? {} : { expanded }),
 		},
 	};
 }
@@ -291,7 +296,7 @@ export function chatMessageViewModelToPlainText(message: ChatMessageViewModel): 
 				case "code":
 					return `\`\`\`${block.lang}\n${block.source}\n\`\`\``;
 				case "tool":
-					return [`[tool] ${block.tool.name} · ${block.tool.status}`, block.tool.output, block.tool.error].filter(Boolean).join("\n");
+					return renderCompactToolPill(block.tool);
 				case "skill":
 					return `[skill] ${block.name}${block.expanded ? " (expanded)" : " (⌘O to expand)"}`;
 				case "question":

--- a/src/sumo-tui/widgets/chat-message.ts
+++ b/src/sumo-tui/widgets/chat-message.ts
@@ -3,7 +3,7 @@ import { CATHEDRAL_TOKENS } from "../../tokens.js";
 import { SumoNode } from "../layout/node.js";
 import { MEASURE_MODE_EXACTLY, type MeasureMode, type Yoga, type YogaNode } from "../layout/yoga.js";
 import type { CellBuffer, Rect } from "../render/buffer.js";
-import { lineToAnsi, span, textLine, type Span } from "../render/primitives.js";
+import { lineToAnsi, span, textLine, withPersistentStyle, type Span } from "../render/primitives.js";
 import { renderToolBlockRows } from "../transcript/tool-renderer.js";
 import type { ChatBlock } from "../transcript/view-model.js";
 
@@ -98,7 +98,7 @@ function frameTop(role: ChatMessageRole, timestamp: Date | undefined, width: num
 	const leftParts: (Span | string)[] = [
 		span("╭ ", { fg: CATHEDRAL_TOKENS.colors.divider }),
 		span(label, { fg: roleColor(role) }),
-		span(" ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span(" ", { fg: CATHEDRAL_TOKENS.colors.foreground }),
 	];
 
 	const showTime = (role === "sumo" || role === "assistant") && timestamp !== undefined;
@@ -123,11 +123,10 @@ function frameTop(role: ChatMessageRole, timestamp: Date | undefined, width: num
 function frameBody(row: string, width: number): string {
 	const inner = Math.max(0, width - 4);
 	const text = fitCellText(row, inner);
+	const body = withPersistentStyle(` ${text} `, CATHEDRAL_TOKENS.colors.foreground, CATHEDRAL_TOKENS.colors.surfaceRecess);
 	return lineToAnsi(textLine([
 		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
-		" ",
-		span(text, { fg: CATHEDRAL_TOKENS.colors.foreground }),
-		" ",
+		span(body),
 		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
 	]), { width });
 }

--- a/src/sumo-tui/widgets/chat-message.ts
+++ b/src/sumo-tui/widgets/chat-message.ts
@@ -4,6 +4,8 @@ import { SumoNode } from "../layout/node.js";
 import { MEASURE_MODE_EXACTLY, type MeasureMode, type Yoga, type YogaNode } from "../layout/yoga.js";
 import type { CellBuffer, Rect } from "../render/buffer.js";
 import { lineToAnsi, span, textLine, type Span } from "../render/primitives.js";
+import { renderToolBlockRows } from "../transcript/tool-renderer.js";
+import type { ChatBlock } from "../transcript/view-model.js";
 
 export type ChatMessageRole = "user" | "sumo" | "system" | "tool" | string;
 
@@ -16,6 +18,7 @@ export interface ChatMessageSnapshot {
 	role: ChatMessageRole;
 	text: string;
 	timestamp: Date;
+	blocks?: readonly ChatBlock[];
 }
 
 const MIN_BOX_WIDTH = 8;
@@ -81,7 +84,7 @@ function textWidth(parts: readonly (Span | string)[]): number {
 
 function fitCellText(text: string, width: number): string {
 	const visible = visibleWidth(text);
-	return visible >= width ? takeVisible(text, width).head : `${text}${" ".repeat(width - visible)}`;
+	return visible > width ? takeVisible(text, width).head : `${text}${" ".repeat(width - visible)}`;
 }
 
 function formatTime(timestamp: Date): string {
@@ -137,37 +140,103 @@ function frameBottom(width: number): string {
 	]), { width });
 }
 
+function renderSkillRow(block: Extract<ChatBlock, { type: "skill" }>): string {
+	return `[skill] ${block.name}${block.expanded ? " (expanded)" : " (⌘O to expand)"}`;
+}
+
+function renderQuestionRows(block: Extract<ChatBlock, { type: "question" }>): string[] {
+	return [`[question] ${block.question.prompt}`, ...block.question.choices.map((choice) => `- ${choice}`)];
+}
+
+function renderDelegationRows(block: Extract<ChatBlock, { type: "delegation" }>): string[] {
+	return [`[delegation] ${block.delegation.title} · ${block.delegation.status}`, ...(block.delegation.summary ? [block.delegation.summary] : [])];
+}
+
+function renderCodeRows(block: Extract<ChatBlock, { type: "code" }>, width: number): string[] {
+	return wrapPlainText(`\`\`\`${block.lang}\n${block.source}\n\`\`\``, width);
+}
+
+function renderBlockRows(blocks: readonly ChatBlock[], width: number): string[] {
+	const rows: string[] = [];
+	for (const block of blocks) {
+		if (rows.length > 0) rows.push("");
+		switch (block.type) {
+			case "markdown":
+				rows.push(...wrapPlainText(block.text, width));
+				break;
+			case "code":
+				rows.push(...renderCodeRows(block, width));
+				break;
+			case "tool":
+				rows.push(...renderToolBlockRows(block.tool, width));
+				break;
+			case "skill":
+				rows.push(renderSkillRow(block));
+				break;
+			case "question":
+				rows.push(...renderQuestionRows(block));
+				break;
+			case "delegation":
+				rows.push(...renderDelegationRows(block));
+				break;
+		}
+	}
+	return rows.length === 0 ? [""] : rows;
+}
+
 /** One V2 framed chat message. Markdown block parsing lands in #89/#90. */
 export class ChatMessage extends SumoNode {
 	public readonly timestamp: Date;
 	private measuring = false;
 	private lastMeasure: ChatMessageMeasure = { width: 0, height: 1 };
 
-	public constructor(yogaNode: YogaNode, public role: ChatMessageRole, public text: string, parent?: SumoNode, timestamp = new Date()) {
+	public constructor(
+		yogaNode: YogaNode,
+		public role: ChatMessageRole,
+		public text: string,
+		parent?: SumoNode,
+		timestamp = new Date(),
+		private blocks?: readonly ChatBlock[],
+	) {
 		super(yogaNode, parent);
 		this.timestamp = timestamp;
 		this.marginBottom = 1;
 		this.setMeasureFunc((width, widthMode, height, heightMode) => this.measure(width, widthMode, height, heightMode));
 	}
 
-	public static create(yoga: Yoga, role: ChatMessageRole, text: string, parent?: SumoNode, timestamp?: Date): ChatMessage {
-		return new ChatMessage(yoga.Node.create(), role, text, parent, timestamp);
+	public static create(yoga: Yoga, role: ChatMessageRole, text: string, parent?: SumoNode, timestamp?: Date, blocks?: readonly ChatBlock[]): ChatMessage {
+		return new ChatMessage(yoga.Node.create(), role, text, parent, timestamp, blocks);
 	}
 
 	public setText(text: string): void {
-		if (this.text === text) return;
+		if (this.text === text && this.blocks === undefined) return;
+		this.text = text;
+		this.blocks = undefined;
+		this.markDirty();
+	}
+
+	public setBlocks(blocks: readonly ChatBlock[], text: string): void {
+		this.blocks = blocks;
 		this.text = text;
 		this.markDirty();
 	}
 
+	public setToolExpansion(expanded: boolean): boolean {
+		if (!this.blocks?.some((block) => block.type === "tool" && Boolean(block.tool.expanded) !== expanded)) return false;
+		this.blocks = this.blocks.map((block) => block.type === "tool" ? { ...block, tool: { ...block.tool, expanded } } : block);
+		this.markDirty();
+		return true;
+	}
+
 	public appendText(chunk: string): void {
 		if (chunk.length === 0) return;
+		this.blocks = undefined;
 		this.text += chunk;
 		this.markDirty();
 	}
 
 	public toSnapshot(): ChatMessageSnapshot {
-		return { role: this.role, text: this.text, timestamp: this.timestamp };
+		return { role: this.role, text: this.text, timestamp: this.timestamp, blocks: this.blocks };
 	}
 
 	public getEstimatedHeight(width = this.getComputedWidth()): number {
@@ -188,7 +257,7 @@ export class ChatMessage extends SumoNode {
 		if (renderWidth < MIN_BOX_WIDTH) return [fitCellText(this.text, renderWidth)];
 
 		const bodyWidth = Math.max(1, renderWidth - 4);
-		const bodyRows = wrapPlainText(this.text, bodyWidth);
+		const bodyRows = this.blocks ? renderBlockRows(this.blocks, bodyWidth) : wrapPlainText(this.text, bodyWidth);
 		return [
 			frameTop(this.role, this.timestamp, renderWidth),
 			...bodyRows.map((row) => frameBody(row, renderWidth)),

--- a/src/sumo-tui/widgets/chat-pager.test.ts
+++ b/src/sumo-tui/widgets/chat-pager.test.ts
@@ -101,6 +101,25 @@ describe("ChatPager", () => {
 		root.dispose();
 	});
 
+	it("renders structured tool blocks compact by default and expands them on demand", async () => {
+		const { root, chat, buffer } = await makeChat(90, 8);
+		chat.addViewModel({
+			id: "s1",
+			role: "sumo",
+			displayName: "SUMO",
+			blocks: [{ type: "tool", tool: { name: "read", status: "success", input: { path: "src/auth/session.ts" } } }],
+		});
+		let frame = buffer();
+		expect(frame.toPlainRow(1)).toContain("✓ [read]  src/auth/session.ts  · ⌘O expand");
+		expect(frame.toPlainRow(2)).toMatch(/^╰─+╯/);
+
+		chat.setToolExpansion(true);
+		frame = buffer();
+		expect(frame.toPlainRow(1)).toContain("╭─ [read]  src/auth/session.ts");
+		expect(frame.toPlainRow(2)).toContain("preview collapsed");
+		root.dispose();
+	});
+
 	it("accepts deterministic timestamps for fixture-backed visual states", async () => {
 		const { root, chat } = await makeChat();
 		const timestamp = new Date("2026-04-30T11:42:00Z");

--- a/src/sumo-tui/widgets/chat-pager.ts
+++ b/src/sumo-tui/widgets/chat-pager.ts
@@ -2,6 +2,7 @@ import { SumoNode } from "../layout/node.js";
 import { FLEX_DIRECTION_COLUMN, type Yoga, type YogaNode } from "../layout/yoga.js";
 import type { KeyEvent } from "../input/key-router.js";
 import type { MouseEvent } from "../input/mouse.js";
+import { chatMessageViewModelToPlainText, type ChatMessageViewModel } from "../transcript/view-model.js";
 import { ChatMessage, type ChatMessageRole } from "./chat-message.js";
 import { ScrolledUpBanner } from "./scrolled-up-banner.js";
 import { ScrollBox, type ScrollBoxStateChange } from "./scrollbox.js";
@@ -20,6 +21,12 @@ export interface ChatPagerOptions {
 const DEFAULT_MAX_RENDERED_MESSAGES = 200;
 
 function noop(): void {}
+
+function chatRoleFromViewModel(message: ChatMessageViewModel): ChatMessageRole {
+	const onlyToolBlocks = message.blocks.length > 0 && message.blocks.every((block) => block.type === "tool");
+	if (onlyToolBlocks) return "tool";
+	return message.role;
+}
 
 /** Stateful chat scrollback wrapper: messages + ScrollBox + unread banner. */
 export class ChatPager extends SumoNode {
@@ -59,16 +66,19 @@ export class ChatPager extends SumoNode {
 	}
 
 	public addMessage(role: ChatMessageRole, text: string, timestamp?: Date): ChatMessage {
-		const wasReadingHistory = this.isReadingHistory();
-		const message = ChatMessage.create(this.yoga, role, text, undefined, timestamp);
-		const addedLines = message.getEstimatedHeight(this.scrollBox.getComputedWidth());
-		this.activeMessages.push(message);
-		this.scrollBox.addChild(message);
-		const virtualized = this.virtualizeIfNeeded();
-		if (wasReadingHistory) this.unreadCount += 1;
-		this.scrollBox.notifyContentChanged(addedLines + virtualized.addedLines, virtualized.removedLines);
-		this.scheduleRender();
-		return message;
+		return this.addChatMessage(ChatMessage.create(this.yoga, role, text, undefined, timestamp));
+	}
+
+	public addViewModel(message: ChatMessageViewModel): ChatMessage {
+		const role = chatRoleFromViewModel(message);
+		return this.addChatMessage(ChatMessage.create(
+			this.yoga,
+			role,
+			chatMessageViewModelToPlainText(message),
+			undefined,
+			message.timestamp,
+			message.blocks,
+		));
 	}
 
 	public appendToLast(chunk: string): void {
@@ -94,10 +104,30 @@ export class ChatPager extends SumoNode {
 			return;
 		}
 		if (last.text === text) return;
+		this.updateLast(last, () => last.setText(text));
+	}
+
+	public replaceLastWithViewModel(message: ChatMessageViewModel): void {
+		const last = this.getLastMessage();
+		if (!last) {
+			this.addViewModel(message);
+			return;
+		}
+		last.role = chatRoleFromViewModel(message);
+		this.updateLast(last, () => last.setBlocks(message.blocks, chatMessageViewModelToPlainText(message)));
+	}
+
+	public setToolExpansion(expanded: boolean): void {
 		const width = this.scrollBox.getComputedWidth();
-		const beforeHeight = last.getEstimatedHeight(width);
-		last.setText(text);
-		const afterHeight = last.getEstimatedHeight(width);
+		let beforeHeight = 0;
+		let afterHeight = 0;
+		let changed = false;
+		for (const message of this.activeMessages) {
+			beforeHeight += message.getEstimatedHeight(width);
+			changed = message.setToolExpansion(expanded) || changed;
+			afterHeight += message.getEstimatedHeight(width);
+		}
+		if (!changed) return;
 		this.scrollBox.notifyContentChanged(Math.max(0, afterHeight - beforeHeight), Math.max(0, beforeHeight - afterHeight));
 		this.scheduleRender();
 	}
@@ -145,6 +175,27 @@ export class ChatPager extends SumoNode {
 
 	public handleMouseEvent(event: MouseEvent): boolean {
 		return this.scrollBox.handleMouseEvent(event);
+	}
+
+	private addChatMessage(message: ChatMessage): ChatMessage {
+		const wasReadingHistory = this.isReadingHistory();
+		const addedLines = message.getEstimatedHeight(this.scrollBox.getComputedWidth());
+		this.activeMessages.push(message);
+		this.scrollBox.addChild(message);
+		const virtualized = this.virtualizeIfNeeded();
+		if (wasReadingHistory) this.unreadCount += 1;
+		this.scrollBox.notifyContentChanged(addedLines + virtualized.addedLines, virtualized.removedLines);
+		this.scheduleRender();
+		return message;
+	}
+
+	private updateLast(message: ChatMessage, update: () => void): void {
+		const width = this.scrollBox.getComputedWidth();
+		const beforeHeight = message.getEstimatedHeight(width);
+		update();
+		const afterHeight = message.getEstimatedHeight(width);
+		this.scrollBox.notifyContentChanged(Math.max(0, afterHeight - beforeHeight), Math.max(0, beforeHeight - afterHeight));
+		this.scheduleRender();
 	}
 
 	private scheduleRender(): void {

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -6,7 +6,7 @@ export const CATHEDRAL_TOKENS = {
 		surfaceLifted: "#3D3024",
 		foreground: "#F5E6C8",
 		foregroundDim: "#8B7A63",
-		divider: "#3A2F25",
+		divider: "#5A4D3C",
 		accent: "#D97706",
 		states: {
 			idle: "#7FB069",

--- a/src/top-chrome.ts
+++ b/src/top-chrome.ts
@@ -81,8 +81,8 @@ const DOT_GLYPHS: Record<TopChromeDotSize, string> = {
 function activeSegment(active: TopChromeSnapshot["activeSession"], maxLabel: number, dotSize: TopChromeDotSize): string {
 	const label = ellipsize(active.label, maxLabel);
 	const dot = color(DOT_GLYPHS[dotSize], CATHEDRAL_TOKENS.colors.accent);
-	const wrap = (ch: string): string => color(ch, CATHEDRAL_TOKENS.colors.foregroundDim);
-	return `${wrap("║")} ${dot} ${label} ${wrap("║")}`;
+	const dim = (ch: string): string => color(ch, CATHEDRAL_TOKENS.colors.foregroundDim);
+	return `${dim("║" + " ")}${dot}${dim(" " + label + " " + "║")}`;
 }
 
 const ACTIVE_OVERHEAD = 6; // chars consumed by `║ ● ` + ` ║`
@@ -155,8 +155,9 @@ export function renderTopChrome(snapshot: TopChromeSnapshot, width: number): str
 		const maxActiveLabel = Math.max(1, innerWidth - brandLen - BRAND_ACTIVE_GAP - ACTIVE_OVERHEAD);
 		active = activeSegment(snapshot.activeSession, maxActiveLabel, dotSize);
 	}
+	const brandGap = color(" ".repeat(BRAND_ACTIVE_GAP), CATHEDRAL_TOKENS.colors.foregroundDim);
 	let consumed = brandLen + BRAND_ACTIVE_GAP + visibleLength(active);
-	let line = `${brand}${" ".repeat(BRAND_ACTIVE_GAP)}${active}`;
+	let line = `${brand}${brandGap}${active}`;
 	const compact = innerWidth < COMPACT_TOP_CHROME_WIDTH;
 
 	if (!compact) {


### PR DESCRIPTION
## Summary

Implements the first production slice of the V2 runtime tool renderer from #131.

### Changes
- Adds a typed `src/sumo-tui/transcript/tool-renderer.ts` shared by runtime rendering and fixture capture.
- Formats `ChatBlock.tool` via `chatMessageViewModelToPlainText()` as Cathedral compact pills:
  - `✓ [name]  target  · note  · ⌘O hint`
  - `▶` uses tool blue
  - `✗` uses approval red
- Adds expanded ledger rendering for tool blocks when `tool.expanded` is true:
  - read/write-style line gutter + collapsed marker
  - edit diff rows with addition/removal coloring
  - bash output rows with success/error coloring
- Routes runtime session replay/live agent events through structured transcript view models instead of ad-hoc `textFromAgentMessage()` flattening.
- Mirrors Pi's `setToolsExpanded()` into retained chat so Pi tool expansion toggles expand/collapse structured tool blocks.
- Removes the fixture lane's separate JS-only tool-pill formatter; fixture capture now uses the production ChatPager/ViewModel path.

## Notes

This does **not** promote any visual crop to required. `fixture-tool-ledger-landscape` still reports known surrounding scene drift in styled-cell-diff (divider exactness, chat body bg, topbar/session color), but geometry passes and the tool rows now come from the production renderer.

The remaining per-tool/nearest-tool `⌘O` interaction and exact `scene-active-tool-ledger` visual parity can continue on #131 if we want that issue to stay open until every checkbox is complete.

## Visual evidence

Generated review pack:

```txt
docs/visual/out/parity/index.html
```

Inspected:

```bash
cat docs/visual/out/parity/fixture-tool-ledger-landscape/raw/styled-cell-diff.txt
cat docs/visual/out/parity/fixture-tool-ledger-landscape/raw/styled-cell-diff-chat-area.txt
cat docs/visual/out/parity/fixture-tool-ledger-landscape/raw/geometry-audit.txt
```

Geometry result:

```txt
Geometry audit passed: 45 rows, no mismatches
```

## Verification

- `pnpm test`
- `pnpm test:integration`
- `pnpm visual:ci` — 11 scenarios, review-only diffs remain review-only
- `pnpm exec tsc --noEmit`
- `pnpm build`

Refs #131
