### PR TITLE
fix(layout): reserve sidebar gutter and input rows

### DIFF
--- a/src/sidebar-placement.test.ts
+++ b/src/sidebar-placement.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+	PORTRAIT_SIDEBAR_GUTTER_WIDTH,
 	SIDEBAR_MIN_TERMINAL_WIDTH,
+	SIDEBAR_OVERLAY_BOTTOM_RESERVED_ROWS,
+	SIDEBAR_OVERLAY_TOP_MARGIN_ROWS,
 	SIDEBAR_WIDTH,
+	SIDEBAR_GUTTER_WIDTH,
 	StaticSidebarDock,
+	sidebarGutterWidth,
 	chooseSidebarAnchor,
 	dockStaticSidebar,
 	installNonCapturingSidebarOverlay,
@@ -32,6 +37,11 @@ describe("sidebar placement", () => {
 		expect(chooseSidebarAnchor(140, 80, "bottom-right")).toBe("bottom-right");
 	});
 
+	it("uses a wider sidebar gutter for portrait-wide terminals", () => {
+		expect(sidebarGutterWidth(160, 45)).toBe(SIDEBAR_GUTTER_WIDTH);
+		expect(sidebarGutterWidth(130, 180)).toBe(PORTRAIT_SIDEBAR_GUTTER_WIDTH);
+	});
+
 	it("renders the legacy dock with clipped sidebar height", () => {
 		const left = component(["chat row"]);
 		const right = component(["SIDE 1", "SIDE 2", "SIDE 3"]);
@@ -39,7 +49,7 @@ describe("sidebar placement", () => {
 
 		const lines = dock.render(160).map(stripAnsi);
 
-		expect(left.renderCalls).toEqual([160 - SIDEBAR_WIDTH - 1]);
+		expect(left.renderCalls).toEqual([160 - SIDEBAR_WIDTH - SIDEBAR_GUTTER_WIDTH]);
 		expect(right.renderCalls).toEqual([SIDEBAR_WIDTH]);
 		expect(lines).toHaveLength(1);
 		expect(lines[0]).toContain("chat row");
@@ -89,6 +99,12 @@ describe("sidebar placement", () => {
 		expect(showOverlay).toHaveBeenCalledWith(sidebar, expect.objectContaining({
 			width: SIDEBAR_WIDTH,
 			anchor: "top-right",
+			margin: {
+				top: SIDEBAR_OVERLAY_TOP_MARGIN_ROWS,
+				right: 0,
+				bottom: SIDEBAR_OVERLAY_BOTTOM_RESERVED_ROWS,
+				left: 0,
+			},
 			nonCapturing: true,
 		}));
 		const options = showOverlay.mock.calls[0]![1];

--- a/src/sidebar-placement.ts
+++ b/src/sidebar-placement.ts
@@ -33,7 +33,18 @@ export function chooseSidebarAnchor(
 	return "right-center";
 }
 
-const STATIC_SIDEBAR_GUTTER = 1;
+export const SIDEBAR_GUTTER_WIDTH = 2;
+export const PORTRAIT_SIDEBAR_GUTTER_WIDTH = 4;
+export const SIDEBAR_OVERLAY_TOP_MARGIN_ROWS = 2;
+export const SIDEBAR_OVERLAY_BOTTOM_RESERVED_ROWS = 8;
+
+export function sidebarOverlayTargetRows(termHeight: number): number {
+	return Math.max(1, Math.floor(termHeight) - SIDEBAR_OVERLAY_TOP_MARGIN_ROWS - SIDEBAR_OVERLAY_BOTTOM_RESERVED_ROWS);
+}
+
+export function sidebarGutterWidth(termWidth: number, termHeight: number): number {
+	return termHeight > termWidth ? PORTRAIT_SIDEBAR_GUTTER_WIDTH : SIDEBAR_GUTTER_WIDTH;
+}
 const STATIC_SIDEBAR_DOCK_MARKER = Symbol("sumocode.staticSidebarDock");
 
 type MutableTuiRoot = {
@@ -85,7 +96,7 @@ export class StaticSidebarDock implements Component {
 			return renderComponents(this.mainComponents, width);
 		}
 
-		const mainWidth = Math.max(1, width - SIDEBAR_WIDTH - STATIC_SIDEBAR_GUTTER);
+		const mainWidth = Math.max(1, width - SIDEBAR_WIDTH - SIDEBAR_GUTTER_WIDTH);
 		const mainLines = renderComponents(this.mainComponents, mainWidth);
 		const sidebarLines = this.sidebarComponent.render(SIDEBAR_WIDTH);
 		// The dock is part of Pi's vertical root flow above the editor/footer. Its
@@ -109,7 +120,7 @@ export class StaticSidebarDock implements Component {
 			const right = i < sidebarLines.length
 				? padToWidth(sidebarLines[i]!, SIDEBAR_WIDTH)
 				: blankSidebarRow;
-			lines.push(`${left}${" ".repeat(STATIC_SIDEBAR_GUTTER)}${right}`);
+			lines.push(`${left}${" ".repeat(SIDEBAR_GUTTER_WIDTH)}${right}`);
 		}
 
 		return lines;
@@ -168,7 +179,7 @@ export function installNonCapturingSidebarOverlay(
 	const overlayOptions: OverlayOptions = {
 		width: SIDEBAR_WIDTH,
 		anchor: "top-right",
-		margin: { top: 1, right: 0, bottom: 6, left: 0 },
+		margin: { top: SIDEBAR_OVERLAY_TOP_MARGIN_ROWS, right: 0, bottom: SIDEBAR_OVERLAY_BOTTOM_RESERVED_ROWS, left: 0 },
 		maxHeight: "100%",
 		nonCapturing: true,
 		visible: (termWidth) => termWidth >= SIDEBAR_MIN_TERMINAL_WIDTH && shouldShowSidebar(),

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -79,7 +79,7 @@ describe("StaticSidebarDock", () => {
 
 		const lines = dock.render(160).map(stripAnsi);
 
-		expect(left.renderCalls).toEqual([160 - SIDEBAR_WIDTH - 1]);
+		expect(left.renderCalls).toEqual([160 - SIDEBAR_WIDTH - 2]);
 		expect(right.renderCalls).toEqual([SIDEBAR_WIDTH]);
 		expect(lines[0]).toContain("hello from chat");
 		expect(lines[0]).toContain("CTX");

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -14,7 +14,7 @@ import {
 	type SidebarSubTab,
 } from "./sumo-tui/cathedral/sidebar-rendering.js";
 import { surfaceLine } from "./sumo-tui/cathedral/ansi.js";
-import { installNonCapturingSidebarOverlay } from "./sidebar-placement.js";
+import { installNonCapturingSidebarOverlay, sidebarOverlayTargetRows } from "./sidebar-placement.js";
 export {
 	SIDEBAR_MIN_TERMINAL_WIDTH,
 	SIDEBAR_WIDTH,
@@ -28,14 +28,6 @@ export {
 export const SIDEBAR_MEMORY_DEBOUNCE_MS = 200;
 /** Retry cadence while Remnic is unavailable. */
 export const SIDEBAR_MEMORY_RETRY_MS = 5_000;
-/**
- * Rows the sidebar yields to chrome above (top breathing + top bar) and below
- * (input frame, hint row, footer, breathing). Tuned to match the V2 Bible
- * active landscape scene where the registry surface ends just above the input
- * frame.
- */
-const ACTIVE_LANDSCAPE_NON_SIDEBAR_ROWS = 7;
-
 /** Static placeholder until Pi exposes MCP server health. */
 export const PLACEHOLDER_MCP: readonly McpServerSnapshot[] = [
 	{ name: "github", status: "idle" },
@@ -245,7 +237,7 @@ export function installSidebar(pi: ExtensionAPI): void {
 						width,
 					);
 					const terminalRows = (tui.terminal as { rows?: number } | undefined)?.rows ?? lines.length;
-					const targetRows = Math.max(lines.length, terminalRows - ACTIVE_LANDSCAPE_NON_SIDEBAR_ROWS);
+					const targetRows = Math.max(lines.length, sidebarOverlayTargetRows(terminalRows));
 					return [
 						...lines,
 						...Array.from({ length: Math.max(0, targetRows - lines.length) }, () => surfaceLine("", width)),

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { SIDEBAR_WIDTH } from "../../sidebar.js";
+import { PORTRAIT_SIDEBAR_GUTTER_WIDTH, SIDEBAR_GUTTER_WIDTH } from "../../sidebar-placement.js";
 import { SumoNode } from "../layout/node.js";
 import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga } from "../layout/yoga.js";
 import { bufferToAnsiLines } from "../render/ansi-writer.js";
@@ -82,7 +83,7 @@ describe("ChatViewportController", () => {
 
 		chat.addMessage("user", "hello");
 		controller.render(130);
-		expect(runtime.renderCalls.at(-1)).toEqual({ width: 130 - SIDEBAR_WIDTH, height: 12 });
+		expect(runtime.renderCalls.at(-1)).toEqual({ width: 130 - SIDEBAR_WIDTH - SIDEBAR_GUTTER_WIDTH, height: 12 });
 		root.dispose();
 
 		const portrait = await makeController({ terminalRows: 100, terminalColumns: 60 });
@@ -90,6 +91,12 @@ describe("ChatViewportController", () => {
 		portrait.controller.render(60);
 		expect(portrait.runtime.renderCalls.at(-1)).toMatchObject({ width: 59 });
 		portrait.root.dispose();
+
+		const portraitWide = await makeController({ terminalRows: 180, terminalColumns: 130 });
+		portraitWide.chat.addMessage("user", "hello");
+		portraitWide.controller.render(130);
+		expect(portraitWide.runtime.renderCalls.at(-1)).toEqual({ width: 130 - SIDEBAR_WIDTH - PORTRAIT_SIDEBAR_GUTTER_WIDTH, height: 176 });
+		portraitWide.root.dispose();
 	});
 
 	it("translates wheel and jump-to-bottom input into local viewport repaint", async () => {

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -6,6 +6,7 @@ import { chatMessageViewModelFromPiMessage, chatMessageViewModelToPlainText, tra
 import { ChatPager } from "../widgets/chat-pager.js";
 import { chatScrollCommandFromInput } from "../widgets/chat-scroll-command.js";
 import { SIDEBAR_MIN_TERMINAL_WIDTH, SIDEBAR_WIDTH } from "../../sidebar.js";
+import { sidebarGutterWidth } from "../../sidebar-placement.js";
 
 const CHAT_VIEWPORT_BRIDGE_INSTALLED = Symbol("sumo-tui.chat-viewport-bridge-installed");
 const PORTRAIT_STATUS_MIN_WIDTH = 80;
@@ -174,10 +175,12 @@ export class ChatViewportController {
 		// predicate Pi uses for showing the sidebar is true. The sidebar's own
 		// right-side cols come from Pi's separate widget paint.
 		const terminalWidth = Math.max(1, Math.floor(width));
+		const terminalHeight = Math.max(1, this.host.ui?.terminal?.rows ?? 24);
 		const sidebarVisible = terminalWidth >= SIDEBAR_MIN_TERMINAL_WIDTH && this.chat.hasMessages();
+		const sidebarGutter = sidebarVisible ? sidebarGutterWidth(terminalWidth, terminalHeight) : 0;
 		const portraitGutterVisible = !sidebarVisible && this.chat.hasMessages() && terminalWidth < PORTRAIT_CHAT_GUTTER_MIN_WIDTH;
 		const effectiveWidth = sidebarVisible
-			? Math.max(1, terminalWidth - SIDEBAR_WIDTH)
+			? Math.max(1, terminalWidth - SIDEBAR_WIDTH - sidebarGutter)
 			: portraitGutterVisible
 				? Math.max(1, terminalWidth - 1)
 				: terminalWidth;


### PR DESCRIPTION
## Fixes

Closes #157.

- Restores the Bible's 2-column gutter between chat content and the sidebar in landscape.
- Adds a wider 4-column gutter for wide portrait terminals where the sidebar is still visible.
- Reserves more bottom rows for input frame + hint/footer so the sidebar no longer bleeds into the input panel.
- Moves sidebar row math into shared layout constants instead of duplicating the old `terminalRows - 7` magic number.
- Applies the same gutter policy to retained chat viewport width calculation and the legacy sidebar dock path.

## Visual evidence

Ran:

```bash
pnpm visual:ci -- --scenario active-landscape-runtime
pnpm visual:ci -- --scenario active-portrait-runtime
```

Results are `review` as expected for broader runtime/Bible drift, but the landscape screenshot now shows:
- sidebar stops above the input frame
- visible gutter between chat/user frame and sidebar

The canonical portrait scenario remains no-sidebar per policy (`60x100`). A new unit test covers the wide-portrait sidebar case (`130x180`) and verifies the wider gutter reservation.

## Verification

```bash
pnpm exec tsc --noEmit
pnpm test -- src/sidebar-placement.test.ts src/sidebar.test.ts src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
pnpm build
```

All passed.
