### PR TITLE
[codex] sweep V2 spec/code drift

### DIFF
--- a/docs/ui/CATHEDRAL_UX_SPEC_V2.md
+++ b/docs/ui/CATHEDRAL_UX_SPEC_V2.md
@@ -48,7 +48,7 @@ Unchanged from v1. Reproduced for completeness.
 | `#1A1511` | `background` | terminal-default (OSC 11), splash bg, chat bg |
 | `#241D17` | `surface` | sidebar bg, modal bg |
 | `#120D0A` | `surfaceRecess` | input frame bg, code block bg |
-| `#3A342F` | `surfaceLifted` | modal bg (alternate), focused row band |
+| `#3D3024` | `surfaceLifted` | modal bg (alternate), focused row band |
 | `#3A2F25` | `divider` | sub-section dividers, sidebar tab inactive bg |
 | `#F5E6C8` | `foreground` | most body text |
 | `#8B7A63` | `foregroundDim` | metadata, line numbers, hints |

--- a/src/command-palette.test.ts
+++ b/src/command-palette.test.ts
@@ -213,4 +213,10 @@ describe("handlePaletteSelection", () => {
 		expect(select).toHaveBeenCalledWith("THINKING", ["off", "minimal", "low", "medium", "high", "xhigh"]);
 		expect(setThinkingLevel).toHaveBeenCalledWith("xhigh");
 	});
+
+	it("SETTINGS opens Pi settings through the command editor", async () => {
+		const setEditorText = vi.fn();
+		await handlePaletteSelection("SETTINGS", { ui: { setEditorText } } as never, {} as never);
+		expect(setEditorText).toHaveBeenCalledWith("/settings");
+	});
 });

--- a/src/command-palette.ts
+++ b/src/command-palette.ts
@@ -280,6 +280,12 @@ export async function handlePaletteSelection(mode: PaletteMode | undefined, ctx:
 		const themes = ctx.ui.getAllThemes().map((theme) => theme.name);
 		const selected = await ctx.ui.select("THEME", themes);
 		if (selected) ctx.ui.setTheme(selected);
+		return;
+	}
+
+	if (mode === "SETTINGS") {
+		ctx.ui.setEditorText("/settings");
+		return;
 	}
 }
 

--- a/src/config/sumocode-config.test.ts
+++ b/src/config/sumocode-config.test.ts
@@ -1,0 +1,59 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_SUMOCODE_CONFIG, loadSumoCodeConfig, resolveSumoCodeConfigCandidates } from "./sumocode-config.js";
+
+function writeJson(path: string, value: unknown): void {
+	mkdirSync(dirname(path), { recursive: true });
+	writeFileSync(path, `${JSON.stringify(value)}\n`);
+}
+
+function removeIfExists(path: string): void {
+	if (existsSync(path)) unlinkSync(path);
+}
+
+describe("sumocode-config", () => {
+	it("resolves config in deterministic project, project .pi, global, default order", () => {
+		const root = mkdtempSync(join(tmpdir(), "sumocode-config-"));
+		const cwd = join(root, "project");
+		const homeDir = join(root, "home");
+		mkdirSync(cwd, { recursive: true });
+
+		const [project, projectPi, global] = resolveSumoCodeConfigCandidates({ cwd, homeDir });
+		writeJson(global.path, { primaryAgentName: "Global" });
+		writeJson(projectPi.path, { primaryAgentName: "ProjectPi" });
+		writeJson(project.path, { primaryAgentName: "Project" });
+
+		try {
+			expect(loadSumoCodeConfig({ cwd, homeDir })).toMatchObject({ config: { primaryAgentName: "Project" }, source: "project" });
+
+			removeIfExists(project.path);
+			expect(loadSumoCodeConfig({ cwd, homeDir })).toMatchObject({ config: { primaryAgentName: "ProjectPi" }, source: "project-pi" });
+
+			removeIfExists(projectPi.path);
+			expect(loadSumoCodeConfig({ cwd, homeDir })).toMatchObject({ config: { primaryAgentName: "Global" }, source: "global" });
+
+			removeIfExists(global.path);
+			expect(loadSumoCodeConfig({ cwd, homeDir })).toEqual({ config: DEFAULT_SUMOCODE_CONFIG, source: "defaults" });
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("skips malformed config files and validates primaryAgentName", () => {
+		const root = mkdtempSync(join(tmpdir(), "sumocode-config-invalid-"));
+		const cwd = join(root, "project");
+		const homeDir = join(root, "home");
+		mkdirSync(cwd, { recursive: true });
+		const [project, projectPi] = resolveSumoCodeConfigCandidates({ cwd, homeDir });
+		writeFileSync(project.path, "{");
+		writeJson(projectPi.path, { primaryAgentName: "  Zeus  " });
+
+		try {
+			expect(loadSumoCodeConfig({ cwd, homeDir })).toMatchObject({ config: { primaryAgentName: "Zeus" }, source: "project-pi" });
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/config/sumocode-config.ts
+++ b/src/config/sumocode-config.ts
@@ -1,0 +1,71 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+export interface SumoCodeConfig {
+	readonly primaryAgentName: string;
+}
+
+export type SumoCodeConfigSourceKind = "project" | "project-pi" | "global" | "defaults";
+
+export interface SumoCodeConfigCandidate {
+	readonly kind: Exclude<SumoCodeConfigSourceKind, "defaults">;
+	readonly path: string;
+}
+
+export interface SumoCodeConfigLoadResult {
+	readonly config: SumoCodeConfig;
+	readonly source: SumoCodeConfigSourceKind;
+	readonly path?: string;
+}
+
+export interface LoadSumoCodeConfigOptions {
+	readonly cwd?: string;
+	readonly homeDir?: string;
+	readonly readFile?: (path: string) => string | undefined;
+}
+
+export const DEFAULT_SUMOCODE_CONFIG: SumoCodeConfig = {
+	primaryAgentName: "SUMO",
+};
+
+export function resolveSumoCodeConfigCandidates(options: Pick<LoadSumoCodeConfigOptions, "cwd" | "homeDir"> = {}): SumoCodeConfigCandidate[] {
+	const cwd = resolve(options.cwd ?? process.cwd());
+	const homeDir = resolve(options.homeDir ?? homedir());
+	return [
+		{ kind: "project", path: join(cwd, ".sumocode.json") },
+		{ kind: "project-pi", path: join(cwd, ".pi", "sumocode.json") },
+		{ kind: "global", path: join(homeDir, ".pi", "agent", "sumocode.json") },
+	];
+}
+
+export function loadSumoCodeConfig(options: LoadSumoCodeConfigOptions = {}): SumoCodeConfigLoadResult {
+	const readFile = options.readFile ?? readConfigFile;
+	for (const candidate of resolveSumoCodeConfigCandidates(options)) {
+		const raw = readFile(candidate.path);
+		if (raw === undefined) continue;
+		const config = parseSumoCodeConfig(raw);
+		if (config) return { config, source: candidate.kind, path: candidate.path };
+	}
+	return { config: DEFAULT_SUMOCODE_CONFIG, source: "defaults" };
+}
+
+function readConfigFile(path: string): string | undefined {
+	if (!existsSync(path)) return undefined;
+	return readFileSync(path, "utf8");
+}
+
+function parseSumoCodeConfig(raw: string): SumoCodeConfig | undefined {
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(raw);
+	} catch {
+		return undefined;
+	}
+	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return undefined;
+	const primaryAgentName = (parsed as { primaryAgentName?: unknown }).primaryAgentName;
+	if (typeof primaryAgentName !== "string") return undefined;
+	const trimmed = primaryAgentName.trim();
+	if (trimmed.length === 0) return undefined;
+	return { primaryAgentName: trimmed };
+}

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -30,6 +30,7 @@
 import type { AgentSessionRuntime, InteractiveModeOptions } from "@mariozechner/pi-coding-agent";
 import { InteractiveMode } from "@mariozechner/pi-coding-agent";
 import type { ExtensionUIContext } from "@mariozechner/pi-coding-agent";
+import { loadSumoCodeConfig } from "../../config/sumocode-config.js";
 import { EmptyChatQuoteNode, shouldRenderEmptyChatQuote, type EmptyChatQuoteSnapshot } from "../cathedral/empty-chat-quote.js";
 import { createSplashTree, defaultSplashSnapshot, type SplashTree } from "../cathedral/splash-tree.js";
 import { SumoNode } from "../layout/node.js";
@@ -147,9 +148,11 @@ export class SumoInteractiveRuntime {
 		}
 
 		this.yoga = await loadYoga();
+		const sumocodeConfig = loadSumoCodeConfig().config;
 		this.root = new SumoNode(this.yoga.Node.create());
 		this.root.flexDirection = FLEX_DIRECTION_COLUMN;
 		this.chat = ChatPager.create(this.yoga, undefined, {
+			primaryAgentName: sumocodeConfig.primaryAgentName,
 			renderControls: {
 				scheduleRender: () => this.requestRender(),
 				setStreamingMode: (enabled) => this.setStreamingMode(enabled),

--- a/src/sumo-tui/render/ansi-writer.ts
+++ b/src/sumo-tui/render/ansi-writer.ts
@@ -2,6 +2,7 @@ import { visibleWidth } from "@mariozechner/pi-tui";
 import type { Cell, CellAttrs } from "./cell.js";
 import { attrsEqual, createAttrs } from "./cell.js";
 import type { CellBuffer } from "./buffer.js";
+import { parseHexColor } from "./truecolor.js";
 
 interface StyleState {
 	fg?: string;
@@ -10,13 +11,6 @@ interface StyleState {
 }
 
 const DEFAULT_STYLE: StyleState = { attrs: createAttrs() };
-
-function parseHexColor(color: string | undefined): [number, number, number] | undefined {
-	if (!color) return undefined;
-	const hex = color.startsWith("#") ? color.slice(1) : color;
-	if (!/^[0-9a-fA-F]{6}$/.test(hex)) return undefined;
-	return [Number.parseInt(hex.slice(0, 2), 16), Number.parseInt(hex.slice(2, 4), 16), Number.parseInt(hex.slice(4, 6), 16)];
-}
 
 function styleEqual(left: StyleState, right: StyleState): boolean {
 	return left.fg === right.fg && left.bg === right.bg && attrsEqual(left.attrs, right.attrs);

--- a/src/sumo-tui/render/buffer.ts
+++ b/src/sumo-tui/render/buffer.ts
@@ -1,5 +1,6 @@
 import { visibleWidth } from "@mariozechner/pi-tui";
 import { BLANK_CELL, attrsEqual, attrsToMask, createAttrs, maskToAttrs, type Cell } from "./cell.js";
+import { indexedColor, isColorByte, normalizeHexColor } from "./truecolor.js";
 
 export interface Rect {
 	top: number;
@@ -18,25 +19,6 @@ const SEGMENTER_CTOR = (Intl as unknown as {
 
 const GRAPHEME_SEGMENTER = SEGMENTER_CTOR ? new SEGMENTER_CTOR(undefined, { granularity: "grapheme" }) : undefined;
 
-const ANSI_16: readonly string[] = [
-	"#000000",
-	"#800000",
-	"#008000",
-	"#808000",
-	"#000080",
-	"#800080",
-	"#008080",
-	"#c0c0c0",
-	"#808080",
-	"#ff0000",
-	"#00ff00",
-	"#ffff00",
-	"#0000ff",
-	"#ff00ff",
-	"#00ffff",
-	"#ffffff",
-];
-
 function splitGraphemes(text: string): string[] {
 	if (!text) return [];
 	if (!GRAPHEME_SEGMENTER) return Array.from(text);
@@ -49,33 +31,6 @@ function clampRect(rect: Rect, rows: number, cols: number): Rect {
 	const bottom = Math.max(top, Math.min(rows, Math.floor(rect.top + rect.height)));
 	const right = Math.max(left, Math.min(cols, Math.floor(rect.left + rect.width)));
 	return { top, left, width: right - left, height: bottom - top };
-}
-
-function normalizeHex(r: number, g: number, b: number): string {
-	const toHex = (value: number) => Math.max(0, Math.min(255, value)).toString(16).padStart(2, "0");
-	return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
-}
-
-function isColorByte(value: number | undefined): value is number {
-	return value !== undefined && Number.isInteger(value) && value >= 0 && value <= 255;
-}
-
-function indexedColor(index: number): string | undefined {
-	if (!isColorByte(index)) return undefined;
-	if (index < ANSI_16.length) return ANSI_16[index];
-	if (index >= 16 && index <= 231) {
-		const value = index - 16;
-		const r = Math.floor(value / 36);
-		const g = Math.floor((value % 36) / 6);
-		const b = value % 6;
-		const cube = [0, 95, 135, 175, 215, 255];
-		return normalizeHex(cube[r] ?? 0, cube[g] ?? 0, cube[b] ?? 0);
-	}
-	if (index >= 232 && index <= 255) {
-		const gray = 8 + (index - 232) * 10;
-		return normalizeHex(gray, gray, gray);
-	}
-	return undefined;
 }
 
 function sameStyle(left: Cell, right: Cell): boolean {
@@ -365,7 +320,7 @@ export class CellBuffer {
 			const g = codes[offset + 2];
 			const b = codes[offset + 3];
 			if (!isColorByte(r) || !isColorByte(g) || !isColorByte(b)) return undefined;
-			return { value: normalizeHex(r, g, b), nextIndex: offset + 3 };
+			return { value: normalizeHexColor(r, g, b), nextIndex: offset + 3 };
 		}
 		if (mode === 5) {
 			const color = indexedColor(codes[offset + 1] ?? -1);

--- a/src/sumo-tui/render/truecolor.test.ts
+++ b/src/sumo-tui/render/truecolor.test.ts
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { cellRowToAnsi } from "./ansi-writer.js";
 import { CellBuffer } from "./buffer.js";
+import { indexedColor, normalizeHexColor, parseHexColor } from "./truecolor.js";
 
 describe("truecolor ANSI preservation", () => {
+	it("normalizes 24-bit cathedral colors through the shared truecolor helpers", () => {
+		expect(normalizeHexColor(61, 48, 36)).toBe("#3d3024");
+		expect(parseHexColor("#3D3024")).toEqual([61, 48, 36]);
+		expect(indexedColor(208)).toBe("#ff8700");
+	});
+
 	it("round-trips a 24-bit foreground SGR through the cell buffer", () => {
 		const buffer = new CellBuffer(1, 1);
 		buffer.paintRow(0, "\x1b[38;2;217;119;6mX\x1b[0m");

--- a/src/sumo-tui/render/truecolor.ts
+++ b/src/sumo-tui/render/truecolor.ts
@@ -1,0 +1,52 @@
+const ANSI_16: readonly string[] = [
+	"#000000",
+	"#800000",
+	"#008000",
+	"#808000",
+	"#000080",
+	"#800080",
+	"#008080",
+	"#c0c0c0",
+	"#808080",
+	"#ff0000",
+	"#00ff00",
+	"#ffff00",
+	"#0000ff",
+	"#ff00ff",
+	"#00ffff",
+	"#ffffff",
+];
+
+export function isColorByte(value: number | undefined): value is number {
+	return value !== undefined && Number.isInteger(value) && value >= 0 && value <= 255;
+}
+
+export function normalizeHexColor(red: number, green: number, blue: number): string {
+	const toHex = (value: number) => Math.max(0, Math.min(255, value)).toString(16).padStart(2, "0");
+	return `#${toHex(red)}${toHex(green)}${toHex(blue)}`;
+}
+
+export function parseHexColor(color: string | undefined): [number, number, number] | undefined {
+	if (!color) return undefined;
+	const hex = color.startsWith("#") ? color.slice(1) : color;
+	if (!/^[0-9a-fA-F]{6}$/.test(hex)) return undefined;
+	return [Number.parseInt(hex.slice(0, 2), 16), Number.parseInt(hex.slice(2, 4), 16), Number.parseInt(hex.slice(4, 6), 16)];
+}
+
+export function indexedColor(index: number): string | undefined {
+	if (!isColorByte(index)) return undefined;
+	if (index < ANSI_16.length) return ANSI_16[index];
+	if (index >= 16 && index <= 231) {
+		const value = index - 16;
+		const red = Math.floor(value / 36);
+		const green = Math.floor((value % 36) / 6);
+		const blue = value % 6;
+		const cube = [0, 95, 135, 175, 215, 255];
+		return normalizeHexColor(cube[red] ?? 0, cube[green] ?? 0, cube[blue] ?? 0);
+	}
+	if (index >= 232 && index <= 255) {
+		const gray = 8 + (index - 232) * 10;
+		return normalizeHexColor(gray, gray, gray);
+	}
+	return undefined;
+}

--- a/src/sumo-tui/widgets/chat-message.test.ts
+++ b/src/sumo-tui/widgets/chat-message.test.ts
@@ -43,4 +43,20 @@ describe("ChatMessage", () => {
 		expect(buffer.toPlainRow(2)).toBe("│ ery long assis │");
 		root.dispose();
 	});
+
+	it("uses the configured primary agent name for assistant headers", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		root.width = 18;
+		root.height = 5;
+		ChatMessage.create(yoga, "sumo", "configured name", root, FIXED_TIME, undefined, { primaryAgentName: "Zeus" });
+
+		root.yogaNode.calculateLayout(18, 5, DIRECTION_LTR);
+		const buffer = new CellBuffer(5, 18);
+		composite(root, buffer);
+
+		expect(buffer.toPlainRow(0)).toMatch(/^╭ ZEUS ─+ 11:42 ─╮$/);
+		root.dispose();
+	});
 });

--- a/src/sumo-tui/widgets/chat-message.ts
+++ b/src/sumo-tui/widgets/chat-message.ts
@@ -1,4 +1,5 @@
 import { visibleWidth } from "@mariozechner/pi-tui";
+import { DEFAULT_SUMOCODE_CONFIG } from "../../config/sumocode-config.js";
 import { CATHEDRAL_TOKENS } from "../../tokens.js";
 import { SumoNode } from "../layout/node.js";
 import { MEASURE_MODE_EXACTLY, type MeasureMode, type Yoga, type YogaNode } from "../layout/yoga.js";
@@ -22,6 +23,10 @@ export interface ChatMessageSnapshot {
 	blocks?: readonly ChatBlock[];
 }
 
+export interface ChatMessageOptions {
+	readonly primaryAgentName?: string;
+}
+
 const MIN_BOX_WIDTH = 8;
 
 function normalizeWidth(width: number): number {
@@ -29,9 +34,14 @@ function normalizeWidth(width: number): number {
 	return Math.max(0, Math.floor(width));
 }
 
-function roleLabel(role: ChatMessageRole): string {
+function agentRoleLabel(primaryAgentName: string | undefined): string {
+	const label = primaryAgentName?.trim() || DEFAULT_SUMOCODE_CONFIG.primaryAgentName;
+	return label.toUpperCase();
+}
+
+function roleLabel(role: ChatMessageRole, primaryAgentName?: string): string {
 	if (role === "user") return "USER";
-	if (role === "sumo" || role === "assistant") return "SUMO";
+	if (role === "sumo" || role === "assistant") return agentRoleLabel(primaryAgentName);
 	if (role === "tool") return "TOOL";
 	return String(role).toUpperCase();
 }
@@ -94,8 +104,8 @@ function formatTime(timestamp: Date): string {
 	return `${hours}:${minutes}`;
 }
 
-function frameTop(role: ChatMessageRole, timestamp: Date | undefined, width: number): string {
-	const label = roleLabel(role);
+function frameTop(role: ChatMessageRole, timestamp: Date | undefined, width: number, primaryAgentName?: string): string {
+	const label = roleLabel(role, primaryAgentName);
 	const leftParts: (Span | string)[] = [
 		span("╭ ", { fg: CATHEDRAL_TOKENS.colors.divider }),
 		span(label, { fg: roleColor(role) }),
@@ -197,6 +207,7 @@ export class ChatMessage extends SumoNode {
 		parent?: SumoNode,
 		timestamp = new Date(),
 		private blocks?: readonly ChatBlock[],
+		private readonly options: ChatMessageOptions = {},
 	) {
 		super(yogaNode, parent);
 		this.timestamp = timestamp;
@@ -204,8 +215,8 @@ export class ChatMessage extends SumoNode {
 		this.setMeasureFunc((width, widthMode, height, heightMode) => this.measure(width, widthMode, height, heightMode));
 	}
 
-	public static create(yoga: Yoga, role: ChatMessageRole, text: string, parent?: SumoNode, timestamp?: Date, blocks?: readonly ChatBlock[]): ChatMessage {
-		return new ChatMessage(yoga.Node.create(), role, text, parent, timestamp, blocks);
+	public static create(yoga: Yoga, role: ChatMessageRole, text: string, parent?: SumoNode, timestamp?: Date, blocks?: readonly ChatBlock[], options?: ChatMessageOptions): ChatMessage {
+		return new ChatMessage(yoga.Node.create(), role, text, parent, timestamp, blocks, options);
 	}
 
 	public setText(text: string): void {
@@ -259,7 +270,7 @@ export class ChatMessage extends SumoNode {
 		const bodyWidth = Math.max(1, renderWidth - 4);
 		const bodyRows = this.blocks ? renderBlockRows(this.blocks, bodyWidth) : wrapPlainText(this.text, bodyWidth);
 		return [
-			frameTop(this.role, this.timestamp, renderWidth),
+			frameTop(this.role, this.timestamp, renderWidth, this.options.primaryAgentName),
 			...bodyRows.map((row) => frameBody(row, renderWidth)),
 			frameBottom(renderWidth),
 		];

--- a/src/sumo-tui/widgets/chat-pager.test.ts
+++ b/src/sumo-tui/widgets/chat-pager.test.ts
@@ -130,6 +130,23 @@ describe("ChatPager", () => {
 		root.dispose();
 	});
 
+	it("passes the configured primary agent name into assistant chat headers", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const chat = ChatPager.create(yoga, root, { primaryAgentName: "Zeus" });
+		root.width = 24;
+		root.height = 5;
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		chat.addMessage("sumo", "done", new Date("2026-04-30T11:42:00.000"));
+
+		root.yogaNode.calculateLayout(24, 5, DIRECTION_LTR);
+		const frame = new CellBuffer(5, 24);
+		composite(root, frame);
+
+		expect(frame.toPlainRow(0)).toMatch(/^╭ ZEUS ─+ 11:42 ─╮$/);
+		root.dispose();
+	});
+
 	it("tool result during typing keeps the editor cursor leaf stable (EC-2.3)", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());

--- a/src/sumo-tui/widgets/chat-pager.ts
+++ b/src/sumo-tui/widgets/chat-pager.ts
@@ -3,7 +3,7 @@ import { FLEX_DIRECTION_COLUMN, type Yoga, type YogaNode } from "../layout/yoga.
 import type { KeyEvent } from "../input/key-router.js";
 import type { MouseEvent } from "../input/mouse.js";
 import { chatMessageViewModelToPlainText, type ChatMessageViewModel } from "../transcript/view-model.js";
-import { ChatMessage, type ChatMessageRole } from "./chat-message.js";
+import { ChatMessage, type ChatMessageOptions, type ChatMessageRole } from "./chat-message.js";
 import { ScrolledUpBanner } from "./scrolled-up-banner.js";
 import { ScrollBox, type ScrollBoxStateChange } from "./scrollbox.js";
 
@@ -16,6 +16,7 @@ export interface ChatPagerOptions {
 	readonly renderControls?: ChatPagerRenderControls;
 	readonly maxRenderedMessages?: number;
 	readonly stickyBottom?: boolean;
+	readonly primaryAgentName?: string;
 }
 
 const DEFAULT_MAX_RENDERED_MESSAGES = 200;
@@ -36,6 +37,7 @@ export class ChatPager extends SumoNode {
 	private readonly yoga: Yoga;
 	private readonly renderControls: ChatPagerRenderControls;
 	private readonly maxRenderedMessages: number;
+	private readonly chatMessageOptions: ChatMessageOptions;
 	private readonly activeMessages: ChatMessage[] = [];
 	private placeholder: ChatMessage | undefined;
 	private unreadCount = 0;
@@ -47,6 +49,7 @@ export class ChatPager extends SumoNode {
 		this.yoga = yoga;
 		this.renderControls = options.renderControls ?? { scheduleRender: noop, setStreamingMode: noop };
 		this.maxRenderedMessages = Math.max(1, Math.round(options.maxRenderedMessages ?? DEFAULT_MAX_RENDERED_MESSAGES));
+		this.chatMessageOptions = { primaryAgentName: options.primaryAgentName };
 		this.flexGrow = 1;
 		this.flexShrink = 1;
 		this.flexDirection = FLEX_DIRECTION_COLUMN;
@@ -66,7 +69,7 @@ export class ChatPager extends SumoNode {
 	}
 
 	public addMessage(role: ChatMessageRole, text: string, timestamp?: Date): ChatMessage {
-		return this.addChatMessage(ChatMessage.create(this.yoga, role, text, undefined, timestamp));
+		return this.addChatMessage(ChatMessage.create(this.yoga, role, text, undefined, timestamp, undefined, this.chatMessageOptions));
 	}
 
 	public addViewModel(message: ChatMessageViewModel): ChatMessage {
@@ -78,6 +81,7 @@ export class ChatPager extends SumoNode {
 			undefined,
 			message.timestamp,
 			message.blocks,
+			this.chatMessageOptions,
 		));
 	}
 
@@ -235,7 +239,7 @@ export class ChatPager extends SumoNode {
 		if (this.archivedMessages.length === 0) return { addedLines, removedLines };
 		const placeholderText = `── ${this.archivedMessages.length} earlier messages ──`;
 		if (!this.placeholder) {
-			this.placeholder = ChatMessage.create(this.yoga, "system", placeholderText);
+			this.placeholder = ChatMessage.create(this.yoga, "system", placeholderText, undefined, undefined, undefined, this.chatMessageOptions);
 			addedLines += this.placeholder.getEstimatedHeight(width);
 			this.rebuildRenderedChildren();
 		} else if (this.placeholder.text !== placeholderText) {

--- a/src/tokens.test.ts
+++ b/src/tokens.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { CATHEDRAL_TOKENS } from "./tokens.js";
+
+describe("CATHEDRAL_TOKENS", () => {
+	it("uses the V2 warmer lifted surface token", () => {
+		expect(CATHEDRAL_TOKENS.colors.surfaceLifted).toBe("#3D3024");
+	});
+});


### PR DESCRIPTION
## Summary

Closes #133.

Sweeps the remaining V2 spec/code drift without reverting PR #144's token unification work.

## Details

- Adds `src/sumo-tui/render/truecolor.ts` and moves shared truecolor/indexed-color helpers into it.
- Keeps PR #144 token unification intact: `CATHEDRAL_TOKENS.colors.divider` remains the palette divider source, `surfaceLifted` remains `#3D3024`, and chat body `withPersistentStyle` behavior is unchanged.
- Updates the V2 spec token table to the current `surfaceLifted` value.
- Makes the existing `SETTINGS` palette row actionable by filling `/settings`.
- Adds `src/config/sumocode-config.ts` with deterministic lookup: `.sumocode.json` → `.pi/sumocode.json` → `~/.pi/agent/sumocode.json` → defaults.
- Wires `primaryAgentName` into retained chat headers via `ChatPager`/`ChatMessage` so assistant headers can render names like `ZEUS` while product branding remains `SUMOCODE`.

## Verification

- `pnpm exec vitest run src/config/sumocode-config.test.ts src/sumo-tui/render/truecolor.test.ts src/sumo-tui/widgets/chat-message.test.ts src/sumo-tui/widgets/chat-pager.test.ts src/command-palette.test.ts src/tokens.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm test`
- `pnpm exec tsc --noEmit && pnpm build`
- `pnpm test:integration`
- `pnpm visual:ci`
- `git diff --check`
- `rg -n "#3A342F" src test --glob '*.ts' -S` returned no source/test hits
