### PR TITLE
feat(ui): scroll/scribe delegation renderer (Element 12)

### DIFF
--- a/docs/visual/parity/scenarios.json
+++ b/docs/visual/parity/scenarios.json
@@ -750,6 +750,31 @@
 			]
 		},
 		{
+			"id": "fixture-scroll-scribe-landscape",
+			"lane": "fixture",
+			"status": "review",
+			"dimensions": {
+				"cols": 160,
+				"rows": 45
+			},
+			"bibleTarget": "scene-active-scroll-scribe.png",
+			"fixture": {
+				"id": "scroll-scribe"
+			},
+			"crops": [
+				{
+					"id": "full",
+					"targetCrop": "full",
+					"runtimeCrop": "full"
+				},
+				{
+					"id": "chat-area",
+					"targetCrop": "chat-area",
+					"runtimeCrop": "chat-area"
+				}
+			]
+		},
+		{
 			"id": "fixture-skill-pill-landscape",
 			"lane": "fixture",
 			"status": "review",

--- a/scripts/visual-v2/fixture-capture.mjs
+++ b/scripts/visual-v2/fixture-capture.mjs
@@ -102,6 +102,47 @@ const FIXTURES = {
 			],
 		},
 	},
+	"scroll-scribe": {
+		transcript: {
+			messages: [
+				{
+					id: "u1",
+					role: "user",
+					displayName: "USER",
+					timestamp: FIXTURE_TIMES.userOne,
+					blocks: [{ type: "markdown", text: "refactor the auth flow into smaller modules" }],
+				},
+				{
+					id: "s1",
+					role: "sumo",
+					displayName: "SUMO",
+					timestamp: FIXTURE_TIMES.sumoOne,
+					blocks: [
+						{ type: "markdown", text: "Dispatching a scribe to handle the refactor." },
+						{
+							type: "delegation",
+							delegation: {
+								title: "refactor auth flow into smaller modules",
+								agent: "scribe",
+								status: "running",
+								model: "gpt-5.5",
+								thinking: "medium",
+								nestedTools: [
+									{ name: "read", status: "success", input: { path: "src/auth.ts" } },
+									{ name: "edit", status: "success", input: { path: "src/auth.ts" } },
+									{ name: "edit", status: "success", input: { path: "src/auth-helpers.ts" } },
+									{ name: "bash", status: "running", input: { command: "pnpm test src/auth" } },
+								],
+								tokensIn: 8000,
+								tokensOut: 3000,
+								elapsedMs: 22000,
+							},
+						},
+					],
+				},
+			],
+		},
+	},
 	"skill-pill": {
 		transcript: {
 			messages: [

--- a/src/sumo-tui/transcript/scroll-renderer.test.ts
+++ b/src/sumo-tui/transcript/scroll-renderer.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { renderScrollBlock } from "./scroll-renderer.js";
+import type { DelegationViewModel } from "./view-model.js";
+
+const ANSI = /\u001b\[[0-9;]*m/g;
+const stripAnsi = (s: string): string => s.replace(ANSI, "");
+
+function delegation(overrides: Partial<DelegationViewModel> = {}): DelegationViewModel {
+	return {
+		title: "refactor auth flow into smaller modules",
+		agent: "scribe",
+		status: "running",
+		model: "gpt-5.5",
+		thinking: "medium",
+		nestedTools: [
+			{ name: "read", status: "success", input: { path: "src/auth.ts" } },
+			{ name: "edit", status: "success", input: { path: "src/auth.ts" } },
+			{ name: "bash", status: "running", input: { command: "pnpm test src/auth" } },
+		],
+		tokensIn: 8000,
+		tokensOut: 3000,
+		elapsedMs: 22000,
+		...overrides,
+	};
+}
+
+describe("scroll/scribe renderer", () => {
+	it("renders a scroll header with [scroll] tag and status", () => {
+		const rows = renderScrollBlock(delegation(), 130).map(stripAnsi);
+		expect(rows[0]).toContain("[scroll]");
+		expect(rows[0]).toContain("refactor auth flow");
+		expect(rows[0]).toContain("▶");
+		expect(rows[0]).toContain("running");
+	});
+
+	it("renders scribe header with agent, model, and thinking", () => {
+		const rows = renderScrollBlock(delegation(), 130).map(stripAnsi);
+		const header = rows.find((r) => r.includes("scribe"));
+		expect(header).toContain("scribe · gpt-5.5 · medium");
+		expect(header).toContain("┌");
+	});
+
+	it("renders nested tool calls as compact pills", () => {
+		const rows = renderScrollBlock(delegation(), 130).map(stripAnsi);
+		expect(rows.some((r) => r.includes("✓") && r.includes("[read]") && r.includes("src/auth.ts"))).toBe(true);
+		expect(rows.some((r) => r.includes("▶") && r.includes("[bash]") && r.includes("pnpm test"))).toBe(true);
+	});
+
+	it("renders token and elapsed metadata", () => {
+		const rows = renderScrollBlock(delegation(), 130).map(stripAnsi);
+		const meta = rows.find((r) => r.includes("Tokens"));
+		expect(meta).toContain("↑8k");
+		expect(meta).toContain("↓3k");
+		expect(meta).toContain("22s elapsed");
+	});
+
+	it("renders bottom border with └────", () => {
+		const rows = renderScrollBlock(delegation(), 130).map(stripAnsi);
+		const bottom = rows[rows.length - 1];
+		expect(bottom).toMatch(/└─+/);
+	});
+
+	it("renders ✓ done for completed delegations", () => {
+		const rows = renderScrollBlock(delegation({ status: "success" }), 130).map(stripAnsi);
+		expect(rows[0]).toContain("✓");
+		expect(rows[0]).toContain("done");
+	});
+
+	it("renders ✗ failed for errored delegations", () => {
+		const rows = renderScrollBlock(delegation({ status: "error" }), 130).map(stripAnsi);
+		expect(rows[0]).toContain("✗");
+		expect(rows[0]).toContain("failed");
+	});
+
+	it("uses correct ANSI colors", () => {
+		const rows = renderScrollBlock(delegation(), 130);
+		const raw = rows.join("\n");
+		// accent for [scroll]
+		expect(raw).toContain("\u001b[38;2;217;119;6m[scroll]");
+		// tool blue for ▶ (running)
+		expect(raw).toContain("\u001b[38;2;91;155;213m▶");
+		// idle green for ✓
+		expect(raw).toContain("\u001b[38;2;127;176;105m✓");
+	});
+
+	it("formats elapsed time as minutes when over 60s", () => {
+		const rows = renderScrollBlock(delegation({ elapsedMs: 78000 }), 130).map(stripAnsi);
+		const meta = rows.find((r) => r.includes("elapsed"));
+		expect(meta).toContain("1m 18s elapsed");
+	});
+
+	it("pads every row to the requested width", () => {
+		const rows = renderScrollBlock(delegation(), 100);
+		for (const row of rows) {
+			expect(stripAnsi(row).length, `row not padded: ${JSON.stringify(stripAnsi(row))}`).toBe(100);
+		}
+	});
+});

--- a/src/sumo-tui/transcript/scroll-renderer.ts
+++ b/src/sumo-tui/transcript/scroll-renderer.ts
@@ -1,0 +1,205 @@
+/**
+ * Cathedral scroll/scribe delegation renderer — Bible Element 12.
+ *
+ * Renders Pi task/sub-agent tool calls as a `[scroll]` assigned to a `scribe`.
+ * Outer thick-rule header, inner ledger with nested compact tool pills.
+ *
+ * Bible source of truth:
+ *   docs/ui/bible/12-scroll-running.html
+ *   docs/ui/bible/12-scroll-done.html
+ */
+import { visibleWidth } from "@mariozechner/pi-tui";
+import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { lineToAnsi, span, textLine, type Span } from "../render/primitives.js";
+import type { DelegationStatus, DelegationViewModel, ToolCallViewModel } from "./view-model.js";
+
+const STATUS_GLYPH: Record<DelegationStatus, string> = {
+	queued: "○",
+	running: "▶",
+	success: "✓",
+	error: "✗",
+	cancelled: "✗",
+};
+
+const STATUS_COLOR: Record<DelegationStatus, string> = {
+	queued: CATHEDRAL_TOKENS.colors.foregroundDim,
+	running: CATHEDRAL_TOKENS.colors.states.tool,
+	success: CATHEDRAL_TOKENS.colors.states.idle,
+	error: CATHEDRAL_TOKENS.colors.states.approval,
+	cancelled: CATHEDRAL_TOKENS.colors.foregroundDim,
+};
+
+const STATUS_LABEL: Record<DelegationStatus, string> = {
+	queued: "queued",
+	running: "running",
+	success: "done",
+	error: "failed",
+	cancelled: "cancelled",
+};
+
+const TOOL_STATUS_GLYPH: Record<string, string> = {
+	pending: "○", running: "▶", success: "✓", error: "✗", cancelled: "✗",
+};
+
+const TOOL_STATUS_COLOR: Record<string, string> = {
+	pending: CATHEDRAL_TOKENS.colors.foregroundDim,
+	running: CATHEDRAL_TOKENS.colors.states.tool,
+	success: CATHEDRAL_TOKENS.colors.states.idle,
+	error: CATHEDRAL_TOKENS.colors.states.approval,
+	cancelled: CATHEDRAL_TOKENS.colors.foregroundDim,
+};
+
+function toolTarget(tool: ToolCallViewModel): string {
+	const input = typeof tool.input === "object" && tool.input !== null ? tool.input as Record<string, unknown> : {};
+	return typeof input.path === "string" ? input.path
+		: typeof input.command === "string" ? input.command
+		: tool.output ?? "";
+}
+
+function formatTokens(tokensIn?: number, tokensOut?: number): string | undefined {
+	if (tokensIn === undefined && tokensOut === undefined) return undefined;
+	const inStr = tokensIn !== undefined ? `↑${formatK(tokensIn)}` : "";
+	const outStr = tokensOut !== undefined ? `↓${formatK(tokensOut)}` : "";
+	return [inStr, outStr].filter(Boolean).join(" ");
+}
+
+function formatK(n: number): string {
+	if (n >= 10000) return `${Math.round(n / 1000)}k`;
+	if (n >= 1000) return `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+	return String(n);
+}
+
+function formatElapsed(ms?: number): string | undefined {
+	if (ms === undefined) return undefined;
+	const seconds = Math.round(ms / 1000);
+	if (seconds < 60) return `${seconds}s elapsed`;
+	const minutes = Math.floor(seconds / 60);
+	const remaining = seconds % 60;
+	return `${minutes}m ${remaining}s elapsed`;
+}
+
+// ── Rendering ────────────────────────────────────────────────
+
+function scrollHeader(delegation: DelegationViewModel, width: number): string {
+	const statusGlyph = STATUS_GLYPH[delegation.status];
+	const statusColor = STATUS_COLOR[delegation.status];
+	const statusLabel = STATUS_LABEL[delegation.status];
+
+	const left: Span[] = [
+		span("━━━ ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("[scroll]", { fg: CATHEDRAL_TOKENS.colors.accent }),
+		span(`  ${delegation.title} `, { fg: CATHEDRAL_TOKENS.colors.foreground }),
+	];
+	const right: Span[] = [
+		span(" ━━━ ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span(statusGlyph, { fg: statusColor }),
+		span(` ${statusLabel}`, { fg: CATHEDRAL_TOKENS.colors.foreground }),
+	];
+
+	const leftWidth = left.reduce((w, s) => w + visibleWidth(s.text), 0);
+	const rightWidth = right.reduce((w, s) => w + visibleWidth(s.text), 0);
+	const ruleLen = Math.max(1, width - leftWidth - rightWidth);
+
+	return lineToAnsi(textLine([
+		...left,
+		span("━".repeat(ruleLen), { fg: CATHEDRAL_TOKENS.colors.divider }),
+		...right,
+	]), { width });
+}
+
+function scribeHeader(delegation: DelegationViewModel, width: number): string {
+	const agent = delegation.agent ?? "scribe";
+	const metaParts = [agent];
+	if (delegation.model) metaParts.push(delegation.model);
+	if (delegation.thinking) metaParts.push(delegation.thinking);
+	const meta = metaParts.join(" · ");
+
+	const left: Span[] = [
+		span("   "),
+		span("┌ ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span(meta, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+		span(" ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+	];
+	const leftWidth = left.reduce((w, s) => w + visibleWidth(s.text), 0);
+	// Match bottom border alignment: indent(3) + └(1) + dashes + trailing(2)
+	// Header rule ends at the same column as the bottom rule.
+	const bottomRuleEnd = width - 2;  // bottom: 3+1+dashes+2 → last dash at width-3
+	const ruleLen = Math.max(0, bottomRuleEnd - leftWidth);
+	const trailing = Math.max(0, width - leftWidth - ruleLen);
+
+	return lineToAnsi(textLine([
+		...left,
+		span("─".repeat(ruleLen), { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span(" ".repeat(trailing)),
+	]), { width });
+}
+
+function nestedToolRow(tool: ToolCallViewModel, width: number): string {
+	const glyph = TOOL_STATUS_GLYPH[tool.status] ?? "○";
+	const color = TOOL_STATUS_COLOR[tool.status] ?? CATHEDRAL_TOKENS.colors.foregroundDim;
+	const target = toolTarget(tool);
+
+	return lineToAnsi(textLine([
+		span("   "),
+		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span(" "),
+		span(glyph, { fg: color }),
+		span(" "),
+		span(`[${tool.name}]`, { fg: CATHEDRAL_TOKENS.colors.accent }),
+		span(`  ${target}`, { fg: CATHEDRAL_TOKENS.colors.foreground }),
+	]), { width });
+}
+
+function scribeBlankRow(width: number): string {
+	return lineToAnsi(textLine([
+		span("   "),
+		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+	]), { width });
+}
+
+function scribeMetadataRow(delegation: DelegationViewModel, width: number): string {
+	const parts: string[] = [];
+	const tokens = formatTokens(delegation.tokensIn, delegation.tokensOut);
+	if (tokens) parts.push(`Tokens: ${tokens}`);
+	const elapsed = formatElapsed(delegation.elapsedMs);
+	if (elapsed) parts.push(elapsed);
+	const text = parts.length > 0 ? parts.join(" · ") : "";
+
+	return lineToAnsi(textLine([
+		span("   "),
+		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span(` ${text}`, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+	]), { width });
+}
+
+function scribeBottom(width: number): string {
+	const ruleLen = Math.max(0, width - 6); // 3(indent) + 1(└) + dashes + 2(trailing)
+	return lineToAnsi(textLine([
+		span("   "),
+		span("└", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("─".repeat(ruleLen), { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("  "),
+	]), { width });
+}
+
+export function renderScrollBlock(delegation: DelegationViewModel, width: number): string[] {
+	const safeWidth = Math.max(1, Math.floor(width));
+	const rows: string[] = [
+		scrollHeader(delegation, safeWidth),
+		lineToAnsi(textLine([" "]), { width: safeWidth }), // blank after header
+		scribeHeader(delegation, safeWidth),
+	];
+
+	for (const tool of delegation.nestedTools ?? []) {
+		rows.push(nestedToolRow(tool, safeWidth));
+	}
+
+	rows.push(scribeBlankRow(safeWidth));
+
+	if (delegation.tokensIn !== undefined || delegation.elapsedMs !== undefined) {
+		rows.push(scribeMetadataRow(delegation, safeWidth));
+	}
+
+	rows.push(scribeBottom(safeWidth));
+	return rows;
+}

--- a/src/sumo-tui/transcript/view-model.test.ts
+++ b/src/sumo-tui/transcript/view-model.test.ts
@@ -94,7 +94,7 @@ describe("structured transcript view model", () => {
 		});
 
 		expect(message?.blocks).toEqual([
-			{ type: "delegation", delegation: { id: "d1", title: "scribe", agent: "scribe", status: "running", summary: "scrolling the long transcript" } },
+			{ type: "delegation", delegation: { id: "d1", title: "scribe", agent: "scribe", status: "running", summary: "scrolling the long transcript", model: undefined, thinking: undefined, nestedTools: [], tokensIn: undefined, tokensOut: undefined, elapsedMs: undefined } },
 		]);
 	});
 

--- a/src/sumo-tui/transcript/view-model.ts
+++ b/src/sumo-tui/transcript/view-model.ts
@@ -30,6 +30,12 @@ export interface DelegationViewModel {
 	readonly agent?: string;
 	readonly status: DelegationStatus;
 	readonly summary?: string;
+	readonly model?: string;
+	readonly thinking?: string;
+	readonly nestedTools?: readonly ToolCallViewModel[];
+	readonly tokensIn?: number;
+	readonly tokensOut?: number;
+	readonly elapsedMs?: number;
 }
 
 export type ChatBlock =
@@ -195,7 +201,24 @@ function questionBlockFromRecord(record: Record<string, unknown>): ChatBlock {
 	};
 }
 
+function parseDelegationTools(value: unknown): ToolCallViewModel[] {
+	if (!Array.isArray(value)) return [];
+	const results: ToolCallViewModel[] = [];
+	for (const item of value) {
+		const r = asRecord(item);
+		if (!r) continue;
+		results.push({
+			name: firstString(r.name, r.toolName) ?? "tool",
+			status: normalizeStatus(r.status, "success") as ToolStatus,
+			input: r.input ?? r.arguments,
+			output: asString(r.output),
+		});
+	}
+	return results;
+}
+
 function delegationBlockFromRecord(record: Record<string, unknown>): ChatBlock {
+	const details = asRecord(record.details);
 	return {
 		type: "delegation",
 		delegation: {
@@ -204,6 +227,12 @@ function delegationBlockFromRecord(record: Record<string, unknown>): ChatBlock {
 			agent: firstString(record.agent, record.target),
 			status: normalizeDelegationStatus(record.status),
 			summary: firstString(record.summary, record.text, record.description),
+			model: firstString(details?.model, record.model),
+			thinking: firstString(details?.thinking, record.thinking),
+			nestedTools: parseDelegationTools(details?.tools ?? record.tools),
+			tokensIn: typeof (details?.tokensIn ?? record.tokensIn) === "number" ? (details?.tokensIn ?? record.tokensIn) as number : undefined,
+			tokensOut: typeof (details?.tokensOut ?? record.tokensOut) === "number" ? (details?.tokensOut ?? record.tokensOut) as number : undefined,
+			elapsedMs: typeof (details?.elapsedMs ?? record.elapsedMs) === "number" ? (details?.elapsedMs ?? record.elapsedMs) as number : undefined,
 		},
 	};
 }

--- a/src/sumo-tui/widgets/chat-message.ts
+++ b/src/sumo-tui/widgets/chat-message.ts
@@ -6,6 +6,7 @@ import { MEASURE_MODE_EXACTLY, type MeasureMode, type Yoga, type YogaNode } from
 import type { CellBuffer, Rect } from "../render/buffer.js";
 import { lineToAnsi, span, textLine, withPersistentStyle, type Span } from "../render/primitives.js";
 import { renderCathedralCodeBlock } from "../transcript/code-renderer.js";
+import { renderScrollBlock } from "../transcript/scroll-renderer.js";
 import { renderToolBlockRows } from "../transcript/tool-renderer.js";
 import type { ChatBlock } from "../transcript/view-model.js";
 
@@ -223,8 +224,8 @@ function renderQuestionRows(block: Extract<ChatBlock, { type: "question" }>): st
 	return [`[question] ${block.question.prompt}`, ...block.question.choices.map((choice) => `- ${choice}`)];
 }
 
-function renderDelegationRows(block: Extract<ChatBlock, { type: "delegation" }>): string[] {
-	return [`[delegation] ${block.delegation.title} · ${block.delegation.status}`, ...(block.delegation.summary ? [block.delegation.summary] : [])];
+function renderDelegationRows(block: Extract<ChatBlock, { type: "delegation" }>, width: number): string[] {
+	return renderScrollBlock(block.delegation, width);
 }
 
 function renderCodeRows(block: Extract<ChatBlock, { type: "code" }>, width: number): string[] {
@@ -252,7 +253,7 @@ function renderBlockRows(blocks: readonly ChatBlock[], width: number): string[] 
 				rows.push(...renderQuestionRows(block));
 				break;
 			case "delegation":
-				rows.push(...renderDelegationRows(block));
+				rows.push(...renderDelegationRows(block, width));
 				break;
 		}
 	}


### PR DESCRIPTION
## Summary

Renders Pi task/sub-agent tool calls as Cathedral-themed `[scroll]` blocks with nested `scribe` ledgers, matching Bible Element 12.

### Rendering

```
━━━ [scroll]  refactor auth flow ━━━━━━━━━━━━━━━━━━━━━━━━ ━━━ ▶ running

   ┌ scribe · gpt-5.5 · medium ──────────────────────────────────
   │ ✓ [read]  src/auth.ts
   │ ✓ [edit]  src/auth.ts
   │ ▶ [bash]  pnpm test src/auth
   │
   │ Tokens: ↑8k ↓3k · 22s elapsed
   └──────────────────────────────────────────────────────────────
```

### Changes

- `src/sumo-tui/transcript/scroll-renderer.ts` — new renderer
- Extended `DelegationViewModel` with model, thinking, nestedTools, tokensIn/Out, elapsedMs
- Wired into `chat-message.ts` replacing plain-text delegation rendering
- Added `fixture-scroll-scribe-landscape` scenario (14th visual scenario, **passed on first run**)

### Verification

```
pnpm test              # 516/516 ✅
pnpm test:integration  # 18/18 ✅
pnpm visual:ci         # 14 scenarios, 6 passed ✅
pnpm tsc --noEmit      # ✅
pnpm build             # ✅
```

Closes #141
Tracker: #124 Phase 5