### PR TITLE
fix(input): position cursor after prompt, not after placeholder

### DIFF
--- a/src/cathedral/cathedral-editor.ts
+++ b/src/cathedral/cathedral-editor.ts
@@ -237,10 +237,10 @@ class CathedralEditor extends CustomEditor {
 				// Preserve Pi's zero-width cursor marker while painting our ghost text.
 				// Without this, TUI.positionHardwareCursor() sees no marker on the
 				// splash empty state and emits \x1b[?25l after every render.
-				const prompt = ` ${color(">", CATHEDRAL_TOKENS.colors.accent)} `;
+				const prompt = ` ${color(">", CATHEDRAL_TOKENS.colors.accent)} ${CURSOR_MARKER}`;
 				const maxPlaceholder = Math.max(0, frameWidth - 2 - visibleLength(prompt));
 				const placeholder = ellipsize(INPUT_FRAME_PLACEHOLDER, maxPlaceholder);
-				const ghost = `${prompt}${color(`${placeholder}${CURSOR_MARKER}`, CATHEDRAL_TOKENS.colors.foregroundDim)}`;
+				const ghost = `${prompt}${color(placeholder, CATHEDRAL_TOKENS.colors.foregroundDim)}`;
 				return fullRow(wrapRow(ghost, frameWidth, paintFrameBackground));
 			}
 			if (!splash) return wrapActiveRow(row, frameWidth, paintFrameBackground, isFirstContent);


### PR DESCRIPTION
## Problem

The splash input cursor was positioned at the end of the ghost placeholder text:

```
> Ask anything... "Refactor the auth flow."█
```

Instead of right after the `>` prompt where the user starts typing:

```
> █Ask anything... "Refactor the auth flow."
```

## Fix

Move `CURSOR_MARKER` into the prompt string before the placeholder ghost text so Pi's `positionHardwareCursor()` lands at the typing position.

## Verification

```
pnpm test        # 523/523 ✅
pnpm tsc --noEmit # ✅
```

Found during manual smoke test.