### PR TITLE
[codex] Add mouse selection and OSC 52 copy

### DIFF
--- a/src/sumo-tui/input/key-router.ts
+++ b/src/sumo-tui/input/key-router.ts
@@ -4,6 +4,8 @@ export interface KeyEvent {
 	ctrl?: boolean;
 	alt?: boolean;
 	shift?: boolean;
+	meta?: boolean;
+	cmd?: boolean;
 }
 
 export type KeyHandler = (event: KeyEvent) => boolean | void;

--- a/src/sumo-tui/input/selection.ts
+++ b/src/sumo-tui/input/selection.ts
@@ -1,0 +1,241 @@
+import { visibleWidth } from "@mariozechner/pi-tui";
+import type { CellBuffer } from "../render/buffer.js";
+import type { KeyEvent } from "./key-router.js";
+import type { MouseEvent } from "./mouse.js";
+
+export interface SelectionPoint {
+	readonly row: number;
+	readonly col: number;
+}
+
+export interface SelectionRange {
+	readonly anchor: SelectionPoint;
+	readonly focus: SelectionPoint;
+	readonly dragging: boolean;
+}
+
+export interface SelectionControllerOptions {
+	readonly readBuffer?: () => CellBuffer | undefined;
+	readonly emitClipboard?: (sequence: string, text: string) => void;
+	readonly onSelectionChanged?: () => void;
+}
+
+interface OrderedRange {
+	readonly start: SelectionPoint;
+	readonly end: SelectionPoint;
+}
+
+const PRIMARY_BUTTON = 0;
+const OSC52_PREFIX = "\x1b]52;c;";
+const OSC52_SUFFIX = "\x1b\\";
+
+function orderedRange(anchor: SelectionPoint, focus: SelectionPoint): OrderedRange {
+	if (anchor.row < focus.row) return { start: anchor, end: focus };
+	if (anchor.row > focus.row) return { start: focus, end: anchor };
+	return anchor.col <= focus.col ? { start: anchor, end: focus } : { start: focus, end: anchor };
+}
+
+function samePoint(left: SelectionPoint, right: SelectionPoint): boolean {
+	return left.row === right.row && left.col === right.col;
+}
+
+function normalizePoint(point: SelectionPoint, buffer: CellBuffer | undefined): SelectionPoint {
+	const row = Math.max(0, Math.floor(point.row));
+	const col = Math.max(0, Math.floor(point.col));
+	if (!buffer) return { row, col };
+	const dimensions = buffer.getDimensions();
+	return {
+		row: Math.max(0, Math.min(dimensions.rows - 1, row)),
+		col: Math.max(0, Math.min(dimensions.cols - 1, col)),
+	};
+}
+
+function columnsForRow(range: OrderedRange, row: number, cols: number): { startCol: number; endCol: number } | undefined {
+	if (cols <= 0 || row < range.start.row || row > range.end.row) return undefined;
+	if (range.start.row === range.end.row) {
+		return {
+			startCol: Math.max(0, Math.min(cols - 1, range.start.col)),
+			endCol: Math.max(0, Math.min(cols - 1, range.end.col)),
+		};
+	}
+	if (row === range.start.row) return { startCol: Math.max(0, Math.min(cols - 1, range.start.col)), endCol: cols - 1 };
+	if (row === range.end.row) return { startCol: 0, endCol: Math.max(0, Math.min(cols - 1, range.end.col)) };
+	return { startCol: 0, endCol: cols - 1 };
+}
+
+function intersects(leftStart: number, leftEnd: number, rightStart: number, rightEnd: number): boolean {
+	return leftStart <= rightEnd && rightStart <= leftEnd;
+}
+
+function glyphWidth(glyph: string): number {
+	return Math.max(1, visibleWidth(glyph));
+}
+
+function isCopyKey(event: KeyEvent): boolean {
+	const key = event.key.toLowerCase();
+	if (key === "copy" || key === "cmd+c" || key === "command+c" || key === "meta+c") return true;
+	return (event.meta === true || event.cmd === true) && key === "c";
+}
+
+export function createOsc52Sequence(text: string): string {
+	return `${OSC52_PREFIX}${Buffer.from(text, "utf8").toString("base64")}${OSC52_SUFFIX}`;
+}
+
+export class SelectionController {
+	private anchor: SelectionPoint | undefined;
+	private focus: SelectionPoint | undefined;
+	private dragging = false;
+	private revision = 0;
+
+	public constructor(private readonly options: SelectionControllerOptions = {}) {}
+
+	public getRevision(): number {
+		return this.revision;
+	}
+
+	public getRange(): SelectionRange | undefined {
+		if (!this.anchor || !this.focus) return undefined;
+		return { anchor: { ...this.anchor }, focus: { ...this.focus }, dragging: this.dragging };
+	}
+
+	public hasSelection(): boolean {
+		return this.anchor !== undefined && this.focus !== undefined && !samePoint(this.anchor, this.focus);
+	}
+
+	public clear(): boolean {
+		if (!this.anchor && !this.focus && !this.dragging) return false;
+		this.anchor = undefined;
+		this.focus = undefined;
+		this.dragging = false;
+		this.notifyChanged();
+		return true;
+	}
+
+	public handleKey(event: KeyEvent, buffer = this.options.readBuffer?.()): boolean {
+		const key = event.key.toLowerCase();
+		if (key === "escape" || key === "esc") return this.clear();
+		if (!isCopyKey(event)) return false;
+		return this.copyCurrentSelection(buffer);
+	}
+
+	public handleMouseEvent(event: MouseEvent, buffer = this.options.readBuffer?.()): boolean {
+		if (event.type === "scroll" || event.type === "move") return false;
+		if (event.button !== undefined && event.button !== PRIMARY_BUTTON) return false;
+
+		const point = normalizePoint({ row: event.row, col: event.col }, buffer);
+		if (event.type === "down") {
+			if (this.hasSelection() && !this.pointIsSelected(point, buffer)) this.clear();
+			this.anchor = point;
+			this.focus = point;
+			this.dragging = true;
+			this.notifyChanged();
+			return true;
+		}
+
+		if (!this.dragging || !this.anchor) return false;
+
+		if (event.type === "drag") {
+			this.focus = point;
+			this.notifyChanged();
+			return true;
+		}
+
+		this.focus = point;
+		this.dragging = false;
+		const selected = this.hasSelection();
+		if (!selected) {
+			this.clear();
+			return true;
+		}
+		this.notifyChanged();
+		this.copyCurrentSelection(buffer);
+		return true;
+	}
+
+	public copyCurrentSelection(buffer = this.options.readBuffer?.()): boolean {
+		const text = this.extractSelectedText(buffer);
+		if (text.length === 0) return false;
+		this.options.emitClipboard?.(createOsc52Sequence(text), text);
+		return true;
+	}
+
+	public extractSelectedText(buffer = this.options.readBuffer?.()): string {
+		if (!buffer || !this.anchor || !this.focus || samePoint(this.anchor, this.focus)) return "";
+		const dimensions = buffer.getDimensions();
+		const range = orderedRange(
+			normalizePoint(this.anchor, buffer),
+			normalizePoint(this.focus, buffer),
+		);
+		const lines: string[] = [];
+		for (let row = range.start.row; row <= range.end.row && row < dimensions.rows; row += 1) {
+			const columns = columnsForRow(range, row, dimensions.cols);
+			if (!columns) continue;
+			lines.push(this.extractRowText(buffer, row, columns.startCol, columns.endCol).trimEnd());
+		}
+		return lines.join("\n");
+	}
+
+	public applySelectionHighlight(buffer: CellBuffer): void {
+		if (!this.anchor || !this.focus || samePoint(this.anchor, this.focus)) return;
+		const dimensions = buffer.getDimensions();
+		const range = orderedRange(
+			normalizePoint(this.anchor, buffer),
+			normalizePoint(this.focus, buffer),
+		);
+		for (let row = range.start.row; row <= range.end.row && row < dimensions.rows; row += 1) {
+			const columns = columnsForRow(range, row, dimensions.cols);
+			if (!columns) continue;
+			this.applyRowHighlight(buffer, row, columns.startCol, columns.endCol);
+		}
+	}
+
+	private extractRowText(buffer: CellBuffer, row: number, startCol: number, endCol: number): string {
+		const { cols } = buffer.getDimensions();
+		let output = "";
+		for (let col = 0; col < cols;) {
+			const cell = buffer.getCell(row, col);
+			if (cell.char.length === 0) {
+				col += 1;
+				continue;
+			}
+			const width = glyphWidth(cell.char);
+			const glyphEnd = col + width - 1;
+			if (intersects(col, glyphEnd, startCol, endCol)) output += cell.char;
+			col += width;
+		}
+		return output;
+	}
+
+	private applyRowHighlight(buffer: CellBuffer, row: number, startCol: number, endCol: number): void {
+		const { cols } = buffer.getDimensions();
+		for (let col = 0; col < cols;) {
+			const cell = buffer.getCell(row, col);
+			if (cell.char.length === 0) {
+				col += 1;
+				continue;
+			}
+			const width = glyphWidth(cell.char);
+			const glyphEnd = col + width - 1;
+			if (intersects(col, glyphEnd, startCol, endCol)) {
+				for (let offset = 0; offset < width && col + offset < cols; offset += 1) {
+					buffer.updateCellAttrs(row, col + offset, (attrs) => ({ ...attrs, inverse: true }));
+				}
+			}
+			col += width;
+		}
+	}
+
+	private pointIsSelected(point: SelectionPoint, buffer: CellBuffer | undefined): boolean {
+		if (!this.anchor || !this.focus || samePoint(this.anchor, this.focus)) return false;
+		const dimensions = buffer?.getDimensions();
+		const cols = dimensions?.cols ?? Math.max(this.anchor.col, this.focus.col, point.col) + 1;
+		const range = orderedRange(this.anchor, this.focus);
+		const columns = columnsForRow(range, point.row, cols);
+		return columns !== undefined && point.col >= columns.startCol && point.col <= columns.endCol;
+	}
+
+	private notifyChanged(): void {
+		this.revision += 1;
+		this.options.onSelectionChanged?.();
+	}
+}

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -1,4 +1,5 @@
 import { parseSgrMouseStream, type MouseEvent } from "../input/mouse.js";
+import type { KeyEvent } from "../input/key-router.js";
 import { logDiagnostic } from "../runtime/diagnostics.js";
 import { ChatPager } from "../widgets/chat-pager.js";
 import { chatScrollCommandFromInput } from "../widgets/chat-scroll-command.js";
@@ -41,6 +42,8 @@ export interface ChatViewportRuntime {
 	requestRender(): void;
 	setEmptyChatQuoteState(state: { active: boolean; userMessageCount: number }): void;
 	noteUserMessage(): void;
+	handleSelectionMouse?(event: MouseEvent, width: number, height: number): boolean;
+	handleSelectionKey?(event: KeyEvent, width: number, height: number): boolean;
 }
 
 interface ChatViewportBridgeRuntime extends ChatViewportRuntime {
@@ -266,6 +269,12 @@ export class ChatViewportController {
 			return { consume: true };
 		}
 
+		const selectionKey = selectionCopyKeyFromInput(nextData);
+		if (selectionKey && this.runtime.handleSelectionKey?.(selectionKey, this.lastChatWidth, this.lastChatHeight) === true) {
+			this.renderChatViewportOrRequest();
+			return { consume: true };
+		}
+
 		if (nextData.length === 0 && consumed) return { consume: true };
 		if (nextData !== data) return { data: nextData };
 		return undefined;
@@ -348,8 +357,9 @@ export class ChatViewportController {
 		};
 		if (localEvent.row < 0 || localEvent.row >= this.lastChatHeight || localEvent.col < 0 || localEvent.col >= this.lastChatWidth) return false;
 		const handled = this.chat.handleMouseEvent(localEvent);
-		if (handled) this.renderChatViewportOrRequest();
-		return handled;
+		const handledSelection = this.runtime.handleSelectionMouse?.(localEvent, this.lastChatWidth, this.lastChatHeight) === true;
+		if (handled || handledSelection) this.renderChatViewportOrRequest();
+		return handled || handledSelection;
 	}
 
 	private renderChatViewportOrRequest(): void {
@@ -383,6 +393,13 @@ export class ChatViewportController {
 			renderableLineCount(this.host.footer, terminalWidth);
 		return Math.max(1, terminalRows - chromeRows);
 	}
+}
+
+function selectionCopyKeyFromInput(data: string): KeyEvent | undefined {
+	if (data.length === 0) return undefined;
+	const lower = data.toLowerCase();
+	if (lower === "cmd+c" || lower === "command+c" || lower === "meta+c") return { key: "c", sequence: data, meta: true };
+	return undefined;
 }
 
 export function installChatViewportBridge(upstream: unknown, runtime: ChatViewportBridgeRuntime): (() => void) | undefined {

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
@@ -111,7 +111,7 @@ describe("sumo interactive Pi noise filtering", () => {
 
 		const written = write.mock.calls.map(([chunk]) => String(chunk)).join("");
 		expect(written.match(/\x1b\[\?1049h/g) ?? []).toHaveLength(1);
-		expect(written.match(/\x1b\[\?1000h\x1b\[\?1006h/g) ?? []).toHaveLength(1);
+		expect(written.match(/\x1b\[\?1000h\x1b\[\?1002h\x1b\[\?1006h/g) ?? []).toHaveLength(1);
 		runtime.stop();
 	});
 

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -37,6 +37,9 @@ import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga, type Yoga } from "../la
 import { bufferToAnsiLines } from "../render/ansi-writer.js";
 import { CellBuffer } from "../render/buffer.js";
 import { composite } from "../render/compositor.js";
+import type { KeyEvent } from "../input/key-router.js";
+import type { MouseEvent } from "../input/mouse.js";
+import { SelectionController } from "../input/selection.js";
 import { diffFrames } from "../render/diff.js";
 import { FrameScheduler } from "../runtime/frame-scheduler.js";
 import { defaultTerminalSessionOwner, TerminalSessionOwner, type TerminalOutput } from "../runtime/terminal-controller.js";
@@ -114,6 +117,7 @@ export class SumoInteractiveRuntime {
 	private emptyChatQuote: EmptyChatQuoteNode | undefined;
 	private shellTransition: RetainedShellTransition | undefined;
 	private scheduler: FrameScheduler | undefined;
+	private readonly selection: SelectionController;
 	private previousFrame: CellBuffer | undefined;
 	private resizeHandler: (() => void) | undefined;
 	private externalRenderControls: { scheduleRender(): void; setStreamingMode(enabled: boolean): void } | undefined;
@@ -121,7 +125,7 @@ export class SumoInteractiveRuntime {
 	private renderedVersion = -1;
 	private renderedWidth = 0;
 	private renderedHeight = 0;
-	private chatFrameCache: { width: number; height: number; version: number; lines: string[] } | undefined;
+	private chatFrameCache: { width: number; height: number; version: number; selectionRevision: number; frame: CellBuffer; lines: string[] } | undefined;
 	private activeEmptyChat = false;
 	private emptyChatUserMessageCount = 0;
 	private started = false;
@@ -129,6 +133,12 @@ export class SumoInteractiveRuntime {
 	public constructor(output: TerminalLike = process.stdout, terminalSession?: TerminalSessionOwner) {
 		this.output = output;
 		this.terminal = terminalSession ?? (output === process.stdout ? defaultTerminalSessionOwner : new TerminalSessionOwner({ output }));
+		this.selection = new SelectionController({
+			emitClipboard: (sequence) => {
+				this.terminal.writeClipboardSequence(sequence);
+			},
+			onSelectionChanged: () => this.requestRender(),
+		});
 	}
 
 	public async start(): Promise<SumoInteractiveRuntimeSnapshot> {
@@ -177,12 +187,30 @@ export class SumoInteractiveRuntime {
 	}
 
 	public renderChatLines(width: number, height: number): string[] {
-		if (!this.root) return [];
+		return [...this.renderChatFrame(width, height).lines];
+	}
+
+	public handleSelectionMouse(event: MouseEvent, width: number, height: number): boolean {
+		const frame = this.renderChatFrame(width, height).frame;
+		return this.selection.handleMouseEvent(event, frame);
+	}
+
+	public handleSelectionKey(event: KeyEvent, width: number, height: number): boolean {
+		const frame = this.renderChatFrame(width, height).frame;
+		return this.selection.handleKey(event, frame);
+	}
+
+	private renderChatFrame(width: number, height: number): { frame: CellBuffer; lines: string[] } {
 		const safeWidth = Math.max(1, Math.floor(width));
 		const safeHeight = Math.max(1, Math.floor(height));
+		if (!this.root) {
+			const empty = new CellBuffer(safeHeight, safeWidth);
+			return { frame: empty, lines: bufferToAnsiLines(empty) };
+		}
+		const selectionRevision = this.selection.getRevision();
 		const cached = this.chatFrameCache;
-		if (cached && cached.width === safeWidth && cached.height === safeHeight && cached.version === this.frameVersion) {
-			return [...cached.lines];
+		if (cached && cached.width === safeWidth && cached.height === safeHeight && cached.version === this.frameVersion && cached.selectionRevision === selectionRevision) {
+			return { frame: cached.frame.clone(), lines: [...cached.lines] };
 		}
 
 		this.syncChatSlot();
@@ -190,10 +218,10 @@ export class SumoInteractiveRuntime {
 		this.root.height = safeHeight;
 		this.root.yogaNode.calculateLayout(safeWidth, safeHeight, DIRECTION_LTR);
 		const frame = new CellBuffer(safeHeight, safeWidth);
-		composite(this.root, frame);
+		composite(this.root, frame, { selection: this.selection });
 		const lines = bufferToAnsiLines(frame);
-		this.chatFrameCache = { width: safeWidth, height: safeHeight, version: this.frameVersion, lines };
-		return [...lines];
+		this.chatFrameCache = { width: safeWidth, height: safeHeight, version: this.frameVersion, selectionRevision, frame: frame.clone(), lines };
+		return { frame: frame.clone(), lines: [...lines] };
 	}
 
 	public writeChatViewport(top: number, left: number, width: number, height: number): boolean {
@@ -293,7 +321,7 @@ export class SumoInteractiveRuntime {
 		this.root.height = height;
 		this.root.yogaNode.calculateLayout(width, height, DIRECTION_LTR);
 		const nextFrame = new CellBuffer(height, width);
-		const result = composite(this.root, nextFrame);
+		const result = composite(this.root, nextFrame, { selection: this.selection });
 		const patches = diffFrames(this.previousFrame, nextFrame);
 		this.terminal.writeFramePatches(patches, result.hardwareCursor);
 		this.previousFrame = nextFrame.clone();

--- a/src/sumo-tui/render/buffer.ts
+++ b/src/sumo-tui/render/buffer.ts
@@ -192,6 +192,15 @@ export class CellBuffer {
 		};
 	}
 
+	public updateCellAttrs(row: number, col: number, update: (attrs: Cell["attrs"]) => Cell["attrs"]): void {
+		if (!this.inBounds(row, col)) return;
+		const index = this.index(row, col);
+		const next = update(maskToAttrs(this.attrs.get(index) ?? 0));
+		const mask = attrsToMask(next);
+		if (mask === 0) this.attrs.delete(index);
+		else this.attrs.set(index, mask);
+	}
+
 	public clear(rect?: Rect): void {
 		const area = rect ? clampRect(rect, this.rows, this.cols) : { top: 0, left: 0, width: this.cols, height: this.rows };
 		for (let row = area.top; row < area.top + area.height; row += 1) {

--- a/src/sumo-tui/render/compositor.ts
+++ b/src/sumo-tui/render/compositor.ts
@@ -13,6 +13,14 @@ export interface CompositeResult {
 	hardwareCursor: HardwareCursor | null;
 }
 
+export interface CompositeSelectionPass {
+	applySelectionHighlight(buffer: CellBuffer): void;
+}
+
+export interface CompositeOptions {
+	selection?: CompositeSelectionPass;
+}
+
 interface RenderableNode extends SumoNode {
 	render?: (buffer: CellBuffer, rect: Rect) => void;
 	getHardwareCursor?: () => HardwareCursor | null;
@@ -74,7 +82,7 @@ function orderedChildren(node: SumoNode): PositionedChild[] {
  * Yoga walk (`docs/spike-research/opentui-island/src/adapters/ink/index.tsx:106-123`),
  * while the retained frame shape follows the OpenTUI host-frame model.
  */
-export function composite(root: SumoNode, buffer: CellBuffer): CompositeResult {
+export function composite(root: SumoNode, buffer: CellBuffer, options: CompositeOptions = {}): CompositeResult {
 	buffer.setDefaultBackground(CATHEDRAL_TOKENS.colors.background);
 	buffer.setDefaultForeground(CATHEDRAL_TOKENS.colors.foreground);
 	buffer.clear();
@@ -102,6 +110,7 @@ export function composite(root: SumoNode, buffer: CellBuffer): CompositeResult {
 	}
 
 	visit(root, 0, 0);
+	options.selection?.applySelectionHighlight(buffer);
 	return { hardwareCursor };
 }
 

--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -3,6 +3,7 @@ import {
 	ALTSCREEN_ENTER_SEQUENCE,
 	CURSOR_COLOR_RESET,
 	CURSOR_COLOR_SET,
+	MOUSE_SGR_DISABLE_SEQUENCE,
 	MOUSE_SGR_ENABLE_SEQUENCE,
 	TERMINAL_BG_RESET,
 	TERMINAL_BG_SET,
@@ -94,7 +95,7 @@ describe("TerminalSessionOwner", () => {
 		terminal.enableMouseSGR();
 
 		expect(output.writes).toEqual([MOUSE_SGR_ENABLE_SEQUENCE]);
-		expect(output.writes[0]).toBe("\x1b[?1000h\x1b[?1006h");
+		expect(output.writes[0]).toBe("\x1b[?1000h\x1b[?1002h\x1b[?1006h");
 	});
 
 	it("writes absolute chat viewport rows behind the terminal ownership seam", () => {
@@ -122,7 +123,7 @@ describe("TerminalSessionOwner", () => {
 		terminal.exitTerminal();
 
 		expect(output.writes).toEqual([TERMINAL_CLEANUP_SEQUENCE]);
-		expect(output.writes[0]).toBe("\x1b[<u\x1b[>4;0m\x1b[?2004l\x1b[?1003l\x1b[?1006l\x1b[?1000l\x1b[?1049l\x1b[?25h\x1b[0m");
+		expect(output.writes[0]).toBe(`\x1b[<u\x1b[>4;0m\x1b[?2004l${MOUSE_SGR_DISABLE_SEQUENCE}\x1b[?1049l\x1b[?25h\x1b[0m`);
 		expect(output.writes[0]).not.toContain("\x1b]12;");
 		expect(output.writes[0]).not.toContain(CURSOR_COLOR_RESET);
 		expect(terminal.restored).toBe(true);

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -21,18 +21,19 @@ export const CURSOR_COLOR_RESET = "\x1b]112\x1b\\";
 export const TERMINAL_BG_SET = "\x1b]11;#1A1511\x1b\\";
 export const TERMINAL_BG_RESET = "\x1b]111\x1b\\";
 /**
- * Enable click/wheel mouse reporting in SGR format without xterm any-event
+ * Enable click/wheel/drag mouse reporting in SGR format without xterm any-event
  * motion tracking. `?1003h` makes Mac trackpads feel "captured" because mere
  * finger hover/movement is turned into app mouse events even when the editor
- * does not support pointer placement. `?1000h` + `?1006h` preserves wheel
- * scroll for chat/history while leaving trackpad cursoring usable.
+ * does not support pointer placement. `?1000h` + `?1002h` + `?1006h` preserves
+ * wheel scroll and button-drag selection while leaving trackpad cursoring usable.
  */
-export const MOUSE_SGR_ENABLE_SEQUENCE = "\x1b[?1000h\x1b[?1006h";
+export const MOUSE_SGR_ENABLE_SEQUENCE = "\x1b[?1000h\x1b[?1002h\x1b[?1006h";
+export const MOUSE_SGR_DISABLE_SEQUENCE = "\x1b[?1003l\x1b[?1002l\x1b[?1006l\x1b[?1000l";
 export const TERMINAL_CLEANUP_SEQUENCE =
 	"\x1b[<u" + // kitty keyboard pop
 	"\x1b[>4;0m" + // xterm modifyOtherKeys off
 	"\x1b[?2004l" + // bracketed paste off
-	"\x1b[?1003l\x1b[?1006l\x1b[?1000l" + // mouse off
+	MOUSE_SGR_DISABLE_SEQUENCE + // mouse off
 	"\x1b[?1049l" + // altscreen off
 	"\x1b[?25h\x1b[0m"; // cursor visible + SGR reset
 
@@ -169,6 +170,12 @@ export class TerminalSessionOwner {
 		}
 		output += "\x1b8\x1b[?2026l";
 		this.write(output);
+		return true;
+	}
+
+	public writeClipboardSequence(sequence: string): boolean {
+		if (!this.isTTY() || sequence.length === 0) return false;
+		this.write(sequence);
 		return true;
 	}
 

--- a/src/sumo-tui/testing/test-backend.test.ts
+++ b/src/sumo-tui/testing/test-backend.test.ts
@@ -2,6 +2,8 @@ import type { CustomEditor } from "@mariozechner/pi-coding-agent";
 import { CURSOR_MARKER } from "@mariozechner/pi-tui";
 import { afterEach, describe, expect, it } from "vitest";
 import { SumoNode } from "../layout/node.js";
+import type { YogaNode } from "../layout/yoga.js";
+import { CellBuffer, type Rect } from "../render/buffer.js";
 import { PiEditorLeaf } from "../widgets/pi-editor-leaf.js";
 import { SumoTuiTestBackend } from "./test-backend.js";
 
@@ -23,6 +25,16 @@ class CursorEditor {
 	public render(width: number): string[] {
 		const row = `> ${this.text}${CURSOR_MARKER}`;
 		return [row.padEnd(Math.max(0, width), " ")];
+	}
+}
+
+class TextRowNode extends SumoNode {
+	public constructor(yogaNode: YogaNode, parent: SumoNode, private readonly text: string) {
+		super(yogaNode, parent);
+	}
+
+	public render(buffer: CellBuffer, rect: Rect): void {
+		buffer.paintRow(rect.top, this.text, rect.left, rect.width);
 	}
 }
 
@@ -100,5 +112,57 @@ describe("SumoTuiTestBackend", () => {
 		}
 
 		expect(frame.current.toPlainRow(0).trimEnd()).toBe("> ZQXJW");
+	});
+
+	it("selects text through Pilot mouse events, highlights it, and emits OSC 52 on mouse-up", async () => {
+		const backend = await createBackend({ cols: 12, rows: 2 });
+		const node = new TextRowNode(backend.yoga.Node.create(), backend.root, "hello world");
+		node.width = "100%";
+		node.height = 1;
+		backend.render();
+
+		expect(backend.pilot.mouse({ type: "down", button: 0, row: 0, col: 0 })).toBe(true);
+		expect(backend.pilot.mouse({ type: "drag", button: 0, row: 0, col: 4 })).toBe(true);
+		let frame = backend.pilot.mouse({ type: "up", button: 0, row: 0, col: 4 });
+
+		expect(frame).toBe(true);
+		expect(backend.clipboardWrites.at(-1)).toEqual({
+			text: "hello",
+			sequence: "\x1b]52;c;aGVsbG8=\x1b\\",
+		});
+		expect(backend.current?.getCell(0, 0).attrs.inverse).toBe(true);
+		expect(backend.current?.getCell(0, 4).attrs.inverse).toBe(true);
+		expect(backend.current?.getCell(0, 5).attrs.inverse).toBe(false);
+
+		backend.clipboardWrites.length = 0;
+		expect(backend.pilot.key({ key: "c", meta: true })).toBe(true);
+		expect(backend.clipboardWrites.at(-1)?.text).toBe("hello");
+
+		expect(backend.pilot.key("Escape")).toBe(true);
+		expect(backend.current?.getCell(0, 0).attrs.inverse).toBe(false);
+	});
+
+	it("clears selection on outside click and keeps wide glyphs intact", async () => {
+		const backend = await createBackend({ cols: 8, rows: 2 });
+		const node = new TextRowNode(backend.yoga.Node.create(), backend.root, "a界b");
+		node.width = "100%";
+		node.height = 1;
+		backend.render();
+
+		backend.pilot.mouse({ type: "down", button: 0, row: 0, col: 2 });
+		backend.pilot.mouse({ type: "drag", button: 0, row: 0, col: 3 });
+		backend.pilot.mouse({ type: "up", button: 0, row: 0, col: 3 });
+
+		expect(backend.clipboardWrites.at(-1)?.text).toBe("界b");
+		expect(backend.current?.getCell(0, 1).attrs.inverse).toBe(true);
+		expect(backend.current?.getCell(0, 2).attrs.inverse).toBe(true);
+
+		backend.clipboardWrites.length = 0;
+		backend.pilot.mouse({ type: "down", button: 0, row: 1, col: 0 });
+		backend.pilot.mouse({ type: "up", button: 0, row: 1, col: 0 });
+
+		expect(backend.clipboardWrites).toEqual([]);
+		expect(backend.current?.getCell(0, 1).attrs.inverse).toBe(false);
+		expect(backend.current?.getCell(0, 2).attrs.inverse).toBe(false);
 	});
 });

--- a/src/sumo-tui/testing/test-backend.ts
+++ b/src/sumo-tui/testing/test-backend.ts
@@ -4,6 +4,7 @@ import { CellBuffer } from "../render/buffer.js";
 import type { KeyEvent, KeyTarget } from "../input/key-router.js";
 import { KeyRouter } from "../input/key-router.js";
 import type { MouseEvent } from "../input/mouse.js";
+import { SelectionController } from "../input/selection.js";
 import { SumoNode } from "../layout/node.js";
 import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga, type Yoga } from "../layout/yoga.js";
 
@@ -40,7 +41,9 @@ export class SumoTuiTestBackend {
 	public readonly yoga: Yoga;
 	public readonly root: SumoNode;
 	public readonly keyRouter = new KeyRouter();
+	public readonly selection: SelectionController;
 	public readonly pilot: SumoTuiPilot;
+	public readonly clipboardWrites: { sequence: string; text: string }[] = [];
 	private cols: number;
 	private rows: number;
 	private currentBuffer: CellBuffer | undefined;
@@ -54,6 +57,16 @@ export class SumoTuiTestBackend {
 		this.rows = options.rows;
 		this.root = new SumoNode(yoga.Node.create());
 		this.root.flexDirection = FLEX_DIRECTION_COLUMN;
+		this.selection = new SelectionController({
+			readBuffer: () => this.currentBuffer?.clone(),
+			emitClipboard: (sequence, text) => this.clipboardWrites.push({ sequence, text }),
+		});
+		this.keyRouter.bind("Escape", (event) => this.selection.handleKey(event));
+		this.keyRouter.bind("Esc", (event) => this.selection.handleKey(event));
+		this.keyRouter.bind("c", (event) => this.selection.handleKey(event));
+		this.keyRouter.bind("Cmd+C", (event) => this.selection.handleKey(event));
+		this.keyRouter.bind("Meta+C", (event) => this.selection.handleKey(event));
+		this.keyRouter.bind("Copy", (event) => this.selection.handleKey(event));
 		this.pilot = new SumoTuiPilot(this);
 	}
 
@@ -93,7 +106,7 @@ export class SumoTuiTestBackend {
 
 		const previous = this.currentBuffer?.clone();
 		const current = new CellBuffer(this.rows, this.cols);
-		const result = composite(this.root, current);
+		const result = composite(this.root, current, { selection: this.selection });
 
 		this.previousBuffer = previous;
 		this.currentBuffer = current.clone();
@@ -115,7 +128,9 @@ export class SumoTuiTestBackend {
 
 	public sendMouse(event: MouseEvent): boolean {
 		this.assertNotDisposed();
-		return dispatchMouseEvent(this.root, event);
+		const handledByTree = dispatchMouseEvent(this.root, event);
+		const handledBySelection = handledByTree ? false : this.selection.handleMouseEvent(event, this.currentBuffer);
+		return handledByTree || handledBySelection;
 	}
 
 	public resize(cols: number, rows: number): void {

--- a/test/integration/spawn-pi-pty.ts
+++ b/test/integration/spawn-pi-pty.ts
@@ -2,7 +2,7 @@ import { chmodSync, existsSync } from "node:fs";
 import { createRequire } from "node:module";
 import { dirname, join, resolve } from "node:path";
 import { spawn, type IPty } from "node-pty";
-import { ALTSCREEN_ENTER_SEQUENCE, MOUSE_SGR_ENABLE_SEQUENCE, TERMINAL_CLEANUP_SEQUENCE } from "../../src/sumo-tui/runtime/terminal-controller.js";
+import { ALTSCREEN_ENTER_SEQUENCE, MOUSE_SGR_DISABLE_SEQUENCE, MOUSE_SGR_ENABLE_SEQUENCE, TERMINAL_CLEANUP_SEQUENCE } from "../../src/sumo-tui/runtime/terminal-controller.js";
 
 export interface TerminalStateProbe {
 	readonly altscreenActive: boolean;
@@ -56,7 +56,7 @@ function lastModeState(buffer: string, enableSequence: string, disableSequence: 
 
 function parseTerminalState(buffer: string): TerminalStateProbe {
 	const altscreenActive = lastModeState(buffer, "\x1b[?1049h", "\x1b[?1049l");
-	const mouseSGRActive = buffer.lastIndexOf(MOUSE_SGR_ENABLE_SEQUENCE) > buffer.lastIndexOf("\x1b[?1003l\x1b[?1006l\x1b[?1000l");
+	const mouseSGRActive = buffer.lastIndexOf(MOUSE_SGR_ENABLE_SEQUENCE) > buffer.lastIndexOf(MOUSE_SGR_DISABLE_SEQUENCE);
 	const cursorVisible = buffer.lastIndexOf("\x1b[?25h") > buffer.lastIndexOf("\x1b[?25l");
 
 	return {


### PR DESCRIPTION
## Summary
- add a retained selection controller for drag selection, OSC 52 clipboard copy, escape clearing, and copy key handling
- apply inverse-video selection highlighting as a compositor pass over the rendered cell buffer
- wire selection through the retained runtime, chat viewport bridge, and headless TestBackend with wide-glyph coverage

## Why
Issue #142 requires replacing terminal-native selection blocked by SGR mouse capture with an in-app selection layer that persists across redraws and auto-copies on release.

## Validation
- pnpm exec tsc --noEmit
- pnpm test
- pnpm test:integration
- pnpm build
- pnpm render:bible
- pnpm visual:ci
- node-pty runtime harness: SGR mouse down/drag/up highlighted selected text and emitted OSC 52 for `hello`; bridge `cmd+c` token emitted a second OSC 52 copy

Closes #142