### PR TITLE
[codex] fix chat word-wrap

### DIFF
--- a/src/sumo-tui/widgets/chat-message.test.ts
+++ b/src/sumo-tui/widgets/chat-message.test.ts
@@ -39,8 +39,77 @@ describe("ChatMessage", () => {
 		composite(root, buffer);
 
 		expect(buffer.toPlainRow(0)).toMatch(/^╭ SUMO ─+ 11:42 ─╮$/);
-		expect(buffer.toPlainRow(1)).toBe("│ hello from a v │");
-		expect(buffer.toPlainRow(2)).toBe("│ ery long assis │");
+		expect(buffer.toPlainRow(1)).toBe("│ hello from a   │");
+		expect(buffer.toPlainRow(2)).toBe("│ very long      │");
+		expect(buffer.toPlainRow(3)).toBe("│ assistant      │");
+		root.dispose();
+	});
+
+	it("hard-wraps long unbreakable tokens inside the body width", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		root.width = 14;
+		root.height = 6;
+		ChatMessage.create(yoga, "user", "abcdefghijklmnop", root, FIXED_TIME);
+
+		root.yogaNode.calculateLayout(14, 6, DIRECTION_LTR);
+		const buffer = new CellBuffer(6, 14);
+		composite(root, buffer);
+
+		expect(buffer.toPlainRow(1)).toBe("│ abcdefghij │");
+		expect(buffer.toPlainRow(2)).toBe("│ klmnop     │");
+		root.dispose();
+	});
+
+	it("wraps CJK text by whole glyphs when no whitespace is available", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		root.width = 12;
+		root.height = 6;
+		ChatMessage.create(yoga, "user", "界界界界界", root, FIXED_TIME);
+
+		root.yogaNode.calculateLayout(12, 6, DIRECTION_LTR);
+		const buffer = new CellBuffer(6, 12);
+		composite(root, buffer);
+
+		expect(buffer.toPlainRow(1)).toBe("│ 界界界界 │");
+		expect(buffer.toPlainRow(2)).toBe("│ 界       │");
+		root.dispose();
+	});
+
+	it("uses 126 body cells in a 130-column landscape chat frame", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		root.width = 130;
+		root.height = 6;
+		ChatMessage.create(yoga, "user", `${"a".repeat(125)} tail`, root, FIXED_TIME);
+
+		root.yogaNode.calculateLayout(130, 6, DIRECTION_LTR);
+		const buffer = new CellBuffer(6, 130);
+		composite(root, buffer);
+
+		expect(buffer.toPlainRow(1)).toBe(`│ ${"a".repeat(125)}  │`);
+		expect(buffer.toPlainRow(2)).toBe(`│ tail${" ".repeat(122)} │`);
+		root.dispose();
+	});
+
+	it("uses term width minus 4 body cells in a portrait chat frame", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		root.width = 60;
+		root.height = 6;
+		ChatMessage.create(yoga, "user", `${"b".repeat(56)} rest`, root, FIXED_TIME);
+
+		root.yogaNode.calculateLayout(60, 6, DIRECTION_LTR);
+		const buffer = new CellBuffer(6, 60);
+		composite(root, buffer);
+
+		expect(buffer.toPlainRow(1)).toBe(`│ ${"b".repeat(56)} │`);
+		expect(buffer.toPlainRow(2)).toBe(`│ rest${" ".repeat(52)} │`);
 		root.dispose();
 	});
 });

--- a/src/sumo-tui/widgets/chat-message.ts
+++ b/src/sumo-tui/widgets/chat-message.ts
@@ -23,6 +23,17 @@ export interface ChatMessageSnapshot {
 
 const MIN_BOX_WIDTH = 8;
 
+interface TextSegmenter {
+	segment(input: string): Iterable<{ segment: string }>;
+}
+
+const SEGMENTER_CTOR = (Intl as unknown as {
+	Segmenter?: new (locale: string | undefined, options: { granularity: "grapheme" }) => TextSegmenter;
+}).Segmenter;
+
+const GRAPHEME_SEGMENTER = SEGMENTER_CTOR ? new SEGMENTER_CTOR(undefined, { granularity: "grapheme" }) : undefined;
+const TRAILING_WHITESPACE_PATTERN = /\s+$/u;
+
 function normalizeWidth(width: number): number {
 	if (!Number.isFinite(width)) return 0;
 	return Math.max(0, Math.floor(width));
@@ -46,17 +57,75 @@ function takeVisible(input: string, maxWidth: number): { head: string; tail: str
 	if (maxWidth <= 0 || input.length === 0) return { head: "", tail: input };
 	let width = 0;
 	let index = 0;
-	for (const glyph of Array.from(input)) {
+	for (const glyph of splitGraphemes(input)) {
 		const glyphWidth = visibleWidth(glyph);
 		if (width + glyphWidth > maxWidth) break;
 		width += glyphWidth;
 		index += glyph.length;
 	}
 	if (index === 0) {
-		const [first = ""] = Array.from(input);
+		const [first = ""] = splitGraphemes(input);
 		return { head: first, tail: input.slice(first.length) };
 	}
 	return { head: input.slice(0, index), tail: input.slice(index) };
+}
+
+function splitGraphemes(text: string): string[] {
+	if (!text) return [];
+	if (!GRAPHEME_SEGMENTER) return Array.from(text);
+	return [...GRAPHEME_SEGMENTER.segment(text)].map((part) => part.segment);
+}
+
+function isWhitespace(glyph: string): boolean {
+	return /^\s$/u.test(glyph);
+}
+
+function joinLine(glyphs: readonly string[]): string {
+	return glyphs.join("").replace(TRAILING_WHITESPACE_PATTERN, "");
+}
+
+function skipLeadingWhitespace(glyphs: readonly string[]): string[] {
+	let index = 0;
+	while (index < glyphs.length && isWhitespace(glyphs[index] ?? "")) index += 1;
+	return glyphs.slice(index);
+}
+
+function wrapParagraph(paragraph: string, width: number): string[] {
+	let remaining = splitGraphemes(paragraph.replace(TRAILING_WHITESPACE_PATTERN, ""));
+	if (remaining.length === 0) return [""];
+
+	const rows: string[] = [];
+	while (remaining.length > 0) {
+		let visible = 0;
+		let fitEnd = 0;
+		let lastWhitespace = -1;
+		for (let index = 0; index < remaining.length; index += 1) {
+			const glyph = remaining[index] ?? "";
+			const glyphWidth = visibleWidth(glyph);
+			if (fitEnd > 0 && visible + glyphWidth > width) break;
+			visible += glyphWidth;
+			fitEnd = index + 1;
+			if (index > 0 && isWhitespace(glyph)) lastWhitespace = index;
+			if (visible >= width) break;
+		}
+
+		if (fitEnd >= remaining.length) {
+			rows.push(joinLine(remaining));
+			break;
+		}
+
+		if (lastWhitespace > 0) {
+			rows.push(joinLine(remaining.slice(0, lastWhitespace)));
+			remaining = skipLeadingWhitespace(remaining.slice(lastWhitespace));
+			continue;
+		}
+
+		const hardEnd = Math.max(1, fitEnd);
+		rows.push(joinLine(remaining.slice(0, hardEnd)));
+		remaining = skipLeadingWhitespace(remaining.slice(hardEnd));
+	}
+
+	return rows;
 }
 
 function wrapPlainText(input: string, width: number): string[] {
@@ -64,16 +133,7 @@ function wrapPlainText(input: string, width: number): string[] {
 	const rows: string[] = [];
 	const paragraphs = input.split("\n");
 	for (const paragraph of paragraphs) {
-		if (paragraph.length === 0) {
-			rows.push("");
-			continue;
-		}
-		let remaining = paragraph;
-		while (remaining.length > 0) {
-			const part = takeVisible(remaining, width);
-			rows.push(part.head);
-			remaining = part.tail;
-		}
+		rows.push(...wrapParagraph(paragraph, width));
 	}
 	return rows.length === 0 ? [""] : rows;
 }


### PR DESCRIPTION
## Summary

Closes #136.

Replaces chat message character wrapping with word-boundary wrapping. The fallback path remains grapheme-aware for text without whitespace, and long unbreakable tokens still hard-wrap inside the frame body width.

## Details

- Uses `Intl.Segmenter` when available to split by grapheme clusters before width measurement.
- Drops trailing whitespace at wrap boundaries so body rows do not overflow or shift the right border.
- Keeps the V2 body width contract: frame width minus 4 cells.
- Adds coverage for 130-column landscape frames, 60-column portrait frames, long tokens, and CJK fallback wrapping.

## Verification

- `pnpm exec vitest run src/sumo-tui/widgets/chat-message.test.ts`
- `pnpm exec tsc --noEmit && pnpm build`
- `pnpm test`
- `pnpm test:integration`
- `pnpm visual:ci`
- Inspected `docs/visual/out/parity/fixture-completed-landscape/raw/styled-cell-diff-chat-area.txt`
- Inspected `docs/visual/out/parity/fixture-completed-portrait/raw/styled-cell-diff-chat-area.txt`
