### PR TITLE
[codex] Optimize resume transcript hydration

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,52 @@
+name: perf
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "test/**"
+      - "scripts/measure-resume-perf.mjs"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/perf.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/**"
+      - "test/**"
+      - "scripts/measure-resume-perf.mjs"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - ".github/workflows/perf.yml"
+  workflow_dispatch:
+
+jobs:
+  resume:
+    name: resume p95 budget
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.29.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Resume perf budget
+        run: pnpm perf:resume

--- a/docs/research/sumo-tui-resume-performance.md
+++ b/docs/research/sumo-tui-resume-performance.md
@@ -1,0 +1,41 @@
+# SumoTUI Resume Performance
+
+Generated: 2026-04-30T16:54:32.513Z
+
+Machine: darwin 25.4.0, Node v25.1.0, @dhruvkelawala/sumocode@0.1.0, Apple M3 Max
+
+## Current Bulk Resume Path (10000 messages, 30 iterations)
+
+Budget: p95 < 500ms. Result: **PASS** at p95 29.06ms.
+
+| Stage | p50 | p95 |
+|---|---:|---:|
+| session_scan | 0.00ms | 0.00ms |
+| transcript_model | 1.90ms | 3.47ms |
+| transcript_hydrate | 6.68ms | 8.52ms |
+| yoga_first_layout | 7.76ms | 12.97ms |
+| first_frame_render | 6.52ms | 7.91ms |
+| total | 23.11ms | 29.06ms |
+
+Latest retained transcript stats: 10000 accepted, 200 rendered nodes, 9800 archived behind the placeholder.
+
+## Legacy Incremental Replay Proxy (2000 messages, 5 iterations)
+
+This measures the old Sumo-owned replay shape: add every view model one-by-one, create archived Yoga nodes, and schedule a render per message. It is intentionally capped below 10k so the report stays quick enough for local iteration.
+
+| Stage | p50 | p95 |
+|---|---:|---:|
+| session_scan | 0.00ms | 0.00ms |
+| transcript_model | 0.00ms | 0.00ms |
+| transcript_hydrate | 273ms | 273ms |
+| yoga_first_layout | 0.00ms | 0.00ms |
+| first_frame_render | 0.00ms | 0.00ms |
+| total | 273ms | 274ms |
+
+## Conclusion
+
+Dominant Sumo-owned cost was full chat-history replay. The fix bulk-hydrates resumed transcripts, keeps only the active 200-message window as retained nodes, represents older history as a virtual archive count, and schedules one render for the resumed transcript.
+
+Remnic memory is not on the synchronous resume hot path in this checkout: sidebar memory refreshes are debounce-triggered and run through `CancellableWorkerRuntime`.
+
+No retained render loop idle wake is covered by `FrameScheduler` tests: after the coalesced resume render drains, no timer remains scheduled.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,8 @@
     "build": "tsc --noEmit",
     "test": "vitest run",
     "test:integration": "vitest run test/integration/",
+    "perf:resume": "vitest run src/sumo-tui/runtime/resume-flow.perf.test.ts",
+    "perf:resume:report": "node scripts/measure-resume-perf.mjs",
     "render:bible": "node scripts/render-bible.mjs",
     "export:bible-static": "node scripts/export-bible-static.mjs",
     "vitest": "vitest",

--- a/scripts/measure-resume-perf.mjs
+++ b/scripts/measure-resume-perf.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { cpus, platform, release } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createJiti } from "@mariozechner/jiti";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+const OUT_PATH = join(ROOT, "docs", "research", "sumo-tui-resume-performance.md");
+const MESSAGE_COUNT = Number.parseInt(process.env.SUMO_TUI_RESUME_PERF_MESSAGES ?? "10000", 10);
+const ITERATIONS = Number.parseInt(process.env.SUMO_TUI_RESUME_PERF_ITERATIONS ?? "30", 10);
+const LEGACY_MESSAGE_COUNT = Number.parseInt(process.env.SUMO_TUI_RESUME_LEGACY_MESSAGES ?? "2000", 10);
+const LEGACY_ITERATIONS = Number.parseInt(process.env.SUMO_TUI_RESUME_LEGACY_ITERATIONS ?? "5", 10);
+const WIDTH = 160;
+const HEIGHT = 45;
+
+const jiti = createJiti(import.meta.url, {
+	moduleCache: false,
+	tryNative: false,
+});
+
+function formatMs(value) {
+	return `${value.toFixed(value >= 100 ? 0 : 2)}ms`;
+}
+
+function syntheticMessages(count) {
+	return Array.from({ length: count }, (_, index) => ({
+		id: `message-${index}`,
+		role: index % 2 === 0 ? "user" : "assistant",
+		content: `resume message ${index}: hydrate enough text to exercise wrapping, transcript parsing, and retained node creation.`,
+	}));
+}
+
+async function loadModules() {
+	const [
+		{ SumoNode },
+		{ DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga },
+		{ CellBuffer },
+		{ composite },
+		{ transcriptFromSessionContext },
+		{ ChatPager },
+		{ ResumeProfiler, summarizeResumeProfiles },
+	] = await Promise.all([
+		jiti.import(join(ROOT, "src", "sumo-tui", "layout", "node.ts")),
+		jiti.import(join(ROOT, "src", "sumo-tui", "layout", "yoga.ts")),
+		jiti.import(join(ROOT, "src", "sumo-tui", "render", "buffer.ts")),
+		jiti.import(join(ROOT, "src", "sumo-tui", "render", "compositor.ts")),
+		jiti.import(join(ROOT, "src", "sumo-tui", "transcript", "view-model.ts")),
+		jiti.import(join(ROOT, "src", "sumo-tui", "widgets", "chat-pager.ts")),
+		jiti.import(join(ROOT, "src", "sumo-tui", "runtime", "resume-profiler.ts")),
+	]);
+	return { SumoNode, DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga, CellBuffer, composite, transcriptFromSessionContext, ChatPager, ResumeProfiler, summarizeResumeProfiles };
+}
+
+function createChat(modules, yoga) {
+	const root = new modules.SumoNode(yoga.Node.create());
+	root.width = WIDTH;
+	root.height = HEIGHT;
+	root.flexDirection = modules.FLEX_DIRECTION_COLUMN;
+	const chat = modules.ChatPager.create(yoga, root, {
+		renderControls: {
+			scheduleRender() {},
+			setStreamingMode() {},
+		},
+	});
+	return { root, chat };
+}
+
+async function measureBulk(modules, yoga, messages) {
+	const { root, chat } = createChat(modules, yoga);
+	const profiler = new modules.ResumeProfiler();
+	try {
+		const rawMessages = profiler.measure("session_scan", () => messages);
+		const transcript = profiler.measure("transcript_model", () => modules.transcriptFromSessionContext({ messages: rawMessages }));
+		const stats = profiler.measure("transcript_hydrate", () => chat.replaceViewModels(transcript.messages));
+		profiler.measure("yoga_first_layout", () => root.yogaNode.calculateLayout(WIDTH, HEIGHT, modules.DIRECTION_LTR));
+		profiler.measure("first_frame_render", () => modules.composite(root, new modules.CellBuffer(HEIGHT, WIDTH)));
+		return profiler.finish({
+			sourceMessages: messages.length,
+			acceptedMessages: stats.acceptedMessages,
+			renderedMessages: stats.renderedMessages,
+			archivedMessages: stats.archivedMessages,
+		});
+	} finally {
+		root.dispose();
+	}
+}
+
+async function measureIncrementalHydrate(modules, yoga, messages) {
+	const { root, chat } = createChat(modules, yoga);
+	const profiler = new modules.ResumeProfiler();
+	try {
+		const transcript = modules.transcriptFromSessionContext({ messages });
+		const stats = profiler.measure("transcript_hydrate", () => {
+			for (const message of transcript.messages) chat.addViewModel(message);
+			return {
+				acceptedMessages: transcript.messages.length,
+				renderedMessages: chat.getRenderedMessages().length,
+				archivedMessages: chat.getArchivedMessageCount(),
+			};
+		});
+		return profiler.finish({
+			sourceMessages: messages.length,
+			acceptedMessages: stats.acceptedMessages,
+			renderedMessages: stats.renderedMessages,
+			archivedMessages: stats.archivedMessages,
+		});
+	} finally {
+		root.dispose();
+	}
+}
+
+function stageTable(summary) {
+	const rows = [
+		["session_scan", summary.stages.session_scan],
+		["transcript_model", summary.stages.transcript_model],
+		["transcript_hydrate", summary.stages.transcript_hydrate],
+		["yoga_first_layout", summary.stages.yoga_first_layout],
+		["first_frame_render", summary.stages.first_frame_render],
+		["total", summary.total],
+	];
+	return [
+		"| Stage | p50 | p95 |",
+		"|---|---:|---:|",
+		...rows.map(([stage, value]) => `| ${stage} | ${formatMs(value.p50Ms)} | ${formatMs(value.p95Ms)} |`),
+	].join("\n");
+}
+
+function machineLabel() {
+	const require = createRequire(import.meta.url);
+	const packageJson = require(join(ROOT, "package.json"));
+	const cpu = cpus()[0]?.model ?? "unknown CPU";
+	return `${platform()} ${release()}, Node ${process.version}, ${packageJson.name}@${packageJson.version}, ${cpu}`;
+}
+
+async function main() {
+	const modules = await loadModules();
+	const yoga = await modules.loadYoga();
+	const bulkMessages = syntheticMessages(MESSAGE_COUNT);
+	const legacyMessages = syntheticMessages(LEGACY_MESSAGE_COUNT);
+	const bulkProfiles = [];
+	const legacyProfiles = [];
+
+	for (let index = 0; index < ITERATIONS; index += 1) {
+		bulkProfiles.push(await measureBulk(modules, yoga, bulkMessages));
+	}
+	for (let index = 0; index < LEGACY_ITERATIONS; index += 1) {
+		legacyProfiles.push(await measureIncrementalHydrate(modules, yoga, legacyMessages));
+	}
+
+	const bulkSummary = modules.summarizeResumeProfiles(bulkProfiles);
+	const legacySummary = modules.summarizeResumeProfiles(legacyProfiles);
+	const latest = bulkProfiles[bulkProfiles.length - 1];
+	const generatedAt = new Date().toISOString();
+	const pass = bulkSummary.total.p95Ms < 500 ? "PASS" : "MISS";
+	const markdown = `# SumoTUI Resume Performance
+
+Generated: ${generatedAt}
+
+Machine: ${machineLabel()}
+
+## Current Bulk Resume Path (${MESSAGE_COUNT} messages, ${ITERATIONS} iterations)
+
+Budget: p95 < 500ms. Result: **${pass}** at p95 ${formatMs(bulkSummary.total.p95Ms)}.
+
+${stageTable(bulkSummary)}
+
+Latest retained transcript stats: ${latest?.metadata.acceptedMessages ?? 0} accepted, ${latest?.metadata.renderedMessages ?? 0} rendered nodes, ${latest?.metadata.archivedMessages ?? 0} archived behind the placeholder.
+
+## Legacy Incremental Replay Proxy (${LEGACY_MESSAGE_COUNT} messages, ${LEGACY_ITERATIONS} iterations)
+
+This measures the old Sumo-owned replay shape: add every view model one-by-one, create archived Yoga nodes, and schedule a render per message. It is intentionally capped below 10k so the report stays quick enough for local iteration.
+
+${stageTable(legacySummary)}
+
+## Conclusion
+
+Dominant Sumo-owned cost was full chat-history replay. The fix bulk-hydrates resumed transcripts, keeps only the active ${latest?.metadata.renderedMessages ?? 200}-message window as retained nodes, represents older history as a virtual archive count, and schedules one render for the resumed transcript.
+
+Remnic memory is not on the synchronous resume hot path in this checkout: sidebar memory refreshes are debounce-triggered and run through \`CancellableWorkerRuntime\`.
+
+No retained render loop idle wake is covered by \`FrameScheduler\` tests: after the coalesced resume render drains, no timer remains scheduled.
+`;
+
+	await mkdir(dirname(OUT_PATH), { recursive: true });
+	await writeFile(OUT_PATH, markdown, "utf8");
+	console.log(markdown);
+}
+
+main().catch((error) => {
+	console.error(error);
+	process.exitCode = 1;
+});

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -1,6 +1,7 @@
 import { parseSgrMouseStream, type MouseEvent } from "../input/mouse.js";
 import type { KeyEvent } from "../input/key-router.js";
 import { logDiagnostic } from "../runtime/diagnostics.js";
+import { ResumeProfiler, type ResumeProfileMetadata } from "../runtime/resume-profiler.js";
 import { chatMessageViewModelFromPiMessage, chatMessageViewModelToPlainText, transcriptFromSessionContext, type ChatMessageViewModel } from "../transcript/view-model.js";
 import { ChatPager } from "../widgets/chat-pager.js";
 import { chatScrollCommandFromInput } from "../widgets/chat-scroll-command.js";
@@ -47,6 +48,8 @@ export interface ChatViewportRuntime {
 	noteUserMessage(): void;
 	handleSelectionMouse?(event: MouseEvent, width: number, height: number): boolean;
 	handleSelectionKey?(event: KeyEvent, width: number, height: number): boolean;
+	startResumeProfile?(): ResumeProfiler;
+	completeResumeHydration?(profile: ResumeProfiler, metadata: ResumeProfileMetadata): void;
 }
 
 interface ChatViewportBridgeRuntime extends ChatViewportRuntime {
@@ -279,12 +282,21 @@ export class ChatViewportController {
 	}
 
 	public renderSessionContext(sessionContext: unknown): void {
-		this.clear();
-		const messages = sessionMessages(sessionContext);
+		this.lastAssistantText = "";
+		this.pendingMouseInput = "";
+		const profile = this.runtime.startResumeProfile?.();
+		const measure = <T>(name: Parameters<ResumeProfiler["measure"]>[0], run: () => T): T => profile ? profile.measure(name, run) : run();
+		const messages = measure("session_scan", () => sessionMessages(sessionContext));
 		this.runtime.setEmptyChatQuoteState({ active: messages.length === 0, userMessageCount: countUserMessages(messages) });
-		for (const message of transcriptFromSessionContext(sessionContext).messages) {
-			if (chatMessageViewModelToPlainText(message).length === 0) continue;
-			addViewModel(this.chat, message);
+		const transcript = measure("transcript_model", () => transcriptFromSessionContext(sessionContext));
+		const stats = measure("transcript_hydrate", () => this.chat.replaceViewModels(transcript.messages));
+		if (profile) {
+			this.runtime.completeResumeHydration?.(profile, {
+				sourceMessages: messages.length,
+				acceptedMessages: stats.acceptedMessages,
+				renderedMessages: stats.renderedMessages,
+				archivedMessages: stats.archivedMessages,
+			});
 		}
 	}
 

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -1,7 +1,7 @@
 import { parseSgrMouseStream, type MouseEvent } from "../input/mouse.js";
 import type { KeyEvent } from "../input/key-router.js";
 import { logDiagnostic } from "../runtime/diagnostics.js";
-import { ResumeProfiler, type ResumeProfileMetadata } from "../runtime/resume-profiler.js";
+import { measureMaybe, ResumeProfiler, type ResumeProfileMetadata } from "../runtime/resume-profiler.js";
 import { chatMessageViewModelFromPiMessage, chatMessageViewModelToPlainText, transcriptFromSessionContext, type ChatMessageViewModel } from "../transcript/view-model.js";
 import { ChatPager } from "../widgets/chat-pager.js";
 import { chatScrollCommandFromInput } from "../widgets/chat-scroll-command.js";
@@ -284,12 +284,13 @@ export class ChatViewportController {
 	public renderSessionContext(sessionContext: unknown): void {
 		this.lastAssistantText = "";
 		this.pendingMouseInput = "";
+		// Resume uses bulk transcript replacement instead of `clear()` + per-message
+		// replay; `replaceViewModels()` resets the chat-side scroll/banner state.
 		const profile = this.runtime.startResumeProfile?.();
-		const measure = <T>(name: Parameters<ResumeProfiler["measure"]>[0], run: () => T): T => profile ? profile.measure(name, run) : run();
-		const messages = measure("session_scan", () => sessionMessages(sessionContext));
+		const messages = measureMaybe(profile, "session_scan", () => sessionMessages(sessionContext));
 		this.runtime.setEmptyChatQuoteState({ active: messages.length === 0, userMessageCount: countUserMessages(messages) });
-		const transcript = measure("transcript_model", () => transcriptFromSessionContext(sessionContext));
-		const stats = measure("transcript_hydrate", () => this.chat.replaceViewModels(transcript.messages));
+		const transcript = measureMaybe(profile, "transcript_model", () => transcriptFromSessionContext(sessionContext));
+		const stats = measureMaybe(profile, "transcript_hydrate", () => this.chat.replaceViewModels(transcript.messages));
 		if (profile) {
 			this.runtime.completeResumeHydration?.(profile, {
 				sourceMessages: messages.length,

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import {
 	SumoInteractiveRuntime,
@@ -9,7 +12,7 @@ import {
 	shouldHidePiNoise,
 	type PiNoiseFilterState,
 } from "./sumo-interactive-mode.js";
-import { installChatViewportBridge } from "./chat-viewport-controller.js";
+import { ChatViewportController, installChatViewportBridge } from "./chat-viewport-controller.js";
 import { defaultSplashSnapshot, getSplashContentHeight } from "../cathedral/splash-tree.js";
 import { ALTSCREEN_ENTER_SEQUENCE, MOUSE_SGR_ENABLE_SEQUENCE, TerminalSessionOwner } from "../runtime/terminal-controller.js";
 
@@ -141,6 +144,43 @@ describe("sumo interactive Pi noise filtering", () => {
 
 		expect(second).toEqual(first);
 		runtime.stop();
+	});
+
+	it("emits resume budget diagnostics after session context hydration and first full render", async () => {
+		const previousDiagFile = process.env.SUMO_TUI_DIAG_FILE;
+		const diagFile = join(mkdtempSync(join(tmpdir(), "sumocode-resume-diag-")), "diag.jsonl");
+		process.env.SUMO_TUI_DIAG_FILE = diagFile;
+		const runtime = new SumoInteractiveRuntime({ isTTY: true, columns: 100, rows: 30, write: vi.fn() });
+		try {
+			const snapshot = await runtime.start();
+			const controller = new ChatViewportController(runtime, snapshot.chat, {});
+			controller.renderSessionContext({
+				messages: [
+					{ role: "user", content: "resume prompt" },
+					{ role: "assistant", content: "resume response" },
+				],
+			});
+
+			(runtime as unknown as { render(): void }).render();
+
+			const events = readFileSync(diagFile, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line) as Record<string, unknown>);
+			const resumeEvent = events.find((event) => event.event === "resume_budget");
+			expect(resumeEvent).toMatchObject({
+				event: "resume_budget",
+				pass: true,
+				source_messages: 2,
+				accepted_messages: 2,
+				rendered_messages: 2,
+				archived_messages: 0,
+			});
+			for (const stage of ["session_scan_ms", "transcript_model_ms", "transcript_hydrate_ms", "yoga_first_layout_ms", "first_frame_render_ms"]) {
+				expect(typeof resumeEvent?.[stage]).toBe("number");
+			}
+		} finally {
+			runtime.stop();
+			if (previousDiagFile === undefined) delete process.env.SUMO_TUI_DIAG_FILE;
+			else process.env.SUMO_TUI_DIAG_FILE = previousDiagFile;
+		}
 	});
 
 	it("routes Pi chat rendering and wheel input through ChatPager", async () => {

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -43,6 +43,7 @@ import type { MouseEvent } from "../input/mouse.js";
 import { SelectionController } from "../input/selection.js";
 import { diffFrames } from "../render/diff.js";
 import { FrameScheduler } from "../runtime/frame-scheduler.js";
+import { emitResumeBudgetOverlay, ResumeProfiler, type ResumeProfileMetadata } from "../runtime/resume-profiler.js";
 import { defaultTerminalSessionOwner, TerminalSessionOwner, type TerminalOutput } from "../runtime/terminal-controller.js";
 import { ChatPager } from "../widgets/chat-pager.js";
 import { SIDEBAR_MIN_TERMINAL_WIDTH } from "../../sidebar.js";
@@ -130,6 +131,7 @@ export class SumoInteractiveRuntime {
 	private activeEmptyChat = false;
 	private emptyChatUserMessageCount = 0;
 	private started = false;
+	private pendingResumeProfile: { profile: ResumeProfiler; metadata: ResumeProfileMetadata } | undefined;
 
 	public constructor(output: TerminalLike = process.stdout, terminalSession?: TerminalSessionOwner) {
 		this.output = output;
@@ -203,6 +205,14 @@ export class SumoInteractiveRuntime {
 		return this.selection.handleKey(event, frame);
 	}
 
+	public startResumeProfile(): ResumeProfiler {
+		return new ResumeProfiler();
+	}
+
+	public completeResumeHydration(profile: ResumeProfiler, metadata: ResumeProfileMetadata): void {
+		this.pendingResumeProfile = { profile, metadata };
+	}
+
 	private renderChatFrame(width: number, height: number): { frame: CellBuffer; lines: string[] } {
 		const safeWidth = Math.max(1, Math.floor(width));
 		const safeHeight = Math.max(1, Math.floor(height));
@@ -210,6 +220,7 @@ export class SumoInteractiveRuntime {
 			const empty = new CellBuffer(safeHeight, safeWidth);
 			return { frame: empty, lines: bufferToAnsiLines(empty) };
 		}
+		const root = this.root;
 		const selectionRevision = this.selection.getRevision();
 		const cached = this.chatFrameCache;
 		if (cached && cached.width === safeWidth && cached.height === safeHeight && cached.version === this.frameVersion && cached.selectionRevision === selectionRevision) {
@@ -217,13 +228,27 @@ export class SumoInteractiveRuntime {
 		}
 
 		this.syncChatSlot();
-		this.root.width = safeWidth;
-		this.root.height = safeHeight;
-		this.root.yogaNode.calculateLayout(safeWidth, safeHeight, DIRECTION_LTR);
-		const frame = new CellBuffer(safeHeight, safeWidth);
-		composite(this.root, frame, { selection: this.selection });
-		const lines = bufferToAnsiLines(frame);
+		root.width = safeWidth;
+		root.height = safeHeight;
+		const pendingProfile = this.pendingResumeProfile;
+		if (pendingProfile) {
+			pendingProfile.profile.measure("yoga_first_layout", () => root.yogaNode.calculateLayout(safeWidth, safeHeight, DIRECTION_LTR));
+		} else {
+			root.yogaNode.calculateLayout(safeWidth, safeHeight, DIRECTION_LTR);
+		}
+		const { frame, lines } = pendingProfile
+			? pendingProfile.profile.measure("first_frame_render", () => {
+				const nextFrame = new CellBuffer(safeHeight, safeWidth);
+				composite(root, nextFrame, { selection: this.selection });
+				return { frame: nextFrame, lines: bufferToAnsiLines(nextFrame) };
+			})
+			: (() => {
+				const nextFrame = new CellBuffer(safeHeight, safeWidth);
+				composite(root, nextFrame, { selection: this.selection });
+				return { frame: nextFrame, lines: bufferToAnsiLines(nextFrame) };
+			})();
 		this.chatFrameCache = { width: safeWidth, height: safeHeight, version: this.frameVersion, selectionRevision, frame: frame.clone(), lines };
+		if (pendingProfile) this.finishPendingResumeProfile(pendingProfile);
 		return { frame: frame.clone(), lines: [...lines] };
 	}
 
@@ -243,6 +268,7 @@ export class SumoInteractiveRuntime {
 		this.previousFrame = undefined;
 		this.chatFrameCache = undefined;
 		this.externalRenderControls = undefined;
+		this.pendingResumeProfile = undefined;
 		this.scheduler = undefined;
 		this.chat = undefined;
 		this.splash = undefined;
@@ -314,23 +340,47 @@ export class SumoInteractiveRuntime {
 
 	private render(): void {
 		if (!this.root || !this.output.isTTY) return;
+		const root = this.root;
 		const width = Math.max(1, this.output.columns ?? 80);
 		const height = Math.max(1, this.output.rows ?? 24);
-		if (this.previousFrame && this.renderedVersion === this.frameVersion && this.renderedWidth === width && this.renderedHeight === height && !this.root.yogaNode.isDirty()) {
+		if (this.previousFrame && this.renderedVersion === this.frameVersion && this.renderedWidth === width && this.renderedHeight === height && !root.yogaNode.isDirty()) {
 			return;
 		}
 		this.syncChatSlot();
-		this.root.width = width;
-		this.root.height = height;
-		this.root.yogaNode.calculateLayout(width, height, DIRECTION_LTR);
-		const nextFrame = new CellBuffer(height, width);
-		const result = composite(this.root, nextFrame, { selection: this.selection });
-		const patches = diffFrames(this.previousFrame, nextFrame);
-		this.terminal.writeFramePatches(patches, result.hardwareCursor);
+		root.width = width;
+		root.height = height;
+		const pendingProfile = this.pendingResumeProfile;
+		if (pendingProfile) {
+			pendingProfile.profile.measure("yoga_first_layout", () => root.yogaNode.calculateLayout(width, height, DIRECTION_LTR));
+		} else {
+			root.yogaNode.calculateLayout(width, height, DIRECTION_LTR);
+		}
+		const nextFrame = pendingProfile
+			? pendingProfile.profile.measure("first_frame_render", () => {
+				const frame = new CellBuffer(height, width);
+				const compositeResult = composite(root, frame, { selection: this.selection });
+				const patches = diffFrames(this.previousFrame, frame);
+				this.terminal.writeFramePatches(patches, compositeResult.hardwareCursor);
+				return frame;
+			})
+			: (() => {
+				const frame = new CellBuffer(height, width);
+				const compositeResult = composite(root, frame, { selection: this.selection });
+				const patches = diffFrames(this.previousFrame, frame);
+				this.terminal.writeFramePatches(patches, compositeResult.hardwareCursor);
+				return frame;
+			})();
 		this.previousFrame = nextFrame.clone();
 		this.renderedVersion = this.frameVersion;
 		this.renderedWidth = width;
 		this.renderedHeight = height;
+		if (pendingProfile) this.finishPendingResumeProfile(pendingProfile);
+	}
+
+	private finishPendingResumeProfile(pendingProfile: { profile: ResumeProfiler; metadata: ResumeProfileMetadata }): void {
+		if (this.pendingResumeProfile !== pendingProfile) return;
+		this.pendingResumeProfile = undefined;
+		emitResumeBudgetOverlay(pendingProfile.profile.finish(pendingProfile.metadata));
 	}
 }
 

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -43,7 +43,7 @@ import type { MouseEvent } from "../input/mouse.js";
 import { SelectionController } from "../input/selection.js";
 import { diffFrames } from "../render/diff.js";
 import { FrameScheduler } from "../runtime/frame-scheduler.js";
-import { emitResumeBudgetOverlay, ResumeProfiler, type ResumeProfileMetadata } from "../runtime/resume-profiler.js";
+import { emitResumeBudgetOverlay, measureMaybe, ResumeProfiler, type ResumeProfileMetadata } from "../runtime/resume-profiler.js";
 import { defaultTerminalSessionOwner, TerminalSessionOwner, type TerminalOutput } from "../runtime/terminal-controller.js";
 import { ChatPager } from "../widgets/chat-pager.js";
 import { SIDEBAR_MIN_TERMINAL_WIDTH } from "../../sidebar.js";
@@ -230,23 +230,13 @@ export class SumoInteractiveRuntime {
 		this.syncChatSlot();
 		root.width = safeWidth;
 		root.height = safeHeight;
-		const pendingProfile = this.pendingResumeProfile;
-		if (pendingProfile) {
-			pendingProfile.profile.measure("yoga_first_layout", () => root.yogaNode.calculateLayout(safeWidth, safeHeight, DIRECTION_LTR));
-		} else {
-			root.yogaNode.calculateLayout(safeWidth, safeHeight, DIRECTION_LTR);
-		}
-		const { frame, lines } = pendingProfile
-			? pendingProfile.profile.measure("first_frame_render", () => {
-				const nextFrame = new CellBuffer(safeHeight, safeWidth);
-				composite(root, nextFrame, { selection: this.selection });
-				return { frame: nextFrame, lines: bufferToAnsiLines(nextFrame) };
-			})
-			: (() => {
-				const nextFrame = new CellBuffer(safeHeight, safeWidth);
-				composite(root, nextFrame, { selection: this.selection });
-				return { frame: nextFrame, lines: bufferToAnsiLines(nextFrame) };
-			})();
+		const pendingProfile = this.claimPendingResumeProfile();
+		measureMaybe(pendingProfile?.profile, "yoga_first_layout", () => root.yogaNode.calculateLayout(safeWidth, safeHeight, DIRECTION_LTR));
+		const { frame, lines } = measureMaybe(pendingProfile?.profile, "first_frame_render", () => {
+			const nextFrame = new CellBuffer(safeHeight, safeWidth);
+			composite(root, nextFrame, { selection: this.selection });
+			return { frame: nextFrame, lines: bufferToAnsiLines(nextFrame) };
+		});
 		this.chatFrameCache = { width: safeWidth, height: safeHeight, version: this.frameVersion, selectionRevision, frame: frame.clone(), lines };
 		if (pendingProfile) this.finishPendingResumeProfile(pendingProfile);
 		return { frame: frame.clone(), lines: [...lines] };
@@ -349,27 +339,15 @@ export class SumoInteractiveRuntime {
 		this.syncChatSlot();
 		root.width = width;
 		root.height = height;
-		const pendingProfile = this.pendingResumeProfile;
-		if (pendingProfile) {
-			pendingProfile.profile.measure("yoga_first_layout", () => root.yogaNode.calculateLayout(width, height, DIRECTION_LTR));
-		} else {
-			root.yogaNode.calculateLayout(width, height, DIRECTION_LTR);
-		}
-		const nextFrame = pendingProfile
-			? pendingProfile.profile.measure("first_frame_render", () => {
-				const frame = new CellBuffer(height, width);
-				const compositeResult = composite(root, frame, { selection: this.selection });
-				const patches = diffFrames(this.previousFrame, frame);
-				this.terminal.writeFramePatches(patches, compositeResult.hardwareCursor);
-				return frame;
-			})
-			: (() => {
-				const frame = new CellBuffer(height, width);
-				const compositeResult = composite(root, frame, { selection: this.selection });
-				const patches = diffFrames(this.previousFrame, frame);
-				this.terminal.writeFramePatches(patches, compositeResult.hardwareCursor);
-				return frame;
-			})();
+		const pendingProfile = this.claimPendingResumeProfile();
+		measureMaybe(pendingProfile?.profile, "yoga_first_layout", () => root.yogaNode.calculateLayout(width, height, DIRECTION_LTR));
+		const nextFrame = measureMaybe(pendingProfile?.profile, "first_frame_render", () => {
+			const frame = new CellBuffer(height, width);
+			const compositeResult = composite(root, frame, { selection: this.selection });
+			const patches = diffFrames(this.previousFrame, frame);
+			this.terminal.writeFramePatches(patches, compositeResult.hardwareCursor);
+			return frame;
+		});
 		this.previousFrame = nextFrame.clone();
 		this.renderedVersion = this.frameVersion;
 		this.renderedWidth = width;
@@ -377,9 +355,18 @@ export class SumoInteractiveRuntime {
 		if (pendingProfile) this.finishPendingResumeProfile(pendingProfile);
 	}
 
-	private finishPendingResumeProfile(pendingProfile: { profile: ResumeProfiler; metadata: ResumeProfileMetadata }): void {
-		if (this.pendingResumeProfile !== pendingProfile) return;
+	private claimPendingResumeProfile(): { profile: ResumeProfiler; metadata: ResumeProfileMetadata } | undefined {
+		const pendingProfile = this.pendingResumeProfile;
+		if (!pendingProfile) return undefined;
+		// Resume can paint through the hybrid chat-frame path or the full retained
+		// root path. The first renderer to claim the profile is the user-visible
+		// transition owner; clearing here prevents a later render pass from
+		// appending unreported stages to the same profile.
 		this.pendingResumeProfile = undefined;
+		return pendingProfile;
+	}
+
+	private finishPendingResumeProfile(pendingProfile: { profile: ResumeProfiler; metadata: ResumeProfileMetadata }): void {
 		emitResumeBudgetOverlay(pendingProfile.profile.finish(pendingProfile.metadata));
 	}
 }

--- a/src/sumo-tui/runtime/frame-scheduler.test.ts
+++ b/src/sumo-tui/runtime/frame-scheduler.test.ts
@@ -52,4 +52,20 @@ describe("FrameScheduler", () => {
 		scheduler.dispose();
 		vi.useRealTimers();
 	});
+
+	it("does not wake the retained render loop after an idle resume render", async () => {
+		vi.useFakeTimers();
+		const render = vi.fn();
+		const scheduler = new FrameScheduler({ render });
+
+		scheduler.requestRender();
+		await vi.runAllTimersAsync();
+		await vi.advanceTimersByTimeAsync(1_000);
+
+		expect(render).toHaveBeenCalledTimes(1);
+		expect(scheduler.getQueueDepth()).toBe(0);
+		expect(vi.getTimerCount()).toBe(0);
+		scheduler.dispose();
+		vi.useRealTimers();
+	});
 });

--- a/src/sumo-tui/runtime/resume-flow.perf.test.ts
+++ b/src/sumo-tui/runtime/resume-flow.perf.test.ts
@@ -19,6 +19,8 @@ interface SyntheticPiMessage {
 }
 
 function syntheticMessages(count: number): SyntheticPiMessage[] {
+	// Fixed markdown messages keep the CI budget stable; mixed tool/code/skill
+	// transcripts belong in a future realism benchmark, not this regression gate.
 	return Array.from({ length: count }, (_, index) => ({
 		id: `message-${index}`,
 		role: index % 2 === 0 ? "user" : "assistant",

--- a/src/sumo-tui/runtime/resume-flow.perf.test.ts
+++ b/src/sumo-tui/runtime/resume-flow.perf.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { SumoNode } from "../layout/node.js";
+import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga, type Yoga } from "../layout/yoga.js";
+import { CellBuffer } from "../render/buffer.js";
+import { composite } from "../render/compositor.js";
+import { transcriptFromSessionContext, type ChatMessageViewModel } from "../transcript/view-model.js";
+import { ChatPager } from "../widgets/chat-pager.js";
+import { ResumeProfiler, summarizeResumeProfiles, type ResumeProfile } from "./resume-profiler.js";
+
+const MESSAGE_COUNT = Number.parseInt(process.env.SUMO_TUI_RESUME_PERF_MESSAGES ?? "10000", 10);
+const ITERATIONS = Number.parseInt(process.env.SUMO_TUI_RESUME_PERF_ITERATIONS ?? "8", 10);
+const WIDTH = 160;
+const HEIGHT = 45;
+
+interface SyntheticPiMessage {
+	readonly id: string;
+	readonly role: "user" | "assistant";
+	readonly content: string;
+}
+
+function syntheticMessages(count: number): SyntheticPiMessage[] {
+	return Array.from({ length: count }, (_, index) => ({
+		id: `message-${index}`,
+		role: index % 2 === 0 ? "user" : "assistant",
+		content: `resume message ${index}: hydrate enough text to exercise wrapping, transcript parsing, and retained node creation.`,
+	}));
+}
+
+async function createChat(yoga: Yoga): Promise<{ root: SumoNode; chat: ChatPager }> {
+	const root = new SumoNode(yoga.Node.create());
+	root.width = WIDTH;
+	root.height = HEIGHT;
+	root.flexDirection = FLEX_DIRECTION_COLUMN;
+	return {
+		root,
+		chat: ChatPager.create(yoga, root, {
+			renderControls: {
+				scheduleRender(): void {},
+				setStreamingMode(): void {},
+			},
+		}),
+	};
+}
+
+async function measureResume(yoga: Yoga, messages: readonly SyntheticPiMessage[]): Promise<ResumeProfile> {
+	const { root, chat } = await createChat(yoga);
+	const profiler = new ResumeProfiler();
+	try {
+		const rawMessages = profiler.measure("session_scan", () => messages);
+		const transcript = profiler.measure("transcript_model", () => transcriptFromSessionContext({ messages: rawMessages }));
+		const stats = profiler.measure("transcript_hydrate", () => chat.replaceViewModels(transcript.messages as readonly ChatMessageViewModel[]));
+		profiler.measure("yoga_first_layout", () => root.yogaNode.calculateLayout(WIDTH, HEIGHT, DIRECTION_LTR));
+		profiler.measure("first_frame_render", () => composite(root, new CellBuffer(HEIGHT, WIDTH)));
+		return profiler.finish({
+			sourceMessages: messages.length,
+			acceptedMessages: stats.acceptedMessages,
+			renderedMessages: stats.renderedMessages,
+			archivedMessages: stats.archivedMessages,
+		});
+	} finally {
+		root.dispose();
+	}
+}
+
+describe("resume flow performance", () => {
+	it("keeps 10k-message resume hydration plus first frame under the 500ms p95 budget", async () => {
+		const yoga = await loadYoga();
+		const messages = syntheticMessages(MESSAGE_COUNT);
+		const profiles: ResumeProfile[] = [];
+
+		for (let index = 0; index < ITERATIONS; index += 1) {
+			profiles.push(await measureResume(yoga, messages));
+		}
+
+		const summary = summarizeResumeProfiles(profiles);
+		expect(summary.total.p95Ms, `resume p95=${summary.total.p95Ms}ms, stages=${JSON.stringify(summary.stages)}`).toBeLessThan(500);
+		expect(Math.max(...profiles.map((profile) => profile.metadata.renderedMessages ?? 0))).toBeLessThanOrEqual(200);
+	});
+});

--- a/src/sumo-tui/runtime/resume-profiler.test.ts
+++ b/src/sumo-tui/runtime/resume-profiler.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { formatResumeBudgetOverlay, ResumeProfiler, summarizeResumeProfiles } from "./resume-profiler.js";
+
+describe("ResumeProfiler", () => {
+	it("records stage timings and formats the debug budget overlay", () => {
+		let now = 0;
+		const profiler = new ResumeProfiler(() => now);
+
+		profiler.measure("session_scan", () => {
+			now += 5;
+		});
+		profiler.measure("transcript_hydrate", () => {
+			now += 12;
+		});
+		now += 3;
+		const profile = profiler.finish({ sourceMessages: 1000, renderedMessages: 200, archivedMessages: 800 });
+
+		expect(profile.totalMs).toBe(20);
+		expect(profile.pass).toBe(true);
+		expect(formatResumeBudgetOverlay(profile)).toContain("resume-budget overlay: total=20.00ms budget=500ms PASS messages=1000 rendered=200 archived=800");
+		expect(formatResumeBudgetOverlay(profile)).toContain("session_scan=5.00ms");
+	});
+
+	it("summarizes p50 and p95 across resume profiles", () => {
+		const profiles = [10, 20, 30, 40].map((duration) => ({
+			totalMs: duration,
+			budgetMs: 500,
+			pass: true,
+			metadata: {},
+			stages: [{ name: "first_frame_render" as const, durationMs: duration / 2 }],
+		}));
+
+		const summary = summarizeResumeProfiles(profiles);
+
+		expect(summary.total).toEqual({ p50Ms: 20, p95Ms: 40 });
+		expect(summary.stages.first_frame_render).toEqual({ p50Ms: 10, p95Ms: 20 });
+	});
+});

--- a/src/sumo-tui/runtime/resume-profiler.ts
+++ b/src/sumo-tui/runtime/resume-profiler.ts
@@ -55,6 +55,7 @@ function formatMs(value: number): string {
 }
 
 function percentile(values: readonly number[], percentileValue: number): number {
+	// Nearest-rank percentile: ceil((p/100) * n) - 1, indexed into the sorted array.
 	if (values.length === 0) return 0;
 	const sorted = [...values].sort((left, right) => left - right);
 	const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil((percentileValue / 100) * sorted.length) - 1));
@@ -95,6 +96,10 @@ export class ResumeProfiler {
 			metadata,
 		};
 	}
+}
+
+export function measureMaybe<T>(profile: ResumeProfiler | undefined, name: ResumeStageName, run: () => T): T {
+	return profile ? profile.measure(name, run) : run();
 }
 
 export function summarizeResumeProfiles(profiles: readonly ResumeProfile[]): ResumeProfileSummary {

--- a/src/sumo-tui/runtime/resume-profiler.ts
+++ b/src/sumo-tui/runtime/resume-profiler.ts
@@ -1,0 +1,136 @@
+import { performance } from "node:perf_hooks";
+import { logDiagnostic } from "./diagnostics.js";
+
+export const RESUME_BUDGET_MS = 500;
+
+export type ResumeStageName =
+	| "session_scan"
+	| "transcript_model"
+	| "transcript_hydrate"
+	| "yoga_first_layout"
+	| "first_frame_render";
+
+export interface ResumeStageTiming {
+	readonly name: ResumeStageName;
+	readonly durationMs: number;
+}
+
+export interface ResumeProfileMetadata {
+	readonly sourceMessages?: number;
+	readonly acceptedMessages?: number;
+	readonly renderedMessages?: number;
+	readonly archivedMessages?: number;
+}
+
+export interface ResumeProfile {
+	readonly totalMs: number;
+	readonly budgetMs: number;
+	readonly pass: boolean;
+	readonly stages: readonly ResumeStageTiming[];
+	readonly metadata: ResumeProfileMetadata;
+}
+
+export interface ResumeProfileSummary {
+	readonly total: PercentileSummary;
+	readonly stages: Record<ResumeStageName, PercentileSummary>;
+}
+
+export interface PercentileSummary {
+	readonly p50Ms: number;
+	readonly p95Ms: number;
+}
+
+export type ResumeClock = () => number;
+
+function defaultClock(): number {
+	return performance.now();
+}
+
+function roundMs(value: number): number {
+	return Math.round(value * 100) / 100;
+}
+
+function formatMs(value: number): string {
+	return `${value.toFixed(value >= 100 ? 0 : 2)}ms`;
+}
+
+function percentile(values: readonly number[], percentileValue: number): number {
+	if (values.length === 0) return 0;
+	const sorted = [...values].sort((left, right) => left - right);
+	const index = Math.min(sorted.length - 1, Math.max(0, Math.ceil((percentileValue / 100) * sorted.length) - 1));
+	return sorted[index] ?? 0;
+}
+
+function summarize(values: readonly number[]): PercentileSummary {
+	return {
+		p50Ms: roundMs(percentile(values, 50)),
+		p95Ms: roundMs(percentile(values, 95)),
+	};
+}
+
+export class ResumeProfiler {
+	private readonly startedAt: number;
+	private readonly stageTimings: ResumeStageTiming[] = [];
+
+	public constructor(private readonly clock: ResumeClock = defaultClock) {
+		this.startedAt = this.clock();
+	}
+
+	public measure<T>(name: ResumeStageName, run: () => T): T {
+		const startedAt = this.clock();
+		try {
+			return run();
+		} finally {
+			this.stageTimings.push({ name, durationMs: roundMs(this.clock() - startedAt) });
+		}
+	}
+
+	public finish(metadata: ResumeProfileMetadata = {}): ResumeProfile {
+		const totalMs = roundMs(this.clock() - this.startedAt);
+		return {
+			totalMs,
+			budgetMs: RESUME_BUDGET_MS,
+			pass: totalMs <= RESUME_BUDGET_MS,
+			stages: [...this.stageTimings],
+			metadata,
+		};
+	}
+}
+
+export function summarizeResumeProfiles(profiles: readonly ResumeProfile[]): ResumeProfileSummary {
+	const stageNames: readonly ResumeStageName[] = ["session_scan", "transcript_model", "transcript_hydrate", "yoga_first_layout", "first_frame_render"];
+	const stages = Object.fromEntries(stageNames.map((name) => {
+		const values = profiles.flatMap((profile) => profile.stages.filter((stage) => stage.name === name).map((stage) => stage.durationMs));
+		return [name, summarize(values)];
+	})) as Record<ResumeStageName, PercentileSummary>;
+	return {
+		total: summarize(profiles.map((profile) => profile.totalMs)),
+		stages,
+	};
+}
+
+export function formatResumeBudgetOverlay(profile: ResumeProfile): string {
+	const status = profile.pass ? "PASS" : "MISS";
+	const stages = profile.stages.map((stage) => `${stage.name}=${formatMs(stage.durationMs)}`).join(" ");
+	const messages = profile.metadata.sourceMessages === undefined
+		? ""
+		: ` messages=${profile.metadata.sourceMessages} rendered=${profile.metadata.renderedMessages ?? "?"} archived=${profile.metadata.archivedMessages ?? "?"}`;
+	return `resume-budget overlay: total=${formatMs(profile.totalMs)} budget=${formatMs(profile.budgetMs)} ${status}${messages} | ${stages}`;
+}
+
+export function emitResumeBudgetOverlay(profile: ResumeProfile): void {
+	const stageFields = Object.fromEntries(profile.stages.map((stage) => [`${stage.name}_ms`, stage.durationMs]));
+	logDiagnostic("resume_budget", {
+		total_ms: profile.totalMs,
+		budget_ms: profile.budgetMs,
+		pass: profile.pass,
+		source_messages: profile.metadata.sourceMessages,
+		accepted_messages: profile.metadata.acceptedMessages,
+		rendered_messages: profile.metadata.renderedMessages,
+		archived_messages: profile.metadata.archivedMessages,
+		...stageFields,
+	});
+	if (process.env.SUMO_TUI_DEBUG === "1") {
+		console.error(`[sumo-tui] ${formatResumeBudgetOverlay(profile)}`);
+	}
+}

--- a/src/sumo-tui/widgets/chat-pager.test.ts
+++ b/src/sumo-tui/widgets/chat-pager.test.ts
@@ -77,9 +77,36 @@ describe("ChatPager", () => {
 		for (let index = 0; index < 5000; index += 1) chat.addMessage("sumo", `message ${index}`);
 
 		expect(chat.archivedMessages).toHaveLength(4800);
+		expect(chat.getArchivedMessageCount()).toBe(4800);
 		expect(chat.getRenderedMessages()).toHaveLength(200);
 		expect(chat.scrollBox.children).toHaveLength(201);
 		expect(chat.scrollBox.children[0]).toMatchObject({ text: "── 4800 earlier messages ──" });
+		root.dispose();
+	});
+
+	it("bulk hydrates resumed transcripts with one render and no archived Yoga nodes", async () => {
+		const controls: ChatPagerRenderControls = { scheduleRender: vi.fn(), setStreamingMode: vi.fn() };
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const chat = ChatPager.create(yoga, root, { maxRenderedMessages: 50, renderControls: controls });
+		const messages = Array.from({ length: 5000 }, (_, index) => ({
+			id: `message-${index}`,
+			role: "sumo" as const,
+			displayName: "SUMO",
+			blocks: [{ type: "markdown" as const, text: `message ${index}` }],
+		}));
+
+		const stats = chat.replaceViewModels(messages);
+
+		expect(stats).toEqual({ sourceMessages: 5000, acceptedMessages: 5000, renderedMessages: 50, archivedMessages: 4950 });
+		expect(chat.archivedMessages).toHaveLength(0);
+		expect(chat.getArchivedMessageCount()).toBe(4950);
+		expect(chat.getRenderedMessages()).toHaveLength(50);
+		expect(chat.getRenderedMessages()[0]?.text).toBe("message 4950");
+		expect(chat.getRenderedMessages().at(-1)?.text).toBe("message 4999");
+		expect(chat.scrollBox.children).toHaveLength(51);
+		expect(chat.scrollBox.children[0]).toMatchObject({ text: "── 4950 earlier messages ──" });
+		expect(controls.scheduleRender).toHaveBeenCalledTimes(1);
 		root.dispose();
 	});
 

--- a/src/sumo-tui/widgets/chat-pager.test.ts
+++ b/src/sumo-tui/widgets/chat-pager.test.ts
@@ -110,6 +110,26 @@ describe("ChatPager", () => {
 		root.dispose();
 	});
 
+	it("can bulk replace resumed transcripts repeatedly after detaching old Yoga nodes", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const chat = ChatPager.create(yoga, root, { maxRenderedMessages: 3 });
+		const messages = (prefix: string) => Array.from({ length: 6 }, (_, index) => ({
+			id: `${prefix}-${index}`,
+			role: "sumo" as const,
+			displayName: "SUMO",
+			blocks: [{ type: "markdown" as const, text: `${prefix} message ${index}` }],
+		}));
+
+		chat.replaceViewModels(messages("first"));
+		chat.replaceViewModels(messages("second"));
+
+		expect(chat.getArchivedMessageCount()).toBe(3);
+		expect(chat.getRenderedMessages().map((message) => message.text)).toEqual(["second message 3", "second message 4", "second message 5"]);
+		expect(chat.scrollBox.children[0]).toMatchObject({ text: "── 3 earlier messages ──" });
+		root.dispose();
+	});
+
 	it("streaming while scrolled up preserves the visible position (EC-2.5)", async () => {
 		const { root, chat, buffer } = await makeChat(36, 5);
 		for (let index = 0; index < 12; index += 1) chat.addMessage("sumo", `message ${index}`);

--- a/src/sumo-tui/widgets/chat-pager.ts
+++ b/src/sumo-tui/widgets/chat-pager.ts
@@ -19,6 +19,13 @@ export interface ChatPagerOptions {
 	readonly primaryAgentName?: string;
 }
 
+export interface ChatPagerReplaceStats {
+	readonly sourceMessages: number;
+	readonly acceptedMessages: number;
+	readonly renderedMessages: number;
+	readonly archivedMessages: number;
+}
+
 const DEFAULT_MAX_RENDERED_MESSAGES = 200;
 
 function noop(): void {}
@@ -27,6 +34,22 @@ function chatRoleFromViewModel(message: ChatMessageViewModel): ChatMessageRole {
 	const onlyToolBlocks = message.blocks.length > 0 && message.blocks.every((block) => block.type === "tool");
 	if (onlyToolBlocks) return "tool";
 	return message.role;
+}
+
+interface PreparedChatMessage {
+	readonly role: ChatMessageRole;
+	readonly text: string;
+	readonly timestamp?: Date;
+	readonly blocks: readonly ChatMessageViewModel["blocks"][number][];
+}
+
+function prepareChatMessage(message: ChatMessageViewModel): PreparedChatMessage {
+	return {
+		role: chatRoleFromViewModel(message),
+		text: chatMessageViewModelToPlainText(message),
+		timestamp: message.timestamp,
+		blocks: message.blocks,
+	};
 }
 
 /** Stateful chat scrollback wrapper: messages + ScrollBox + unread banner. */
@@ -40,6 +63,7 @@ export class ChatPager extends SumoNode {
 	private readonly chatMessageOptions: ChatMessageOptions;
 	private readonly activeMessages: ChatMessage[] = [];
 	private placeholder: ChatMessage | undefined;
+	private virtualArchivedCount = 0;
 	private unreadCount = 0;
 	private lastReadIndex = -1;
 	private previousManualScroll = false;
@@ -73,16 +97,49 @@ export class ChatPager extends SumoNode {
 	}
 
 	public addViewModel(message: ChatMessageViewModel): ChatMessage {
-		const role = chatRoleFromViewModel(message);
-		return this.addChatMessage(ChatMessage.create(
-			this.yoga,
-			role,
-			chatMessageViewModelToPlainText(message),
-			undefined,
-			message.timestamp,
-			message.blocks,
-			this.chatMessageOptions,
-		));
+		return this.addPreparedMessage(prepareChatMessage(message));
+	}
+
+	public replaceViewModels(messages: readonly ChatMessageViewModel[]): ChatPagerReplaceStats {
+		const previousHeight = this.scrollBox.scrollHeight;
+		const width = this.scrollBox.getComputedWidth();
+		const renderedWindow: PreparedChatMessage[] = [];
+		let acceptedMessages = 0;
+		for (const message of messages) {
+			const prepared = prepareChatMessage(message);
+			if (prepared.text.length === 0) continue;
+			const windowSlot = acceptedMessages % this.maxRenderedMessages;
+			acceptedMessages += 1;
+			if (renderedWindow.length < this.maxRenderedMessages) renderedWindow.push(prepared);
+			else renderedWindow[windowSlot] = prepared;
+		}
+		const windowStart = acceptedMessages > renderedWindow.length ? acceptedMessages % this.maxRenderedMessages : 0;
+		const orderedWindow = windowStart === 0 ? renderedWindow : [...renderedWindow.slice(windowStart), ...renderedWindow.slice(0, windowStart)];
+		this.disposeMessageNodes();
+		this.activeMessages.length = 0;
+		this.archivedMessages = [];
+		this.virtualArchivedCount = Math.max(0, acceptedMessages - renderedWindow.length);
+		this.placeholder = undefined;
+		this.unreadCount = 0;
+		this.previousManualScroll = false;
+		this.scrollBox.manualScroll = false;
+
+		for (const message of orderedWindow) {
+			this.activeMessages.push(this.createChatMessage(message));
+		}
+		if (this.virtualArchivedCount > 0) {
+			this.placeholder = this.createPlaceholder();
+		}
+		this.rebuildRenderedChildren();
+		this.lastReadIndex = this.getTotalMessageCount() - 1;
+		this.scrollBox.notifyContentChanged(this.getRenderedEstimatedHeight(width), previousHeight);
+		this.scheduleRender();
+		return {
+			sourceMessages: messages.length,
+			acceptedMessages,
+			renderedMessages: this.activeMessages.length,
+			archivedMessages: this.getArchivedMessageCount(),
+		};
 	}
 
 	public appendToLast(chunk: string): void {
@@ -142,13 +199,15 @@ export class ChatPager extends SumoNode {
 
 	public clearMessages(): void {
 		const previousHeight = this.scrollBox.scrollHeight;
-		for (const child of [...this.scrollBox.children]) this.scrollBox.removeChild(child);
+		this.disposeMessageNodes();
 		this.activeMessages.length = 0;
 		this.archivedMessages = [];
+		this.virtualArchivedCount = 0;
 		this.placeholder = undefined;
 		this.unreadCount = 0;
 		this.lastReadIndex = -1;
 		this.previousManualScroll = false;
+		this.scrollBox.manualScroll = false;
 		this.scrollBox.notifyContentChanged(0, previousHeight);
 		this.scheduleRender();
 	}
@@ -163,6 +222,10 @@ export class ChatPager extends SumoNode {
 
 	public getUnreadCount(): number {
 		return this.unreadCount;
+	}
+
+	public getArchivedMessageCount(): number {
+		return this.virtualArchivedCount + this.archivedMessages.length;
 	}
 
 	public getLastReadIndex(): number {
@@ -191,6 +254,22 @@ export class ChatPager extends SumoNode {
 		this.scrollBox.notifyContentChanged(addedLines + virtualized.addedLines, virtualized.removedLines);
 		this.scheduleRender();
 		return message;
+	}
+
+	private addPreparedMessage(message: PreparedChatMessage): ChatMessage {
+		return this.addChatMessage(this.createChatMessage(message));
+	}
+
+	private createChatMessage(message: PreparedChatMessage): ChatMessage {
+		return ChatMessage.create(
+			this.yoga,
+			message.role,
+			message.text,
+			undefined,
+			message.timestamp,
+			message.blocks,
+			this.chatMessageOptions,
+		);
 	}
 
 	private updateLast(message: ChatMessage, update: () => void): void {
@@ -236,10 +315,10 @@ export class ChatPager extends SumoNode {
 			archivedAny = true;
 		}
 
-		if (this.archivedMessages.length === 0) return { addedLines, removedLines };
-		const placeholderText = `── ${this.archivedMessages.length} earlier messages ──`;
+		if (this.getArchivedMessageCount() === 0) return { addedLines, removedLines };
+		const placeholderText = this.placeholderText();
 		if (!this.placeholder) {
-			this.placeholder = ChatMessage.create(this.yoga, "system", placeholderText, undefined, undefined, undefined, this.chatMessageOptions);
+			this.placeholder = this.createPlaceholder();
 			addedLines += this.placeholder.getEstimatedHeight(width);
 			this.rebuildRenderedChildren();
 		} else if (this.placeholder.text !== placeholderText) {
@@ -247,6 +326,27 @@ export class ChatPager extends SumoNode {
 		}
 		if (archivedAny && this.placeholder.parent !== this.scrollBox) this.rebuildRenderedChildren();
 		return { addedLines, removedLines };
+	}
+
+	private createPlaceholder(): ChatMessage {
+		return ChatMessage.create(this.yoga, "system", this.placeholderText(), undefined, undefined, undefined, this.chatMessageOptions);
+	}
+
+	private placeholderText(): string {
+		return `── ${this.getArchivedMessageCount()} earlier messages ──`;
+	}
+
+	private getRenderedEstimatedHeight(width: number): number {
+		let height = this.placeholder ? this.placeholder.getEstimatedHeight(width) : 0;
+		for (const message of this.activeMessages) height += message.getEstimatedHeight(width);
+		return height;
+	}
+
+	private disposeMessageNodes(): void {
+		const nodes = new Set<ChatMessage>([...this.activeMessages, ...this.archivedMessages]);
+		if (this.placeholder) nodes.add(this.placeholder);
+		for (const node of nodes) node.dispose();
+		for (const child of [...this.scrollBox.children]) this.scrollBox.removeChild(child);
 	}
 
 	private rebuildRenderedChildren(): void {
@@ -267,7 +367,7 @@ export class ChatPager extends SumoNode {
 	}
 
 	private getTotalMessageCount(): number {
-		return this.archivedMessages.length + this.activeMessages.length;
+		return this.getArchivedMessageCount() + this.activeMessages.length;
 	}
 
 	private getLastVisibleMessageIndex(): number {
@@ -277,14 +377,14 @@ export class ChatPager extends SumoNode {
 		const viewportBottom = viewportTop + this.scrollBox.viewportHeight;
 		let last = -1;
 		if (this.placeholder && this.placeholder.parent === this.scrollBox && this.nodeIntersectsViewport(this.placeholder, viewportTop, viewportBottom)) {
-			last = Math.max(last, this.archivedMessages.length - 1);
+			last = Math.max(last, this.getArchivedMessageCount() - 1);
 		}
 		for (let index = 0; index < this.activeMessages.length; index += 1) {
 			const message = this.activeMessages[index];
-			if (message && this.nodeIntersectsViewport(message, viewportTop, viewportBottom)) last = this.archivedMessages.length + index;
+			if (message && this.nodeIntersectsViewport(message, viewportTop, viewportBottom)) last = this.getArchivedMessageCount() + index;
 		}
 		if (last !== -1) return last;
-		return this.scrollBox.isAtBottom() ? total - 1 : Math.min(total - 1, this.archivedMessages.length);
+		return this.scrollBox.isAtBottom() ? total - 1 : Math.min(total - 1, this.getArchivedMessageCount());
 	}
 
 	private nodeIntersectsViewport(node: ChatMessage, viewportTop: number, viewportBottom: number): boolean {

--- a/src/sumo-tui/widgets/chat-pager.ts
+++ b/src/sumo-tui/widgets/chat-pager.ts
@@ -345,8 +345,8 @@ export class ChatPager extends SumoNode {
 	private disposeMessageNodes(): void {
 		const nodes = new Set<ChatMessage>([...this.activeMessages, ...this.archivedMessages]);
 		if (this.placeholder) nodes.add(this.placeholder);
-		for (const node of nodes) node.dispose();
 		for (const child of [...this.scrollBox.children]) this.scrollBox.removeChild(child);
+		for (const node of nodes) node.dispose();
 	}
 
 	private rebuildRenderedChildren(): void {


### PR DESCRIPTION
## Summary

Fixes #143.

This optimizes the SumoTUI resume path by replacing per-message transcript replay with bulk transcript hydration. The retained chat pager now keeps only the active rendered window as Yoga/render nodes, represents older resumed history as a virtual archive count, and schedules one render for the hydrated transcript.

## Root Cause

The Sumo-owned resume path rebuilt history by calling `addViewModel` for every message. That created archived `ChatMessage`/Yoga nodes for old history and scheduled render invalidations per message, so large sessions scaled with full transcript size instead of the visible retained window.

## Changes

- Added `ChatPager.replaceViewModels()` with fixed-size ring-buffer hydration for resumed transcripts.
- Wired `renderSessionContext()` through the bulk path and added resume-stage profiling.
- Added `SUMO_TUI_DEBUG=1` resume budget output and `resume_budget` diagnostics.
- Added `pnpm perf:resume`, `pnpm perf:resume:report`, a committed research profile, and a GitHub Actions perf workflow.
- Added regression/perf tests for 10k-message resume hydration, idle render-loop wakeups, and debug-profile formatting.

## Evidence

Local profile in `docs/research/sumo-tui-resume-performance.md`:

- 10k-message bulk resume path: p95 `29.06ms`, budget `<500ms`.
- Legacy incremental replay proxy: 2k-message p95 `274ms`, confirming history replay was the dominant Sumo-owned cost.
- Latest retained transcript stats: `10000` accepted, `200` rendered nodes, `9800` virtual archived.

Verification run locally:

- `pnpm exec tsc --noEmit`
- `pnpm build`
- `pnpm test` (`82` files, `510` tests)
- `pnpm test:integration` (`13` files, `18` tests)
- `pnpm perf:resume`
- `pnpm visual:ci` (`12` scenarios; expected review/pass statuses)
- `git diff --check`
- node-pty real Pi smoke with `SUMO_TUI_DEBUG=1`, synthetic resumed session, and `SUMO_TUI_DIAG_FILE`; observed `resume-budget overlay: total=33.32ms ... PASS` and a `resume_budget` diagnostic event.
