### PR TITLE
fix(chat): make default message interiors transparent

### DIFF
--- a/src/sumo-tui/widgets/chat-message.test.ts
+++ b/src/sumo-tui/widgets/chat-message.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { CATHEDRAL_TOKENS } from "../../tokens.js";
 import { SumoNode } from "../layout/node.js";
 import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga } from "../layout/yoga.js";
 import { CellBuffer } from "../render/buffer.js";
@@ -23,6 +24,10 @@ describe("ChatMessage", () => {
 		expect(buffer.toPlainRow(0)).toMatch(/^╭ USER ─+╮$/);
 		expect(buffer.toPlainRow(1)).toBe("│ review src/auth/session.ts             │");
 		expect(buffer.toPlainRow(2)).toMatch(/^╰─+╯$/);
+		for (let col = 0; col < 42; col += 1) {
+			expect(buffer.getCell(1, col).bg).toBe(CATHEDRAL_TOKENS.colors.background);
+			expect(buffer.getCell(1, col).bg).not.toBe(CATHEDRAL_TOKENS.colors.surfaceRecess);
+		}
 		root.dispose();
 	});
 

--- a/src/sumo-tui/widgets/chat-message.ts
+++ b/src/sumo-tui/widgets/chat-message.ts
@@ -4,7 +4,7 @@ import { CATHEDRAL_TOKENS } from "../../tokens.js";
 import { SumoNode } from "../layout/node.js";
 import { MEASURE_MODE_EXACTLY, type MeasureMode, type Yoga, type YogaNode } from "../layout/yoga.js";
 import type { CellBuffer, Rect } from "../render/buffer.js";
-import { lineToAnsi, span, textLine, withPersistentStyle, type Span } from "../render/primitives.js";
+import { lineToAnsi, span, textLine, type Span } from "../render/primitives.js";
 import { renderCathedralCodeBlock } from "../transcript/code-renderer.js";
 import { renderScrollBlock } from "../transcript/scroll-renderer.js";
 import { renderToolBlockRows } from "../transcript/tool-renderer.js";
@@ -195,10 +195,11 @@ function frameTop(role: ChatMessageRole, timestamp: Date | undefined, width: num
 function frameBody(row: string, width: number): string {
 	const inner = Math.max(0, width - 4);
 	const text = fitCellText(row, inner);
-	const body = withPersistentStyle(` ${text} `, CATHEDRAL_TOKENS.colors.foreground, CATHEDRAL_TOKENS.colors.surfaceRecess);
 	return lineToAnsi(textLine([
 		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
-		span(body),
+		span(" "),
+		span(text, { fg: CATHEDRAL_TOKENS.colors.foreground }),
+		span(" "),
 		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
 	]), { width });
 }


### PR DESCRIPTION
## Fixes

Aligns runtime chat message frames with UX Spec V2 Element 13 default style:

- Default chat message interiors are now transparent / terminal-background instead of `surfaceRecess` dark bands.
- Removes the persistent recessed bg from `frameBody()`.
- Keeps text foreground + frame divider styling intact.
- Adds a regression test that body-row cells use the canvas background and not `surfaceRecess`.

Spec reference: `docs/ui/CATHEDRAL_UX_SPEC_V2.md` Element 13 — default locked style is rounded corners with transparent interior.

## Visual evidence

Ran:

```bash
pnpm visual:ci -- --scenario fixture-tool-ledger-landscape
```

Reviewed `docs/visual/out/parity/fixture-tool-ledger-landscape/runtime-full.png`; message interiors now fall through to the same background as the canvas.

## Verification

```bash
pnpm test
pnpm test:integration
pnpm visual:ci
pnpm exec tsc --noEmit && pnpm build
```

Results:

- Unit tests: 84 files / 543 tests passed
- Integration tests: 13 files / 18 tests passed
- Visual CI: 6 passed, 9 review, 0 failed (expected current review baseline)
- TypeScript/build: passed
