### PR TITLE
fix(chat): fold live tool results into SUMO messages

### DIFF
--- a/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
@@ -134,6 +134,47 @@ describe("ChatViewportController", () => {
 		root.dispose();
 	});
 
+	it("folds live tool results into the active SUMO message", async () => {
+		const { root, chat, runtime, controller } = await makeController();
+
+		controller.handleAgentEvent({ type: "message_start", message: { role: "assistant", content: "" } });
+		controller.handleAgentEvent({ type: "message_update", message: { role: "assistant", content: "Reading." }, assistantMessageEvent: { type: "text_delta", delta: "Reading." } });
+		controller.handleAgentEvent({
+			type: "message_update",
+			message: {
+				role: "assistant",
+				content: [
+					{ type: "text", text: "Reading." },
+					{ type: "toolCall", id: "tc1", name: "read", arguments: { path: "src/auth/session.ts" } },
+				],
+			},
+		});
+		controller.handleAgentEvent({ type: "message_end", message: { role: "assistant", content: [{ type: "text", text: "Reading." }, { type: "toolCall", id: "tc1", name: "read", arguments: { path: "src/auth/session.ts" } }] } });
+		controller.handleAgentEvent({ type: "message_start", message: { role: "toolResult", toolCallId: "tc1", toolName: "read", content: [{ type: "text", text: "file contents" }] } });
+
+		const messages = chat.getRenderedMessages().map((message) => message.toSnapshot());
+		expect(messages).toHaveLength(1);
+		expect(messages[0]?.role).toBe("sumo");
+		expect(messages[0]?.blocks).toEqual([
+			{ type: "markdown", text: "Reading." },
+			{ type: "tool", tool: { id: "tc1", name: "read", status: "success", input: { path: "src/auth/session.ts" }, output: "file contents", details: undefined, error: undefined } },
+		]);
+		expect(runtime.noteUserMessage).not.toHaveBeenCalled();
+		root.dispose();
+	});
+
+	it("keeps assistant-only tool blocks under SUMO instead of TOOL", async () => {
+		const { root, chat, controller } = await makeController();
+
+		controller.handleAgentEvent({ type: "message_start", message: { role: "assistant", content: "" } });
+		controller.handleAgentEvent({ type: "message_update", message: { role: "assistant", content: [{ type: "toolCall", id: "tc1", name: "bash", arguments: { command: "pnpm test" } }] } });
+
+		const message = chat.getRenderedMessages()[0]?.toSnapshot();
+		expect(message?.role).toBe("sumo");
+		expect(message?.blocks?.[0]).toMatchObject({ type: "tool", tool: { id: "tc1", name: "bash", status: "pending" } });
+		root.dispose();
+	});
+
 	it("mirrors Pi tool expansion state into retained chat tool blocks", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -2,7 +2,14 @@ import { parseSgrMouseStream, type MouseEvent } from "../input/mouse.js";
 import type { KeyEvent } from "../input/key-router.js";
 import { logDiagnostic } from "../runtime/diagnostics.js";
 import { measureMaybe, ResumeProfiler, type ResumeProfileMetadata } from "../runtime/resume-profiler.js";
-import { chatMessageViewModelFromPiMessage, chatMessageViewModelToPlainText, transcriptFromSessionContext, type ChatMessageViewModel } from "../transcript/view-model.js";
+import {
+	chatMessageViewModelFromPiMessage,
+	chatMessageViewModelToPlainText,
+	markdownAndCodeBlocksFromText,
+	transcriptFromSessionContext,
+	type ChatBlock,
+	type ChatMessageViewModel,
+} from "../transcript/view-model.js";
 import { ChatPager } from "../widgets/chat-pager.js";
 import { chatScrollCommandFromInput } from "../widgets/chat-scroll-command.js";
 import { SIDEBAR_MIN_TERMINAL_WIDTH, SIDEBAR_WIDTH } from "../../sidebar.js";
@@ -122,6 +129,37 @@ function addViewModel(chat: ChatPager, message: ChatMessageViewModel): void {
 	chat.addViewModel(message);
 }
 
+function isToolOnlyViewModel(message: ChatMessageViewModel): boolean {
+	return message.blocks.length > 0 && message.blocks.every((block) => block.type === "tool");
+}
+
+function mergeToolBlock(existing: ChatBlock, incoming: ChatBlock): ChatBlock {
+	if (existing.type !== "tool" || incoming.type !== "tool") return incoming;
+	return {
+		type: "tool",
+		tool: {
+			...existing.tool,
+			...incoming.tool,
+			input: incoming.tool.input ?? existing.tool.input,
+			details: incoming.tool.details ?? existing.tool.details,
+		},
+	};
+}
+
+function upsertToolBlock(blocks: readonly ChatBlock[], incoming: ChatBlock): ChatBlock[] {
+	if (incoming.type !== "tool") return [...blocks, incoming];
+	const incomingId = incoming.tool.id;
+	const byId = incomingId
+		? blocks.findIndex((block) => block.type === "tool" && block.tool.id === incomingId)
+		: -1;
+	const byName = byId === -1
+		? blocks.findIndex((block) => block.type === "tool" && block.tool.id === undefined && block.tool.name === incoming.tool.name && (block.tool.status === "pending" || block.tool.status === "running"))
+		: -1;
+	const index = byId !== -1 ? byId : byName;
+	if (index === -1) return [...blocks, incoming];
+	return blocks.map((block, blockIndex) => blockIndex === index ? mergeToolBlock(block, incoming) : block);
+}
+
 function renderableLineCount(component: PiRenderableComponent | undefined, width: number): number {
 	if (!component) return 0;
 	try {
@@ -153,6 +191,8 @@ function countUserMessages(messages: readonly unknown[]): number {
  */
 export class ChatViewportController {
 	private lastAssistantText = "";
+	private liveAssistant: ChatMessageViewModel | undefined;
+	private liveAssistantBlocks: ChatBlock[] = [];
 	private lastChatTop = 0;
 	private lastChatWidth = 1;
 	private lastChatHeight = 1;
@@ -193,6 +233,8 @@ export class ChatViewportController {
 	public clear(): void {
 		this.chat.clearMessages();
 		this.lastAssistantText = "";
+		this.liveAssistant = undefined;
+		this.liveAssistantBlocks = [];
 		this.pendingMouseInput = "";
 		this.runtime.setEmptyChatQuoteState({ active: false, userMessageCount: 0 });
 	}
@@ -286,6 +328,8 @@ export class ChatViewportController {
 
 	public renderSessionContext(sessionContext: unknown): void {
 		this.lastAssistantText = "";
+		this.liveAssistant = undefined;
+		this.liveAssistantBlocks = [];
 		this.pendingMouseInput = "";
 		// Resume uses bulk transcript replacement instead of `clear()` + per-message
 		// replay; `replaceViewModels()` resets the chat-side scroll/banner state.
@@ -306,14 +350,21 @@ export class ChatViewportController {
 
 	private handleMessageStart(message: unknown): void {
 		const role = asRecord(message)?.role;
-		if (role === "user") this.runtime.noteUserMessage();
+		if (role === "user") {
+			this.liveAssistant = undefined;
+			this.liveAssistantBlocks = [];
+			this.runtime.noteUserMessage();
+		}
 		if (role === "assistant") {
-			this.lastAssistantText = "";
-			this.chat.addMessage("sumo", "");
+			this.startAssistantMessage(message);
 			return;
 		}
 		const viewModel = chatMessageViewModelFromPiMessage(message);
 		if (!viewModel || chatMessageViewModelToPlainText(viewModel).length === 0) return;
+		if (isToolOnlyViewModel(viewModel) && this.liveAssistant) {
+			this.foldToolBlocksIntoAssistant(viewModel.blocks);
+			return;
+		}
 		addViewModel(this.chat, viewModel);
 	}
 
@@ -321,15 +372,20 @@ export class ChatViewportController {
 		if (asRecord(message)?.role !== "assistant") return;
 		const streamEvent = asRecord(assistantMessageEvent);
 		if (streamEvent?.type === "text_delta" && typeof streamEvent.delta === "string") {
-			this.chat.appendToLast(streamEvent.delta);
-			this.lastAssistantText += streamEvent.delta;
+			this.appendAssistantTextDelta(streamEvent.delta);
 			return;
 		}
 		const viewModel = chatMessageViewModelFromPiMessage(message);
 		const text = viewModel ? chatMessageViewModelToPlainText(viewModel) : textFromAgentMessage(message);
 		if (text.length === 0 || text === this.lastAssistantText) return;
-		if (viewModel) this.chat.replaceLastWithViewModel(viewModel);
-		else this.chat.replaceLast(text);
+		if (viewModel) {
+			this.liveAssistant = { ...viewModel, role: "sumo", displayName: "SUMO" };
+			this.liveAssistantBlocks = [...viewModel.blocks];
+			this.chat.replaceLastWithViewModel(this.liveAssistant);
+		} else {
+			this.chat.replaceLast(text);
+			this.liveAssistantBlocks = markdownAndCodeBlocksFromText(text);
+		}
 		this.lastAssistantText = text;
 	}
 
@@ -338,12 +394,60 @@ export class ChatViewportController {
 			const viewModel = chatMessageViewModelFromPiMessage(message);
 			const text = viewModel ? chatMessageViewModelToPlainText(viewModel) : textFromAgentMessage(message);
 			if (text.length > 0 && text !== this.lastAssistantText) {
-				if (viewModel) this.chat.replaceLastWithViewModel(viewModel);
-				else this.chat.replaceLast(text);
+				if (viewModel) {
+					this.liveAssistant = { ...viewModel, role: "sumo", displayName: "SUMO" };
+					this.liveAssistantBlocks = [...viewModel.blocks];
+					this.chat.replaceLastWithViewModel(this.liveAssistant);
+				} else {
+					this.chat.replaceLast(text);
+					this.liveAssistantBlocks = markdownAndCodeBlocksFromText(text);
+				}
 				this.lastAssistantText = text;
 			}
 			this.chat.endStreaming();
 		}
+	}
+
+	private startAssistantMessage(message: unknown): void {
+		const viewModel = chatMessageViewModelFromPiMessage(message);
+		this.liveAssistant = viewModel
+			? { ...viewModel, role: "sumo", displayName: "SUMO" }
+			: { id: "live-assistant", role: "sumo", displayName: "SUMO", blocks: [{ type: "markdown", text: "" }] };
+		this.liveAssistantBlocks = viewModel ? [...viewModel.blocks] : [];
+		this.lastAssistantText = chatMessageViewModelToPlainText({ ...this.liveAssistant, blocks: this.liveAssistantBlocks });
+		this.chat.addViewModel({ ...this.liveAssistant, blocks: this.liveAssistantBlocks.length > 0 ? this.liveAssistantBlocks : [{ type: "markdown", text: "" }] });
+	}
+
+	private appendAssistantTextDelta(delta: string): void {
+		if (!this.liveAssistant) {
+			this.chat.appendToLast(delta);
+			this.lastAssistantText += delta;
+			return;
+		}
+		const lastBlock = this.liveAssistantBlocks.at(-1);
+		if (lastBlock?.type === "markdown") {
+			this.liveAssistantBlocks = this.liveAssistantBlocks.map((block, index) => index === this.liveAssistantBlocks.length - 1 && block.type === "markdown" ? { type: "markdown", text: block.text + delta } : block);
+		} else {
+			this.liveAssistantBlocks = [...this.liveAssistantBlocks, { type: "markdown", text: delta }];
+		}
+		this.lastAssistantText = chatMessageViewModelToPlainText({ ...this.liveAssistant, blocks: this.liveAssistantBlocks });
+		this.publishLiveAssistant();
+	}
+
+	private foldToolBlocksIntoAssistant(blocks: readonly ChatBlock[]): void {
+		for (const block of blocks) {
+			this.liveAssistantBlocks = upsertToolBlock(this.liveAssistantBlocks, block);
+		}
+		this.lastAssistantText = this.liveAssistant ? chatMessageViewModelToPlainText({ ...this.liveAssistant, blocks: this.liveAssistantBlocks }) : this.lastAssistantText;
+		this.publishLiveAssistant();
+	}
+
+	private publishLiveAssistant(): void {
+		if (!this.liveAssistant) return;
+		this.chat.replaceLastWithViewModel({
+			...this.liveAssistant,
+			blocks: this.liveAssistantBlocks.length > 0 ? this.liveAssistantBlocks : [{ type: "markdown", text: "" }],
+		});
 	}
 
 	private handleMouse(event: MouseEvent): boolean {

--- a/src/sumo-tui/widgets/chat-pager.ts
+++ b/src/sumo-tui/widgets/chat-pager.ts
@@ -32,7 +32,7 @@ function noop(): void {}
 
 function chatRoleFromViewModel(message: ChatMessageViewModel): ChatMessageRole {
 	const onlyToolBlocks = message.blocks.length > 0 && message.blocks.every((block) => block.type === "tool");
-	if (onlyToolBlocks) return "tool";
+	if (message.role === "system" && onlyToolBlocks) return "tool";
 	return message.role;
 }
 


### PR DESCRIPTION
## Fixes

Closes #155.

Live Pi tool events now fold into the active SUMO message instead of creating standalone `TOOL` frames.

### Changes

- Track the active/live assistant message in `ChatViewportController`.
- Append streamed text deltas as structured markdown blocks.
- When Pi emits separate tool-result messages, upsert their tool blocks into the active SUMO message.
- Merge tool results with existing pending/running tool calls by `toolCallId` (or pending tool name fallback), preserving input metadata.
- Keep assistant-only tool blocks under `SUMO`; standalone system tool messages can still render as `TOOL` if needed.

### New coverage

- Live assistant text + pending tool call + separate tool result becomes **one SUMO message** with markdown + successful tool block.
- Assistant messages that only contain a tool call still render under `SUMO`, not `TOOL`.

## Verification

```bash
pnpm test
pnpm test:integration
pnpm visual:ci
pnpm exec tsc --noEmit && pnpm build
```

Results:

- Unit tests: 84 files / 543 tests passed
- Integration tests: 13 files / 18 tests passed
- Visual CI: 6 passed, 9 review, 0 failed (expected current review baseline)
- TypeScript/build: passed
