### PR TITLE
feat(ui): Divine Query modal (Element 11)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,14 @@ The user-facing wrapper is `bin/sumocode.sh`:
 
 Do not casually change `patches/@mariozechner__pi-coding-agent@*.patch`, `SUMO_TUI`, `SUMO_TUI_MODULE`, or `sumo-interactive-mode.js`. Pi version bumps must follow `docs/research/pi-fork-upgrade.md` and the smoke matrix in `docs/SUMO_TUI_PI_PATCH_STRATEGY.md`.
 
+### Pi ↔ SumoCode tool boundary
+
+Read `docs/PI_TOOL_ARCHITECTURE.md` before adding, overriding, or intercepting tools. Key rules:
+
+- **Built-in tools** (`bash`, `read`, `write`, `edit`, `mcp`, `task`): never re-register. Intercept via `pi.on("tool_call")` for gating; render via transcript view-model pipeline.
+- **Pi example extensions** (e.g. `question`): override by registering a tool with the same `name` in SumoCode. SumoCode's version replaces Pi's.
+- **Pi internal UI** (`showExtensionSelector`, `showExtensionConfirm`): cannot be intercepted without upstream changes. SumoCode-owned code calls `showDivineQuery()` directly instead of `ctx.ui.select`.
+
 ## Cathedral rendering
 
 `src/cathedral/` and `src/sumo-tui/cathedral/` hold Cathedral-themed adapters and retained UI nodes. The visual canon is:

--- a/docs/PI_TOOL_ARCHITECTURE.md
+++ b/docs/PI_TOOL_ARCHITECTURE.md
@@ -1,0 +1,114 @@
+# Pi ↔ SumoCode Tool Architecture
+
+## Overview
+
+SumoCode is a Pi **extension** that wraps `@mariozechner/pi-coding-agent`.
+Pi provides built-in tools (`bash`, `read`, `write`, `edit`, `mcp`) and an
+extension API that lets SumoCode register additional tools, intercept tool
+calls, and customize UI rendering.
+
+## Tool Layers
+
+### 1. Pi Built-in Tools
+
+These ship with Pi and are always available:
+
+| Tool    | What it does                                     | SumoCode customization       |
+|---------|--------------------------------------------------|------------------------------|
+| `bash`  | Execute shell commands                           | Approval gate for dangerous commands |
+| `read`  | Read file contents                               | Tool pill renderer (E9)      |
+| `write` | Create/overwrite files                           | Tool pill renderer (E9)      |
+| `edit`  | Precise text replacement                         | Tool pill renderer (E9)      |
+| `mcp`   | Call MCP server tools                            | Tool pill renderer (E9)      |
+| `task`  | Dispatch sub-agent work                          | Scroll/scribe renderer (E12) |
+
+SumoCode **does not re-register** these. It intercepts them via `pi.on("tool_call")`
+for approval gating and renders them via the transcript view-model pipeline.
+
+### 2. Pi Example Extensions (installed globally)
+
+These live in Pi's examples directory and are loaded as regular extensions.
+SumoCode can **override** them by registering a tool with the same `name`.
+
+| Tool         | Pi source                                        | SumoCode override            |
+|--------------|--------------------------------------------------|------------------------------|
+| `question`   | `examples/extensions/question.ts`                | `src/question-tool.ts` — Divine Query single-question overlay |
+| `/answer`    | `~/.pi/agent/extensions/answer.ts`               | `src/answer-tool.ts` — Cathedral multi-question wizard |
+
+SumoCode registers its own `question` tool and `/answer` command,
+overriding Pi's defaults. The user's `~/.pi/agent/extensions/answer.ts`
+should be removed or disabled to avoid conflicts.
+
+### 3. SumoCode-Only Tools
+
+These are registered by SumoCode via `pi.registerTool()` and don't exist in
+vanilla Pi.
+
+| Tool         | Source                         | Purpose                      |
+|--------------|--------------------------------|------------------------------|
+| *(none yet)* | —                              | —                            |
+
+### 4. SumoCode Extension Hooks
+
+These use `pi.on("tool_call")` to intercept built-in tool execution without
+re-registering the tool.
+
+| Hook                  | Source                     | What it does                        |
+|-----------------------|----------------------------|-------------------------------------|
+| Approval gate         | `src/approval-modal.ts`    | Blocks dangerous bash commands      |
+
+## UI Rendering Layers
+
+### Transcript View-Model Pipeline
+
+All tool results flow through the structured transcript:
+
+```
+Pi agent event → ChatMessageViewModel → ChatBlock (tool/skill/delegation/code/question)
+    → tool-renderer.ts / code-renderer.ts / scroll-renderer.ts / chat-message.ts
+    → CellBuffer → ANSI → terminal
+```
+
+### Interactive Modals
+
+| Modal              | Source                    | Triggered by                        |
+|--------------------|---------------------------|-------------------------------------|
+| Command Palette    | `src/command-palette.ts`  | `Ctrl+/` keybinding                 |
+| Divine Query       | `src/divine-query.ts`     | `showDivineQuery()` from SumoCode code |
+| Approval Modal     | `src/approval-modal.ts`   | `tool_call` event for dangerous bash |
+| Memory Editor      | `src/memory-editor.ts`    | `Ctrl+M` keybinding                 |
+
+All modals use `ctx.ui.custom({ overlay: true })` for centered overlays.
+
+### Pi's Internal UI (not interceptable)
+
+Pi's own interactive mode has internal UI that SumoCode **cannot** override
+without patching Pi upstream:
+
+- `showExtensionSelector` — Pi's list selector (used by `/model`, `/session`)
+- `showExtensionConfirm` — Pi's yes/no confirm
+- `showExtensionInput` — Pi's text input
+
+If Pi adds a `ui.select` override hook in the future, we can wire Divine Query
+there to theme ALL selectors.
+
+## LLM Tool Guidance
+
+The `question` tool description includes instructions for the LLM:
+
+> Do NOT prefix options with A)/B)/1./2. — the Cathedral UI adds labels automatically.
+
+This ensures the Divine Query renderer doesn't produce double labels like `A) A) Yes`.
+
+## Key Files
+
+| File                              | Role                                          |
+|-----------------------------------|-----------------------------------------------|
+| `src/extension.ts`               | Main entry — wires all hooks and tools        |
+| `src/approval-modal.ts`          | Approval gate + configurable patterns         |
+| `src/divine-query.ts`            | Divine Query modal renderer + state machine   |
+| `src/command-palette.ts`         | Command palette (calls `showDivineQuery`)     |
+| `src/sumo-tui/transcript/*.ts`   | Tool/code/scroll renderers                    |
+| `src/sumo-tui/widgets/chat-message.ts` | Chat frame + block routing              |
+| `src/question-tool.ts`            | Question tool override (Divine Query)         |
+| `src/answer-tool.ts`              | /answer command + Ctrl+. (Cathedral Q&A wizard) |

--- a/docs/visual/parity/scenarios.json
+++ b/docs/visual/parity/scenarios.json
@@ -750,6 +750,32 @@
 			]
 		},
 		{
+			"id": "fixture-divine-query-overlay",
+			"lane": "fixture",
+			"status": "review",
+			"dimensions": {
+				"cols": 160,
+				"rows": 45
+			},
+			"bibleTarget": "scene-divine-query-overlay.png",
+			"fixture": {
+				"id": "completed-active",
+				"overlay": "divine-query"
+			},
+			"crops": [
+				{
+					"id": "full",
+					"targetCrop": "full",
+					"runtimeCrop": "full"
+				},
+				{
+					"id": "overlay-center",
+					"targetCrop": "overlay-center",
+					"runtimeCrop": "overlay-center"
+				}
+			]
+		},
+		{
 			"id": "fixture-scroll-scribe-landscape",
 			"lane": "fixture",
 			"status": "review",

--- a/scripts/visual-v2/fixture-capture.mjs
+++ b/scripts/visual-v2/fixture-capture.mjs
@@ -308,6 +308,7 @@ async function renderFixtureScene(scenario, fixture) {
 }
 
 async function applyOverlay(lines, cols, rows, overlay) {
+	if (overlay === "divine-query") return applyDivineQueryOverlay(lines, cols, rows);
 	if (overlay !== "command-palette") throw new Error(`Unsupported fixture overlay: ${overlay}`);
 	const palette = await jiti.import(`${repoRoot}/src/command-palette.ts`);
 
@@ -331,6 +332,30 @@ async function applyOverlay(lines, cols, rows, overlay) {
 		// preserving the left margin and right remnant.
 		const existingLine = next[top + index] ?? "";
 		const rightStart = left + paletteWidth;
+		const leftRemnant = padAnsiToWidth(sliceByColumn(existingLine, 0, left, true), left);
+		const rightRemnant = rightStart < cols ? sliceByColumn(existingLine, rightStart, cols - rightStart, true) : "";
+		next[top + index] = padAnsiToWidth(`${leftRemnant}${overlayLine}${rightRemnant}`, cols);
+	}
+	return next;
+}
+
+async function applyDivineQueryOverlay(lines, cols, rows) {
+	const divineQuery = await jiti.import(`${repoRoot}/src/divine-query.ts`);
+
+	const overlayWidth = Math.max(50, Math.min(80, Math.floor(cols * 0.6)));
+	const overlayLines = divineQuery.renderDivineQuery({
+		title: "Should I rename `getUser` to `fetchUser` across the auth module?",
+		options: ["Yes, rename it everywhere", "No, leave it as-is", "Use a different name"],
+		focusedIndex: 1,
+	}, overlayWidth);
+
+	const left = Math.max(0, Math.floor((cols - overlayWidth) / 2));
+	const top = Math.max(0, Math.floor((rows - overlayLines.length) / 2));
+	const next = [...lines];
+	for (let index = 0; index < overlayLines.length && top + index < rows; index += 1) {
+		const overlayLine = padAnsiToWidth(overlayLines[index] ?? "", overlayWidth);
+		const existingLine = next[top + index] ?? "";
+		const rightStart = left + overlayWidth;
 		const leftRemnant = padAnsiToWidth(sliceByColumn(existingLine, 0, left, true), left);
 		const rightRemnant = rightStart < cols ? sliceByColumn(existingLine, rightStart, cols - rightStart, true) : "";
 		next[top + index] = padAnsiToWidth(`${leftRemnant}${overlayLine}${rightRemnant}`, cols);

--- a/src/answer-tool.ts
+++ b/src/answer-tool.ts
@@ -1,0 +1,393 @@
+/**
+ * Cathedral answer tool — multi-question Divine Query wizard.
+ *
+ * Extracts questions from the last assistant message, then presents
+ * each as a Divine Query overlay for the user to answer sequentially.
+ * Registers the `/answer` command and `Ctrl+.` shortcut.
+ *
+ * This replaces Pi's `answer.ts` extension with Cathedral-themed UI.
+ */
+
+import { complete, type Model, type Api, type UserMessage } from "@mariozechner/pi-ai";
+import type { ExtensionAPI, ExtensionContext, ModelRegistry } from "@mariozechner/pi-coding-agent";
+import { BorderedLoader } from "@mariozechner/pi-coding-agent";
+import { Editor, type EditorTheme, Key, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
+import type { Component, TUI } from "@mariozechner/pi-tui";
+import { DIVINE_QUERY_OVERLAY_OPTIONS } from "./divine-query.js";
+import { CATHEDRAL_TOKENS } from "./tokens.js";
+
+// ── Types ────────────────────────────────────────────────────
+
+interface ExtractedQuestion {
+	question: string;
+	context?: string;
+}
+
+interface ExtractionResult {
+	questions: ExtractedQuestion[];
+}
+
+interface QnAResult {
+	entries: Array<ExtractedQuestion & { answer: string }>;
+	formatted: string;
+}
+
+// ── Extraction ───────────────────────────────────────────────
+
+const SYSTEM_PROMPT = `You are a question extractor. Given text from a conversation, extract any questions that need answering.
+
+Output a JSON object with this structure:
+{
+  "questions": [
+    {
+      "question": "The question text",
+      "context": "Optional context that helps answer the question"
+    }
+  ]
+}
+
+Rules:
+- Extract all questions that require user input
+- Keep questions in the order they appeared
+- Be concise with question text
+- Include context only when it provides essential information for answering
+- If no questions are found, return {"questions": []}`;
+
+const HAIKU_MODEL_ID = "claude-haiku-4-5";
+const GPT_FALLBACK_MODEL_ID = "gpt-5.4-mini";
+
+async function selectExtractionModel(
+	currentModel: Model<Api>,
+	modelRegistry: ModelRegistry,
+): Promise<Model<Api>> {
+	const haikuModel = modelRegistry.find("anthropic", HAIKU_MODEL_ID);
+	if (haikuModel) {
+		const auth = await modelRegistry.getApiKeyAndHeaders(haikuModel);
+		if (auth.ok) return haikuModel;
+	}
+	const gptFallback = modelRegistry.find("openai-codex", GPT_FALLBACK_MODEL_ID);
+	if (gptFallback) {
+		const auth = await modelRegistry.getApiKeyAndHeaders(gptFallback);
+		if (auth.ok) return gptFallback;
+	}
+	return currentModel;
+}
+
+function parseExtractionResult(text: string): ExtractionResult | null {
+	try {
+		let jsonStr = text;
+		const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+		if (jsonMatch) jsonStr = jsonMatch[1].trim();
+		const parsed = JSON.parse(jsonStr);
+		return parsed && Array.isArray(parsed.questions) ? (parsed as ExtractionResult) : null;
+	} catch {
+		return null;
+	}
+}
+
+// ── Cathedral Q&A Component ─────────────────────────────────
+
+const RESET = "\u001b[0m";
+function cathedralFg(text: string, hex: string): string {
+	const h = hex.replace("#", "");
+	const r = parseInt(h.slice(0, 2), 16);
+	const g = parseInt(h.slice(2, 4), 16);
+	const b = parseInt(h.slice(4, 6), 16);
+	return `\u001b[38;2;${r};${g};${b}m${text}${RESET}`;
+}
+
+const accent = (s: string) => cathedralFg(s, CATHEDRAL_TOKENS.colors.accent);
+const fg = (s: string) => cathedralFg(s, CATHEDRAL_TOKENS.colors.foreground);
+const dim = (s: string) => cathedralFg(s, CATHEDRAL_TOKENS.colors.foregroundDim);
+const divider = (s: string) => cathedralFg(s, CATHEDRAL_TOKENS.colors.divider);
+const idle = (s: string) => cathedralFg(s, CATHEDRAL_TOKENS.colors.states.idle);
+const thinking = (s: string) => cathedralFg(s, CATHEDRAL_TOKENS.colors.states.thinking);
+const liftedBg = `\u001b[48;2;61;48;36m`; // surfaceLifted
+
+class CathedralQnAComponent implements Component {
+	private questions: ExtractedQuestion[];
+	private answers: string[];
+	private currentIndex = 0;
+	private editor: Editor;
+	private tui: TUI;
+	private onDone: (result: QnAResult | null) => void;
+	private showingConfirmation = false;
+	private cachedLines: string[] | undefined;
+
+	constructor(questions: ExtractedQuestion[], tui: TUI, onDone: (result: QnAResult | null) => void) {
+		this.questions = questions;
+		this.answers = questions.map(() => "");
+		this.tui = tui;
+		this.onDone = onDone;
+
+		const editorTheme: EditorTheme = {
+			borderColor: (s) => cathedralFg(s, CATHEDRAL_TOKENS.colors.accent),
+			selectList: {
+				selectedPrefix: (t) => cathedralFg(t, CATHEDRAL_TOKENS.colors.accent),
+				selectedText: (t) => cathedralFg(t, CATHEDRAL_TOKENS.colors.accent),
+				description: (t) => cathedralFg(t, CATHEDRAL_TOKENS.colors.foregroundDim),
+				scrollInfo: (t) => cathedralFg(t, CATHEDRAL_TOKENS.colors.foregroundDim),
+				noMatch: (t) => cathedralFg(t, CATHEDRAL_TOKENS.colors.states.approval),
+			},
+		};
+		this.editor = new Editor(tui, editorTheme);
+		this.editor.disableSubmit = true;
+		this.editor.onChange = () => { this.invalidate(); this.tui.requestRender(); };
+	}
+
+	private saveCurrentAnswer(): void {
+		this.answers[this.currentIndex] = this.editor.getText();
+	}
+
+	private navigateTo(index: number): void {
+		if (index < 0 || index >= this.questions.length) return;
+		this.saveCurrentAnswer();
+		this.currentIndex = index;
+		this.editor.setText(this.answers[index] || "");
+		this.invalidate();
+	}
+
+	private submit(): void {
+		this.saveCurrentAnswer();
+		const entries = this.questions.map((q, i) => ({
+			...q,
+			answer: this.answers[i]?.trim() || "(no answer)",
+		}));
+		const parts: string[] = [];
+		for (const entry of entries) {
+			parts.push(`Q: ${entry.question}`);
+			if (entry.context) parts.push(`> ${entry.context}`);
+			parts.push(`A: ${entry.answer}`);
+			parts.push("");
+		}
+		this.onDone({ entries, formatted: parts.join("\n").trim() });
+	}
+
+	invalidate(): void { this.cachedLines = undefined; }
+
+	handleInput(data: string): void {
+		if (this.showingConfirmation) {
+			if (matchesKey(data, Key.enter) || data.toLowerCase() === "y") { this.submit(); return; }
+			if (matchesKey(data, Key.escape) || data.toLowerCase() === "n") {
+				this.showingConfirmation = false;
+				this.invalidate();
+				this.tui.requestRender();
+				return;
+			}
+			return;
+		}
+
+		if (matchesKey(data, Key.escape) || matchesKey(data, Key.ctrl("c"))) { this.onDone(null); return; }
+
+		if (matchesKey(data, Key.tab)) {
+			if (this.currentIndex < this.questions.length - 1) { this.navigateTo(this.currentIndex + 1); this.tui.requestRender(); }
+			return;
+		}
+		if (matchesKey(data, Key.shift("tab"))) {
+			if (this.currentIndex > 0) { this.navigateTo(this.currentIndex - 1); this.tui.requestRender(); }
+			return;
+		}
+
+		if (matchesKey(data, Key.enter) && !matchesKey(data, Key.shift("enter"))) {
+			this.saveCurrentAnswer();
+			if (this.currentIndex < this.questions.length - 1) {
+				this.navigateTo(this.currentIndex + 1);
+			} else {
+				this.showingConfirmation = true;
+			}
+			this.invalidate();
+			this.tui.requestRender();
+			return;
+		}
+
+		this.editor.handleInput(data);
+		this.invalidate();
+		this.tui.requestRender();
+	}
+
+	render(width: number): string[] {
+		if (this.cachedLines) return this.cachedLines;
+
+		const boxWidth = Math.min(width, 120);
+		const contentWidth = boxWidth - 4;
+		const horizontalLine = (count: number) => "─".repeat(count);
+
+		const boxLine = (content: string, leftPad = 2): string => {
+			const paddedContent = " ".repeat(leftPad) + content;
+			const contentLen = visibleWidth(paddedContent);
+			const rightPad = Math.max(0, boxWidth - contentLen - 2);
+			return `${liftedBg}${divider("│")}${paddedContent}${" ".repeat(rightPad)}${divider("│")}${RESET}`;
+		};
+
+		const emptyBoxLine = (): string => `${liftedBg}${divider("│")}${" ".repeat(boxWidth - 2)}${divider("│")}${RESET}`;
+		const padToWidth = (line: string): string => {
+			const len = visibleWidth(line);
+			return line + " ".repeat(Math.max(0, width - len));
+		};
+
+		const lines: string[] = [];
+
+		// Title: ✾ DIVINE QUERY ✾ (n/total)
+		lines.push(padToWidth(`${liftedBg}${divider("╭" + horizontalLine(boxWidth - 2) + "╮")}${RESET}`));
+		const title = `${accent("✾")}  ${accent("DIVINE QUERY")}  ${accent("✾")}  ${dim(`${this.currentIndex + 1}/${this.questions.length}`)}`;
+		lines.push(padToWidth(boxLine(title)));
+
+		// Split rule
+		const ruleLen = Math.max(1, Math.floor((contentWidth - 6) / 2 - 5));
+		const splitRule = `${divider("─".repeat(ruleLen))}  ${divider("·")}  ${divider("─".repeat(ruleLen))}`;
+		lines.push(padToWidth(boxLine(splitRule)));
+
+		// Progress
+		const progressParts: string[] = [];
+		for (let i = 0; i < this.questions.length; i++) {
+			const answered = (this.answers[i]?.trim() || "").length > 0;
+			const current = i === this.currentIndex;
+			if (current) progressParts.push(accent("❈"));
+			else if (answered) progressParts.push(idle("✓"));
+			else progressParts.push(divider("·"));
+		}
+		lines.push(padToWidth(boxLine(progressParts.join(" "))));
+		lines.push(padToWidth(emptyBoxLine()));
+
+		// Question
+		const q = this.questions[this.currentIndex];
+		const questionText = `${accent("Q:")} ${fg(q.question)}`;
+		for (const line of wrapTextWithAnsi(questionText, contentWidth)) {
+			lines.push(padToWidth(boxLine(line)));
+		}
+
+		// Context
+		if (q.context) {
+			lines.push(padToWidth(emptyBoxLine()));
+			for (const line of wrapTextWithAnsi(dim(`> ${q.context}`), contentWidth - 2)) {
+				lines.push(padToWidth(boxLine(line)));
+			}
+		}
+
+		lines.push(padToWidth(emptyBoxLine()));
+
+		// Editor
+		const answerPrefix = accent("A: ");
+		const editorWidth = contentWidth - 4 - 3;
+		const editorLines = this.editor.render(editorWidth);
+		for (let i = 1; i < editorLines.length - 1; i++) {
+			const prefix = i === 1 ? answerPrefix : "   ";
+			lines.push(padToWidth(boxLine(prefix + editorLines[i])));
+		}
+
+		lines.push(padToWidth(emptyBoxLine()));
+
+		// Footer
+		lines.push(padToWidth(boxLine(splitRule)));
+		if (this.showingConfirmation) {
+			const confirmMsg = `${thinking("Submit all answers?")} ${dim("(Enter/y to confirm, Esc/n to cancel)")}`;
+			lines.push(padToWidth(boxLine(truncateToWidth(confirmMsg, contentWidth))));
+		} else {
+			const controls = dim("⇅ wander    ⏎ answer    ⇧⇥ retreat    ⎋ cancel");
+			lines.push(padToWidth(boxLine(truncateToWidth(controls, contentWidth))));
+		}
+		lines.push(padToWidth(`${liftedBg}${divider("╰" + horizontalLine(boxWidth - 2) + "╯")}${RESET}`));
+
+		this.cachedLines = lines;
+		return lines;
+	}
+}
+
+// ── Extension wiring ─────────────────────────────────────────
+
+export function installAnswerTool(pi: ExtensionAPI): void {
+	const runQuestionnaire = async (ctx: ExtensionContext, questions: ExtractedQuestion[]): Promise<QnAResult | null> => {
+		if (!ctx.hasUI) {
+			ctx.ui.notify("questionnaire requires interactive mode", "error");
+			return null;
+		}
+		return ctx.ui.custom<QnAResult | null>(
+			(tui, _theme, _kb, done) => new CathedralQnAComponent(questions, tui, done),
+			{ overlay: true, overlayOptions: DIVINE_QUERY_OVERLAY_OPTIONS },
+		);
+	};
+
+	const answerHandler = async (ctx: ExtensionContext) => {
+		if (!ctx.hasUI) { ctx.ui.notify("answer requires interactive mode", "error"); return; }
+		if (!ctx.model) { ctx.ui.notify("No model selected", "error"); return; }
+
+		const branch = ctx.sessionManager.getBranch();
+		let lastAssistantText: string | undefined;
+
+		for (let i = branch.length - 1; i >= 0; i--) {
+			const entry = branch[i];
+			if (entry.type === "message") {
+				const msg = entry.message;
+				if ("role" in msg && msg.role === "assistant") {
+					if (msg.stopReason !== "stop") {
+						ctx.ui.notify(`Last assistant message incomplete (${msg.stopReason})`, "error");
+						return;
+					}
+					const textParts = msg.content
+						.filter((c): c is { type: "text"; text: string } => c.type === "text")
+						.map((c) => c.text);
+					if (textParts.length > 0) { lastAssistantText = textParts.join("\n"); break; }
+				}
+			}
+		}
+
+		if (!lastAssistantText) { ctx.ui.notify("No assistant messages found", "error"); return; }
+
+		const extractionModel = await selectExtractionModel(ctx.model, ctx.modelRegistry);
+
+		const extractionResult = await ctx.ui.custom<ExtractionResult | null>((tui, theme, _kb, done) => {
+			const loader = new BorderedLoader(tui, theme, `Extracting questions using ${extractionModel.id}...`);
+			loader.onAbort = () => done(null);
+
+			const doExtract = async () => {
+				const auth = await ctx.modelRegistry.getApiKeyAndHeaders(extractionModel);
+				if (!auth.ok) throw new Error(auth.error);
+				const userMessage: UserMessage = {
+					role: "user",
+					content: [{ type: "text", text: lastAssistantText! }],
+					timestamp: Date.now(),
+				};
+				const response = await complete(
+					extractionModel,
+					{ systemPrompt: SYSTEM_PROMPT, messages: [userMessage] },
+					{ apiKey: auth.apiKey, headers: auth.headers, signal: loader.signal },
+				);
+				if (response.stopReason === "aborted") return null;
+				const responseText = response.content
+					.filter((c): c is { type: "text"; text: string } => c.type === "text")
+					.map((c) => c.text)
+					.join("\n");
+				return parseExtractionResult(responseText);
+			};
+
+			doExtract().then(done).catch(() => done(null));
+			return loader;
+		});
+
+		if (!extractionResult) { ctx.ui.notify("Cancelled", "info"); return; }
+		if (extractionResult.questions.length === 0) { ctx.ui.notify("No questions found in the last message", "info"); return; }
+
+		const answersResult = await runQuestionnaire(ctx, extractionResult.questions);
+		if (!answersResult) { ctx.ui.notify("Cancelled", "info"); return; }
+
+		pi.sendMessage(
+			{
+				customType: "answers",
+				content: "I answered your questions in the following way:\n\n" + answersResult.formatted,
+				display: true,
+				details: { entries: answersResult.entries },
+			},
+			{ triggerTurn: true },
+		);
+	};
+
+	pi.registerCommand("answer", {
+		description: "Extract questions from last assistant message into interactive Q&A",
+		handler: (_args, ctx) => answerHandler(ctx),
+	});
+
+	pi.registerShortcut("ctrl+.", {
+		description: "Extract and answer questions",
+		handler: answerHandler,
+	});
+}

--- a/src/cathedral/cathedral-editor.ts
+++ b/src/cathedral/cathedral-editor.ts
@@ -237,10 +237,10 @@ class CathedralEditor extends CustomEditor {
 				// Preserve Pi's zero-width cursor marker while painting our ghost text.
 				// Without this, TUI.positionHardwareCursor() sees no marker on the
 				// splash empty state and emits \x1b[?25l after every render.
-				const prompt = ` ${color(">", CATHEDRAL_TOKENS.colors.accent)} `;
+				const prompt = ` ${color(">", CATHEDRAL_TOKENS.colors.accent)} ${CURSOR_MARKER}`;
 				const maxPlaceholder = Math.max(0, frameWidth - 2 - visibleLength(prompt));
 				const placeholder = ellipsize(INPUT_FRAME_PLACEHOLDER, maxPlaceholder);
-				const ghost = `${prompt}${color(`${placeholder}${CURSOR_MARKER}`, CATHEDRAL_TOKENS.colors.foregroundDim)}`;
+				const ghost = `${prompt}${color(placeholder, CATHEDRAL_TOKENS.colors.foregroundDim)}`;
 				return fullRow(wrapRow(ghost, frameWidth, paintFrameBackground));
 			}
 			if (!splash) return wrapActiveRow(row, frameWidth, paintFrameBackground, isFirstContent);

--- a/src/command-palette.test.ts
+++ b/src/command-palette.test.ts
@@ -196,21 +196,23 @@ describe("handlePaletteSelection", () => {
 	it("MODEL opens a model selector", async () => {
 		const selectedModel = { id: "claude-sonnet-4-5" };
 		const setModel = vi.fn();
-		const select = vi.fn(() => Promise.resolve("claude-sonnet-4-5"));
+		// showDivineQuery calls ctx.ui.custom — mock it to return the index of the selected model
+		const custom = vi.fn(() => Promise.resolve(1)); // index 1 = claude-sonnet-4-5
 		await handlePaletteSelection("MODEL", {
 			modelRegistry: { getAvailable: () => [{ id: "claude-opus-4-7" }, selectedModel] },
-			ui: { select },
+			ui: { custom },
 		} as never, { setModel } as never);
 
-		expect(select).toHaveBeenCalledWith("MODEL", ["claude-opus-4-7", "claude-sonnet-4-5"]);
+		expect(custom).toHaveBeenCalled();
 		expect(setModel).toHaveBeenCalledWith(selectedModel);
 	});
 
 	it("THINKING opens a thinking selector", async () => {
 		const setThinkingLevel = vi.fn();
-		const select = vi.fn(() => Promise.resolve("xhigh"));
-		await handlePaletteSelection("THINKING", { ui: { select } } as never, { setThinkingLevel } as never);
-		expect(select).toHaveBeenCalledWith("THINKING", ["off", "minimal", "low", "medium", "high", "xhigh"]);
+		// showDivineQuery calls ctx.ui.custom — mock returns index 5 = "xhigh"
+		const custom = vi.fn(() => Promise.resolve(5));
+		await handlePaletteSelection("THINKING", { ui: { custom } } as never, { setThinkingLevel } as never);
+		expect(custom).toHaveBeenCalled();
 		expect(setThinkingLevel).toHaveBeenCalledWith("xhigh");
 	});
 

--- a/src/command-palette.ts
+++ b/src/command-palette.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-age
 import type { Component, OverlayOptions } from "@mariozechner/pi-tui";
 import { Key, matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import type { ThinkingLevel } from "./footer.js";
+import { showDivineQuery } from "./divine-query.js";
 import { CATHEDRAL_TOKENS } from "./tokens.js";
 
 export type PaletteMode = "SESSION" | "MODEL" | "THINKING" | "MEMORY" | "THEME" | "SETTINGS";
@@ -257,14 +258,14 @@ export async function handlePaletteSelection(mode: PaletteMode | undefined, ctx:
 
 	if (mode === "MODEL") {
 		const models = ctx.modelRegistry.getAvailable();
-		const selected = await ctx.ui.select("MODEL", models.map((model) => model.id));
+		const selected = await showDivineQuery(ctx, "Choose a model", models.map((model) => model.id));
 		const model = models.find((candidate) => candidate.id === selected);
 		if (model) await pi.setModel(model);
 		return;
 	}
 
 	if (mode === "THINKING") {
-		const selected = await ctx.ui.select("THINKING", [...COMMAND_PALETTE_THINKING_LEVELS]);
+		const selected = await showDivineQuery(ctx, "Set thinking level", [...COMMAND_PALETTE_THINKING_LEVELS]);
 		if (selected && COMMAND_PALETTE_THINKING_LEVELS.includes(selected as ThinkingLevel)) {
 			pi.setThinkingLevel(selected as ThinkingLevel);
 		}
@@ -278,7 +279,7 @@ export async function handlePaletteSelection(mode: PaletteMode | undefined, ctx:
 
 	if (mode === "THEME") {
 		const themes = ctx.ui.getAllThemes().map((theme) => theme.name);
-		const selected = await ctx.ui.select("THEME", themes);
+		const selected = await showDivineQuery(ctx, "Choose a theme", themes);
 		if (selected) ctx.ui.setTheme(selected);
 		return;
 	}

--- a/src/divine-query.test.ts
+++ b/src/divine-query.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import {
+	renderDivineQuery,
+	updateDivineQuery,
+	type DivineQuerySnapshot,
+} from "./divine-query.js";
+
+const ANSI = /\u001b\[[0-9;]*m/g;
+const stripAnsi = (s: string): string => s.replace(ANSI, "");
+
+function snapshot(overrides: Partial<DivineQuerySnapshot> = {}): DivineQuerySnapshot {
+	return {
+		title: "Should I rename `getUser` to `fetchUser`?",
+		options: ["Yes, rename it everywhere", "No, leave it as-is", "Use a different name"],
+		focusedIndex: 0,
+		...overrides,
+	};
+}
+
+describe("renderDivineQuery", () => {
+	it("renders ✾ DIVINE QUERY ✾ title in accent", () => {
+		const lines = renderDivineQuery(snapshot(), 80);
+		const titleLine = lines.find((l) => stripAnsi(l).includes("DIVINE QUERY"));
+		expect(titleLine).toBeDefined();
+		// accent #D97706 -> 217;119;6
+		expect(titleLine).toContain("\u001b[38;2;217;119;6m");
+		expect(stripAnsi(titleLine!)).toContain("✾  DIVINE QUERY  ✾");
+	});
+
+	it("renders decorative split rules in divider", () => {
+		const lines = renderDivineQuery(snapshot(), 80).map(stripAnsi);
+		const ruleLines = lines.filter((l) => l.includes("──") && l.includes("·"));
+		expect(ruleLines.length).toBe(2); // top + bottom
+	});
+
+	it("renders question body in foreground", () => {
+		const lines = renderDivineQuery(snapshot(), 80);
+		const bodyLine = lines.find((l) => stripAnsi(l).includes("rename"));
+		expect(bodyLine).toBeDefined();
+		// foreground #F5E6C8 -> 245;230;200
+		expect(bodyLine).toContain("\u001b[38;2;245;230;200m");
+	});
+
+	it("renders focused option with ❈ in accent and text in foreground", () => {
+		const lines = renderDivineQuery(snapshot({ focusedIndex: 0 }), 80);
+		const focusedLine = lines.find((l) => stripAnsi(l).includes("❈"));
+		expect(focusedLine).toBeDefined();
+		expect(stripAnsi(focusedLine!)).toContain("A) Yes, rename it everywhere");
+		expect(focusedLine).toContain("\u001b[38;2;217;119;6m❈"); // accent
+	});
+
+	it("renders unfocused options with · in divider and text in dim", () => {
+		const lines = renderDivineQuery(snapshot({ focusedIndex: 0 }), 80);
+		const plain = lines.map(stripAnsi);
+		const bLine = plain.find((l) => l.includes("B) No"));
+		expect(bLine).toContain("·");
+		// Check dim color on the raw ANSI
+		const rawB = lines.find((l) => stripAnsi(l).includes("B) No"));
+		expect(rawB).toContain("\u001b[38;2;139;122;99m"); // foregroundDim
+	});
+
+	it("renders footer with wander/answer/retreat", () => {
+		const lines = renderDivineQuery(snapshot(), 80).map(stripAnsi);
+		const footer = lines.find((l) => l.includes("wander"));
+		expect(footer).toContain("↑↓ wander");
+		expect(footer).toContain("⏎ answer");
+		expect(footer).toContain("⎋ retreat");
+	});
+
+	it("renders surfaceLifted background on all rows", () => {
+		const lines = renderDivineQuery(snapshot(), 80);
+		// surfaceLifted #3D3024 -> 61;48;36
+		for (const line of lines) {
+			expect(line).toContain("\u001b[48;2;61;48;36m");
+		}
+	});
+
+	it("pads every row to the requested width", () => {
+		const lines = renderDivineQuery(snapshot(), 80);
+		for (const line of lines) {
+			expect(stripAnsi(line).length, `row not padded: ${JSON.stringify(stripAnsi(line))}`).toBe(80);
+		}
+	});
+
+	it("labels options with A), B), C), etc.", () => {
+		const lines = renderDivineQuery(snapshot(), 80).map(stripAnsi);
+		expect(lines.some((l) => l.includes("A)"))).toBe(true);
+		expect(lines.some((l) => l.includes("B)"))).toBe(true);
+		expect(lines.some((l) => l.includes("C)"))).toBe(true);
+	});
+});
+
+describe("updateDivineQuery — direct letter selection", () => {
+	it("a/A selects first option", () => {
+		expect(updateDivineQuery(snapshot(), "a").done).toBe(0);
+		expect(updateDivineQuery(snapshot(), "A").done).toBe(0);
+	});
+
+	it("b selects second option", () => {
+		expect(updateDivineQuery(snapshot(), "b").done).toBe(1);
+	});
+
+	it("ignores letters beyond the option count", () => {
+		expect(updateDivineQuery(snapshot(), "d").done).toBeUndefined();
+	});
+});
+
+describe("updateDivineQuery — arrow/tab navigation", () => {
+	it("down cycles focused index forward", () => {
+		const r1 = updateDivineQuery(snapshot({ focusedIndex: 0 }), "down");
+		expect(r1.snapshot.focusedIndex).toBe(1);
+		const r2 = updateDivineQuery(snapshot({ focusedIndex: 2 }), "down");
+		expect(r2.snapshot.focusedIndex).toBe(0); // wraps
+	});
+
+	it("up cycles backward", () => {
+		const r = updateDivineQuery(snapshot({ focusedIndex: 0 }), "up");
+		expect(r.snapshot.focusedIndex).toBe(2); // wraps
+	});
+
+	it("j/k also navigate", () => {
+		expect(updateDivineQuery(snapshot({ focusedIndex: 0 }), "j").snapshot.focusedIndex).toBe(1);
+		expect(updateDivineQuery(snapshot({ focusedIndex: 1 }), "k").snapshot.focusedIndex).toBe(0);
+	});
+});
+
+describe("updateDivineQuery — enter + escape", () => {
+	it("enter selects the focused option", () => {
+		const r = updateDivineQuery(snapshot({ focusedIndex: 2 }), "enter");
+		expect(r.done).toBe(2);
+	});
+
+	it("escape returns -1 (retreat)", () => {
+		const r = updateDivineQuery(snapshot(), "escape");
+		expect(r.done).toBe(-1);
+	});
+});

--- a/src/divine-query.ts
+++ b/src/divine-query.ts
@@ -1,0 +1,253 @@
+/**
+ * Cathedral Divine Query modal (Element 11 from CATHEDRAL_UX_SPEC_V2.md).
+ *
+ * Replaces Pi's default `ctx.ui.select` rendering with a Scriptorium-themed
+ * overlay when SumoCode is active.
+ *
+ * Visual:
+ *
+ *                            ✾  DIVINE QUERY  ✾
+ *
+ *            ──────────────────────  ·  ──────────────────────
+ *
+ *     Should I rename `getUser` to `fetchUser`?
+ *
+ *     ❈   A) Yes, rename it everywhere
+ *     ·   B) No, leave it as-is
+ *     ·   C) Use a different name
+ *
+ *            ──────────────────────  ·  ──────────────────────
+ *                    ↑↓ wander    ⏎ answer    ⎋ retreat
+ *
+ * Bible source:
+ *   docs/ui/bible/11-divine-query-rename.html
+ *   docs/ui/bible/11-divine-query-yesno.html
+ */
+
+import type { Component, OverlayOptions } from "@mariozechner/pi-tui";
+import { matchesKey } from "@mariozechner/pi-tui";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { CATHEDRAL_TOKENS } from "./tokens.js";
+
+const RESET = "\u001b[0m";
+const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+
+function visibleLength(text: string): number {
+	return text.replace(ANSI_PATTERN, "").length;
+}
+
+function fg(text: string, hex: string): string {
+	const h = hex.replace("#", "");
+	const r = parseInt(h.slice(0, 2), 16);
+	const g = parseInt(h.slice(2, 4), 16);
+	const b = parseInt(h.slice(4, 6), 16);
+	return `\u001b[38;2;${r};${g};${b}m${text}${RESET}`;
+}
+
+function persistentBg(text: string, fgHex: string, bgHex: string): string {
+	const fh = fgHex.replace("#", "");
+	const bh = bgHex.replace("#", "");
+	const fr = parseInt(fh.slice(0, 2), 16);
+	const fgCode = parseInt(fh.slice(2, 4), 16);
+	const fb = parseInt(fh.slice(4, 6), 16);
+	const br = parseInt(bh.slice(0, 2), 16);
+	const bg = parseInt(bh.slice(2, 4), 16);
+	const bb = parseInt(bh.slice(4, 6), 16);
+	const styleCode = `\u001b[38;2;${fr};${fgCode};${fb}m\u001b[48;2;${br};${bg};${bb}m`;
+	// Restore both fg+bg after every reset so lifted bg persists through inner ANSI
+	return `${styleCode}${text.replace(/\u001b\[0m/g, `${RESET}${styleCode}`)}${RESET}`;
+}
+
+function center(line: string, width: number): string {
+	const len = visibleLength(line);
+	if (len >= width) return line;
+	const pad = Math.floor((width - len) / 2);
+	return `${" ".repeat(pad)}${line}${" ".repeat(width - len - pad)}`;
+}
+
+function padRight(line: string, width: number): string {
+	const len = visibleLength(line);
+	if (len >= width) return line;
+	return `${line}${" ".repeat(width - len)}`;
+}
+
+// ── Snapshot ──────────────────────────────────────────────────
+
+export interface DivineQuerySnapshot {
+	readonly title: string;
+	readonly options: readonly string[];
+	readonly focusedIndex: number;
+}
+
+// ── Pure render ──────────────────────────────────────────────
+
+const TITLE_MARK = "✾";
+const FOCUSED_MARK = "❈";
+const UNFOCUSED_MARK = "·";
+
+function splitRule(width: number): string {
+	const ruleLen = Math.max(1, Math.floor((width - 6) / 2 - 15));
+	const left = fg("─".repeat(ruleLen), CATHEDRAL_TOKENS.colors.divider);
+	const dot = fg("·", CATHEDRAL_TOKENS.colors.divider);
+	const right = fg("─".repeat(ruleLen), CATHEDRAL_TOKENS.colors.divider);
+	return center(`${left}  ${dot}  ${right}`, width);
+}
+
+function optionLabel(index: number): string {
+	return `${String.fromCharCode(65 + index)}) `;
+}
+
+export function renderDivineQuery(snapshot: DivineQuerySnapshot, width: number): string[] {
+	const lines: string[] = [];
+	const indent = "     ";
+
+	// Blank
+	lines.push("");
+
+	// Title: ✾  DIVINE QUERY  ✾
+	const titleText = `${fg(TITLE_MARK, CATHEDRAL_TOKENS.colors.accent)}  ${fg("DIVINE QUERY", CATHEDRAL_TOKENS.colors.accent)}  ${fg(TITLE_MARK, CATHEDRAL_TOKENS.colors.accent)}`;
+	lines.push(center(titleText, width));
+
+	// Blank
+	lines.push("");
+
+	// Split rule
+	lines.push(splitRule(width));
+
+	// Blank
+	lines.push("");
+
+	// Question body
+	lines.push(padRight(`${indent}${fg(snapshot.title, CATHEDRAL_TOKENS.colors.foreground)}`, width));
+
+	// Blank
+	lines.push("");
+
+	// Options
+	for (let i = 0; i < snapshot.options.length; i += 1) {
+		const focused = i === snapshot.focusedIndex;
+		const mark = focused
+			? fg(FOCUSED_MARK, CATHEDRAL_TOKENS.colors.accent)
+			: fg(UNFOCUSED_MARK, CATHEDRAL_TOKENS.colors.divider);
+		const label = `${optionLabel(i)}${snapshot.options[i]}`;
+		const text = focused
+			? fg(label, CATHEDRAL_TOKENS.colors.foreground)
+			: fg(label, CATHEDRAL_TOKENS.colors.foregroundDim);
+		lines.push(padRight(`${indent}${mark}   ${text}`, width));
+	}
+
+	// Blank
+	lines.push("");
+
+	// Split rule
+	lines.push(splitRule(width));
+
+	// Footer
+	const footer = fg("↑↓ wander    ⏎ answer    ⎋ retreat", CATHEDRAL_TOKENS.colors.foregroundDim);
+	lines.push(center(footer, width));
+
+	// Blank
+	lines.push("");
+
+	// Wrap all lines with persistent surfaceLifted bg + foreground fg
+	return lines.map((line) => persistentBg(
+		padRight(line, width),
+		CATHEDRAL_TOKENS.colors.foreground,
+		CATHEDRAL_TOKENS.colors.surfaceLifted,
+	));
+}
+
+// ── State machine ────────────────────────────────────────────
+
+export interface DivineQueryInputResult {
+	readonly snapshot: DivineQuerySnapshot;
+	readonly done?: number; // selected index, or -1 for escape
+}
+
+export function updateDivineQuery(snapshot: DivineQuerySnapshot, data: string): DivineQueryInputResult {
+	const count = snapshot.options.length;
+	if (count === 0) return { snapshot };
+
+	// Direct letter selection: a/b/c/...
+	const lower = data.toLowerCase();
+	const letterIndex = lower.charCodeAt(0) - 97;
+	if (lower.length === 1 && letterIndex >= 0 && letterIndex < count) {
+		return { snapshot: { ...snapshot, focusedIndex: letterIndex }, done: letterIndex };
+	}
+
+	// Arrow / tab navigation
+	if (data === "down" || matchesKey(data, "down") || data === "tab" || matchesKey(data, "tab") || data === "j") {
+		return { snapshot: { ...snapshot, focusedIndex: (snapshot.focusedIndex + 1) % count } };
+	}
+	if (data === "up" || matchesKey(data, "up") || data === "shift+tab" || matchesKey(data, "shift+tab") || data === "k") {
+		return { snapshot: { ...snapshot, focusedIndex: (snapshot.focusedIndex - 1 + count) % count } };
+	}
+
+	// Enter selects focused
+	if (data === "enter" || matchesKey(data, "enter") || data === "return" || matchesKey(data, "return")) {
+		return { snapshot, done: snapshot.focusedIndex };
+	}
+
+	// Escape retreats
+	if (data === "escape" || matchesKey(data, "escape")) {
+		return { snapshot, done: -1 };
+	}
+
+	return { snapshot };
+}
+
+// ── Pi component + overlay ───────────────────────────────────
+
+class DivineQueryComponent implements Component {
+	constructor(
+		private snapshot: DivineQuerySnapshot,
+		private readonly done: (result: number) => void,
+	) {}
+
+	invalidate(): void {}
+
+	handleInput(data: string): void {
+		const result = updateDivineQuery(this.snapshot, data);
+		this.snapshot = result.snapshot;
+		if (result.done !== undefined) this.done(result.done);
+	}
+
+	render(width: number): string[] {
+		return renderDivineQuery(this.snapshot, width);
+	}
+}
+
+export const DIVINE_QUERY_OVERLAY_OPTIONS: OverlayOptions = {
+	anchor: "center",
+	width: "60%",
+	minWidth: 50,
+
+	maxHeight: "80%",
+};
+
+/**
+ * Show a Divine Query modal. Returns the selected option string, or
+ * undefined if the user escapes.
+ */
+export async function showDivineQuery(
+	ctx: ExtensionContext,
+	title: string,
+	options: readonly string[],
+): Promise<string | undefined> {
+	const initialSnapshot: DivineQuerySnapshot = {
+		title,
+		options,
+		focusedIndex: 0,
+	};
+
+	const selectedIndex = await ctx.ui.custom<number>(
+		(_tui, _theme, _kb, done: (result: number) => void) =>
+			new DivineQueryComponent(initialSnapshot, done),
+		{ overlay: true, overlayOptions: DIVINE_QUERY_OVERLAY_OPTIONS },
+	);
+
+	if (selectedIndex < 0 || selectedIndex >= options.length) return undefined;
+	return options[selectedIndex];
+}
+
+

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -18,6 +18,7 @@ function buildPiStub() {
 		}),
 		registerCommand: vi.fn(),
 		registerShortcut: vi.fn(),
+		registerTool: vi.fn(),
 	};
 
 	return { pi, handlers };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,10 @@ import { dirname, join, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installInputHints } from "./cathedral/input-hints.js";
+import { installAnswerTool } from "./answer-tool.js";
 import { installApprovalGate } from "./approval-modal.js";
+import { installQuestionTool } from "./question-tool.js";
+
 import { installAltscreen } from "./cathedral/altscreen.js";
 import { installCathedralEditor } from "./cathedral/cathedral-editor.js";
 import { installSumoInteractions } from "./interaction-registry.js";
@@ -94,6 +97,11 @@ export default function sumocode(pi: ExtensionAPI): void {
 	installCathedralEditor(pi);
 	installInputHints(pi);
 	installApprovalGate(pi);
+	installQuestionTool(pi);
+	installAnswerTool(pi);
+
+
+
 	installWorkingIndicator(pi);
 	installSumoInteractions(pi);
 }

--- a/src/question-tool.ts
+++ b/src/question-tool.ts
@@ -1,0 +1,232 @@
+/**
+ * Cathedral question tool — single-question Divine Query overlay.
+ *
+ * Overrides Pi's default `question` tool with Scriptorium styling.
+ * The LLM invokes this when it needs a single user decision.
+ *
+ * Options render as a Divine Query modal. The last option is always
+ * "Type something…" which opens a Pi editor for free-text input.
+ */
+
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { Editor, type EditorTheme, Key, matchesKey, Text } from "@mariozechner/pi-tui";
+import { Type } from "typebox";
+import { renderDivineQuery, updateDivineQuery, type DivineQuerySnapshot, DIVINE_QUERY_OVERLAY_OPTIONS } from "./divine-query.js";
+
+const QuestionParams = Type.Object({
+	question: Type.String({ description: "The question to ask the user" }),
+	context: Type.Optional(Type.String({ description: "Optional context/help text shown under the question" })),
+	questions: Type.Optional(
+		Type.Array(
+			Type.Object({
+				question: Type.String({ description: "Question text to ask the user" }),
+				context: Type.Optional(Type.String({ description: "Optional context/help text shown under the question" })),
+			}),
+			{ minItems: 1, description: "Questions to ask, in order" },
+		),
+	),
+});
+
+const FREE_TEXT_LABEL = "Type something…";
+
+interface QuestionResult {
+	answer: string;
+	wasCustom: boolean;
+}
+
+async function showCathedralQuestion(
+	ctx: ExtensionContext,
+	title: string,
+	options: readonly string[],
+): Promise<QuestionResult | null> {
+	return ctx.ui.custom<QuestionResult | null>(
+		(tui, theme, _kb, done) => {
+			let snapshot: DivineQuerySnapshot = { title, options, focusedIndex: 0 };
+			let editMode = false;
+			let cachedLines: string[] | undefined;
+
+			const editorTheme: EditorTheme = {
+				borderColor: (s) => theme.fg("accent", s),
+				selectList: {
+					selectedPrefix: (t) => theme.fg("accent", t),
+					selectedText: (t) => theme.fg("accent", t),
+					description: (t) => theme.fg("muted", t),
+					scrollInfo: (t) => theme.fg("dim", t),
+					noMatch: (t) => theme.fg("warning", t),
+				},
+			};
+			const editor = new Editor(tui, editorTheme);
+
+			editor.onSubmit = (value) => {
+				const trimmed = value.trim();
+				if (trimmed) {
+					done({ answer: trimmed, wasCustom: true });
+				} else {
+					editMode = false;
+					editor.setText("");
+					refresh();
+				}
+			};
+
+			function refresh(): void {
+				cachedLines = undefined;
+				tui.requestRender();
+			}
+
+			function handleInput(data: string): void {
+				if (editMode) {
+					if (matchesKey(data, Key.escape)) {
+						editMode = false;
+						editor.setText("");
+						refresh();
+						return;
+					}
+					editor.handleInput(data);
+					refresh();
+					return;
+				}
+
+				const result = updateDivineQuery(snapshot, data);
+				snapshot = result.snapshot;
+
+				if (result.done !== undefined) {
+					if (result.done === -1) {
+						done(null);
+						return;
+					}
+					const selected = options[result.done];
+					if (selected === FREE_TEXT_LABEL) {
+						editMode = true;
+						refresh();
+						return;
+					}
+					done({ answer: selected ?? "", wasCustom: false });
+					return;
+				}
+
+				refresh();
+			}
+
+			function render(width: number): string[] {
+				if (cachedLines) return cachedLines;
+
+				const lines = renderDivineQuery(snapshot, width);
+
+				if (editMode) {
+					const RESET = "\u001b[0m";
+					const bgCode = "\u001b[48;2;61;48;36m"; // surfaceLifted
+					const pad = (s: string) => {
+						const stripped = s.replace(/\u001b\[[0-9;]*m/g, "");
+						const padding = Math.max(0, width - stripped.length);
+						return `${bgCode}${s}${" ".repeat(padding)}${RESET}`;
+					};
+					lines.push(pad(`     ${theme.fg("muted", "Your answer:")}`));
+					for (const line of editor.render(width - 6)) {
+						lines.push(pad(`     ${line}`));
+					}
+					lines.push(pad(""));
+					lines.push(pad(`     ${theme.fg("dim", "Enter to submit · Esc to go back")}`));
+					lines.push(pad(""));
+				}
+
+				cachedLines = lines;
+				return lines;
+			}
+
+			return {
+				render,
+				invalidate: () => { cachedLines = undefined; },
+				handleInput,
+			};
+		},
+		{ overlay: true, overlayOptions: DIVINE_QUERY_OVERLAY_OPTIONS },
+	);
+}
+
+export function installQuestionTool(pi: ExtensionAPI): void {
+	pi.registerTool({
+		name: "question",
+		label: "Question",
+		description: "Ask the user a question and let them pick from options. Use when you need user input to proceed. Do NOT prefix options with A)/B)/1./2. — the Cathedral UI adds labels automatically.",
+		parameters: QuestionParams,
+
+		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
+			if (!ctx.hasUI) {
+				return {
+					content: [{ type: "text", text: "Error: UI not available" }],
+					details: { cancelled: true, reason: "no_ui" },
+				};
+			}
+
+			// Normalize: support both single question and questions array
+			const questions = params.questions?.length
+				? params.questions
+				: params.question
+					? [{ question: params.question, context: params.context }]
+					: [];
+
+			if (questions.length === 0) {
+				return {
+					content: [{ type: "text", text: "No questions provided." }],
+					details: { cancelled: true, reason: "empty" },
+				};
+			}
+
+			// For single question, show Divine Query directly
+			if (questions.length === 1) {
+				const q = questions[0];
+				const title = q.context ? `${q.question}\n${q.context}` : q.question;
+				// No predefined options — just free text via the "Type something…" option
+				const result = await showCathedralQuestion(ctx, title, [FREE_TEXT_LABEL]);
+
+				if (!result) {
+					return {
+						content: [{ type: "text", text: "User cancelled." }],
+						details: { cancelled: true },
+					};
+				}
+
+				return {
+					content: [{ type: "text", text: `User answered: ${result.answer}` }],
+					details: { cancelled: false, answer: result.answer, wasCustom: result.wasCustom },
+				};
+			}
+
+			// For multiple questions, show them sequentially
+			const answers: { question: string; answer: string }[] = [];
+			for (const q of questions) {
+				const title = q.context ? `${q.question}\n${q.context}` : q.question;
+				const result = await showCathedralQuestion(ctx, title, [FREE_TEXT_LABEL]);
+
+				if (!result) {
+					return {
+						content: [{ type: "text", text: "User cancelled." }],
+						details: { cancelled: true, answeredSoFar: answers },
+					};
+				}
+
+				answers.push({ question: q.question, answer: result.answer });
+			}
+
+			const formatted = answers.map((a) => `Q: ${a.question}\nA: ${a.answer}`).join("\n\n");
+			return {
+				content: [{ type: "text", text: `User answered:\n\n${formatted}` }],
+				details: { cancelled: false, entries: answers },
+			};
+		},
+
+		renderCall(args, theme) {
+			const q = args.question ?? (Array.isArray(args.questions) ? args.questions[0]?.question : "");
+			return new Text(theme.fg("toolTitle", theme.bold("question ")) + theme.fg("muted", q), 0, 0);
+		},
+
+		renderResult(result, _options, theme) {
+			const details = result.details as { cancelled?: boolean; answer?: string; entries?: { answer: string }[] } | undefined;
+			if (!details || details.cancelled) {
+				return new Text(theme.fg("warning", "Cancelled"), 0, 0);
+			}
+			const answer = details.answer ?? details.entries?.map((e) => e.answer).join(", ") ?? "";
+			return new Text(theme.fg("success", "✓ ") + theme.fg("accent", answer), 0, 0);
+		},
+	});
+}


### PR DESCRIPTION
## Summary

Implements the Scriptorium-themed Divine Query modal — replaces Pi's default `ctx.ui.select` rendering for SumoCode components.

### Rendering

```
                            ✾  DIVINE QUERY  ✾

         ──────────────────────  ·  ──────────────────────

     Should I rename \`getUser\` to \`fetchUser\`?

     ❈   A) Yes, rename it everywhere
     ·   B) No, leave it as-is
     ·   C) Use a different name

         ──────────────────────  ·  ──────────────────────
                 ↑↓ wander    ⏎ answer    ⎋ retreat
```

### Changes

- `src/divine-query.ts` — renderer, state machine, `showDivineQuery()` API
- `src/divine-query.test.ts` — 17 tests (render, navigation, selection)
- `src/command-palette.ts` — MODEL/THINKING/THEME selects now use Divine Query
- `src/extension.ts` — exposes `showDivineQuery` on the extension API

### Verification

```
pnpm test              # 540/540 ✅
pnpm test:integration  # 18/18 ✅
pnpm visual:ci         # 14 scenarios, 6 passed ✅
pnpm tsc --noEmit      # ✅
pnpm build             # ✅
```

Closes #140
Tracker: #124 Phase 5