### PR TITLE
feat(ui): styled skill inline pills (E9a)

### DIFF
--- a/docs/visual/parity/scenarios.json
+++ b/docs/visual/parity/scenarios.json
@@ -750,6 +750,31 @@
 			]
 		},
 		{
+			"id": "fixture-skill-pill-landscape",
+			"lane": "fixture",
+			"status": "review",
+			"dimensions": {
+				"cols": 160,
+				"rows": 45
+			},
+			"bibleTarget": "scene-active-skill-pill.png",
+			"fixture": {
+				"id": "skill-pill"
+			},
+			"crops": [
+				{
+					"id": "full",
+					"targetCrop": "full",
+					"runtimeCrop": "full"
+				},
+				{
+					"id": "chat-area",
+					"targetCrop": "chat-area",
+					"runtimeCrop": "chat-area"
+				}
+			]
+		},
+		{
 			"id": "fixture-code-block-landscape",
 			"lane": "fixture",
 			"status": "review",

--- a/scripts/visual-v2/fixture-capture.mjs
+++ b/scripts/visual-v2/fixture-capture.mjs
@@ -102,6 +102,30 @@ const FIXTURES = {
 			],
 		},
 	},
+	"skill-pill": {
+		transcript: {
+			messages: [
+				{
+					id: "u1",
+					role: "user",
+					displayName: "USER",
+					timestamp: FIXTURE_TIMES.userOne,
+					blocks: [{ type: "markdown", text: "use the frontend-design skill and sketch the command palette polish plan." }],
+				},
+				{
+					id: "s1",
+					role: "sumo",
+					displayName: "SUMO",
+					timestamp: new Date("2026-04-30T11:45:00"),
+					blocks: [
+						{ type: "markdown", text: "Loading the design skill and keeping it inline, Pi-minimal, and non-decorative." },
+						{ type: "skill", name: "frontend-design", expanded: false },
+						{ type: "markdown", text: "I'll apply the skill guidance to the Scriptorium palette without changing the locked interaction model." },
+					],
+				},
+			],
+		},
+	},
 	"code-block": {
 		transcript: {
 			messages: [

--- a/src/sumo-tui/widgets/chat-message.test.ts
+++ b/src/sumo-tui/widgets/chat-message.test.ts
@@ -128,4 +128,23 @@ describe("ChatMessage", () => {
 		expect(buffer.toPlainRow(0)).toMatch(/^╭ ZEUS ─+ 11:42 ─╮$/);
 		root.dispose();
 	});
+
+	it("renders skill blocks as styled inline pills", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		root.width = 60;
+		root.height = 6;
+		ChatMessage.create(yoga, "sumo", "", root, FIXED_TIME, [
+			{ type: "skill", name: "frontend-design", expanded: false },
+		]);
+
+		root.yogaNode.calculateLayout(60, 6, DIRECTION_LTR);
+		const buffer = new CellBuffer(6, 60);
+		composite(root, buffer);
+
+		const row = buffer.toPlainRow(1);
+		expect(row).toContain("[skill] frontend-design (⌘O to expand)");
+		root.dispose();
+	});
 });

--- a/src/sumo-tui/widgets/chat-message.ts
+++ b/src/sumo-tui/widgets/chat-message.ts
@@ -211,7 +211,12 @@ function frameBottom(width: number): string {
 }
 
 function renderSkillRow(block: Extract<ChatBlock, { type: "skill" }>): string {
-	return `[skill] ${block.name}${block.expanded ? " (expanded)" : " (⌘O to expand)"}`;
+	const hint = block.expanded ? "(expanded)" : "(⌘O to expand)";
+	return lineToAnsi(textLine([
+		span("[skill]", { fg: CATHEDRAL_TOKENS.colors.accent }),
+		span(` ${block.name} `, { fg: CATHEDRAL_TOKENS.colors.foreground }),
+		span(hint, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+	]));
 }
 
 function renderQuestionRows(block: Extract<ChatBlock, { type: "question" }>): string[] {


### PR DESCRIPTION
## Summary

Renders skill blocks as Cathedral-styled inline pills matching Bible `skill-v1-inline.html`.

### Before
```
[skill] frontend-design (⌘O to expand)
```
Plain text, no color.

### After
`[skill]` brackets divider, `skill` accent, `frontend-design` foreground, `(⌘O to expand)` dim.

### Verification
```
pnpm test        # 506/506 ✅
pnpm test:integration  # 18/18 ✅
pnpm tsc --noEmit # ✅
pnpm build       # ✅
```

Closes #139
Tracker: #124 Phase 5