### PR TITLE
feat(ui): Cathedral code block renderer (E10)

### DIFF
--- a/docs/visual/parity/scenarios.json
+++ b/docs/visual/parity/scenarios.json
@@ -748,6 +748,31 @@
 					"runtimeCrop": "footer"
 				}
 			]
+		},
+		{
+			"id": "fixture-code-block-landscape",
+			"lane": "fixture",
+			"status": "review",
+			"dimensions": {
+				"cols": 160,
+				"rows": 45
+			},
+			"bibleTarget": "scene-active-code-block.png",
+			"fixture": {
+				"id": "code-block"
+			},
+			"crops": [
+				{
+					"id": "full",
+					"targetCrop": "full",
+					"runtimeCrop": "full"
+				},
+				{
+					"id": "chat-area",
+					"targetCrop": "chat-area",
+					"runtimeCrop": "chat-area"
+				}
+			]
 		}
 	]
 }

--- a/scripts/visual-v2/fixture-capture.mjs
+++ b/scripts/visual-v2/fixture-capture.mjs
@@ -102,6 +102,34 @@ const FIXTURES = {
 			],
 		},
 	},
+	"code-block": {
+		transcript: {
+			messages: [
+				{
+					id: "u1",
+					role: "user",
+					displayName: "USER",
+					timestamp: FIXTURE_TIMES.userOne,
+					blocks: [{ type: "markdown", text: "show me the auth flow" }],
+				},
+				{
+					id: "s1",
+					role: "sumo",
+					displayName: "SUMO",
+					timestamp: FIXTURE_TIMES.sumoOne,
+					blocks: [
+						{ type: "markdown", text: "Here's the authentication handler:" },
+						{
+							type: "code",
+							lang: "ts",
+							source: 'async function authenticate(token: string) {\n  const session = await Session.fromToken(token);\n  if (!session || session.expired) return null;\n\n  // emit auth event for telemetry\n  emit("auth.success", { userId: session.user.id });\n  return session.user;\n}',
+						},
+						{ type: "markdown", text: "The session lookup validates the token and checks expiry before emitting a telemetry event." },
+					],
+				},
+			],
+		},
+	},
 };
 
 export async function captureFixtureScenario(scenario) {

--- a/src/sumo-tui/widgets/chat-message.ts
+++ b/src/sumo-tui/widgets/chat-message.ts
@@ -4,6 +4,7 @@ import { SumoNode } from "../layout/node.js";
 import { MEASURE_MODE_EXACTLY, type MeasureMode, type Yoga, type YogaNode } from "../layout/yoga.js";
 import type { CellBuffer, Rect } from "../render/buffer.js";
 import { lineToAnsi, span, textLine, withPersistentStyle, type Span } from "../render/primitives.js";
+import { renderCathedralCodeBlock } from "../transcript/code-renderer.js";
 import { renderToolBlockRows } from "../transcript/tool-renderer.js";
 import type { ChatBlock } from "../transcript/view-model.js";
 
@@ -152,7 +153,7 @@ function renderDelegationRows(block: Extract<ChatBlock, { type: "delegation" }>)
 }
 
 function renderCodeRows(block: Extract<ChatBlock, { type: "code" }>, width: number): string[] {
-	return wrapPlainText(`\`\`\`${block.lang}\n${block.source}\n\`\`\``, width);
+	return renderCathedralCodeBlock(block.lang, block.source, width);
 }
 
 function renderBlockRows(blocks: readonly ChatBlock[], width: number): string[] {


### PR DESCRIPTION
## Summary

Implements Element 10 from the Cathedral UX Bible — framed code blocks with line gutter and syntax highlighting.

### What changed

- `src/sumo-tui/transcript/code-renderer.ts` — new renderer (already on main via CI fix)
- `src/sumo-tui/widgets/chat-message.ts` — routes `ChatBlock.code` through `renderCathedralCodeBlock()` instead of raw backtick fences
- `scripts/visual-v2/fixture-capture.mjs` — added `code-block` fixture transcript
- `docs/visual/parity/scenarios.json` — added `fixture-code-block-landscape` scenario

### Rendering

```
╭─── ts ──────────────────────────────────────╮
│  1 async function authenticate(token) {     │  (surfaceRecess bg)
│  2   const session = await Session.from...  │
│  3   if (!session || session.expired) ...   │
╰─────────────────────────────────────────────╯
```

- Frame: `╭──── lang ────╮` / `│ gutter source │` / `╰────╯`
- Syntax: keywords → accent, strings → sage, numbers → amber, comments → dim brown
- Body rows use `surfaceRecess` bg via `withPersistentStyle`
- Blocks >20 lines collapse with `… N lines collapsed · ⌘O expand`

### Verification

```bash
pnpm test              # 484/484 ✅
pnpm test:integration  # 18/18 ✅
pnpm visual:ci         # 12 scenarios, fixture-code-block-landscape PASSED ✅
pnpm tsc --noEmit      # ✅
pnpm build             # ✅
```

Closes #132
Tracker: #124 Phase 2