### PR TITLE
fix(input): align autocomplete under Cathedral prompt

### DIFF
--- a/src/cathedral/cathedral-editor.test.ts
+++ b/src/cathedral/cathedral-editor.test.ts
@@ -14,12 +14,16 @@ describe("alignAutocompleteRow", () => {
 		expect(aligned.startsWith("▸")).toBe(false);
 	});
 
-	it("centers splash autocomplete rows under the centered splash frame", () => {
-		const row = "▸ /help";
-		const aligned = stripAnsi(alignAutocompleteRow(row, 80, { splash: true, frameWidth: 60 }));
+	it("anchors splash autocomplete rows to the centered splash frame content column", () => {
+		const shortRow = "▸ /help";
+		const longRow = "▸ /resume  resume previous session";
+		const alignedShort = stripAnsi(alignAutocompleteRow(shortRow, 80, { splash: true, frameWidth: 60 }));
+		const alignedLong = stripAnsi(alignAutocompleteRow(longRow, 80, { splash: true, frameWidth: 60 }));
 
-		expect(aligned).toHaveLength(80);
-		expect(aligned.indexOf("▸ /help")).toBeGreaterThan(0);
+		expect(alignedShort).toHaveLength(80);
+		expect(alignedLong).toHaveLength(80);
+		expect(alignedShort.indexOf("▸ /help")).toBe(11);
+		expect(alignedLong.indexOf("▸ /resume")).toBe(11);
 	});
 
 	it("truncates active autocomplete rows after applying the left anchor", () => {

--- a/src/cathedral/cathedral-editor.test.ts
+++ b/src/cathedral/cathedral-editor.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { alignAutocompleteRow } from "./cathedral-editor.js";
+
+const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+const stripAnsi = (value: string): string => value.replace(ANSI_PATTERN, "");
+
+describe("alignAutocompleteRow", () => {
+	it("anchors active autocomplete under the Cathedral input content, not terminal col 0", () => {
+		const row = "▸ /resume  resume previous session";
+		const aligned = stripAnsi(alignAutocompleteRow(row, 48, { splash: false }));
+
+		expect(aligned).toHaveLength(48);
+		expect(aligned.startsWith("    ▸ /resume")).toBe(true);
+		expect(aligned.startsWith("▸")).toBe(false);
+	});
+
+	it("centers splash autocomplete rows under the centered splash frame", () => {
+		const row = "▸ /help";
+		const aligned = stripAnsi(alignAutocompleteRow(row, 80, { splash: true, frameWidth: 60 }));
+
+		expect(aligned).toHaveLength(80);
+		expect(aligned.indexOf("▸ /help")).toBeGreaterThan(0);
+	});
+
+	it("truncates active autocomplete rows after applying the left anchor", () => {
+		const row = "▸ /very-long-command-name with a very long description";
+		const aligned = stripAnsi(alignAutocompleteRow(row, 20, { splash: false }));
+
+		expect(aligned).toHaveLength(20);
+		expect(aligned.startsWith("    ▸")).toBe(true);
+	});
+});

--- a/src/cathedral/cathedral-editor.ts
+++ b/src/cathedral/cathedral-editor.ts
@@ -174,9 +174,14 @@ function centerRow(row: string, width: number): string {
 
 export function alignAutocompleteRow(row: string, width: number, options: { splash: boolean; frameWidth?: number }): string {
 	if (width <= 0) return "";
-	if (options.splash) return centerRow(row, width);
-	const left = Math.min(ACTIVE_AUTOCOMPLETE_LEFT_OFFSET, Math.max(0, width - 1));
-	const available = Math.max(0, width - left);
+	const left = options.splash
+		? Math.min(
+			Math.max(0, Math.floor((width - Math.min(width, options.frameWidth ?? width)) / 2) + 1),
+			Math.max(0, width - 1),
+		)
+		: Math.min(ACTIVE_AUTOCOMPLETE_LEFT_OFFSET, Math.max(0, width - 1));
+	const frameContentWidth = options.splash ? Math.max(0, Math.min(width, options.frameWidth ?? width) - 2) : undefined;
+	const available = Math.max(0, Math.min(width - left, frameContentWidth ?? width));
 	const fitted = fitAnsiToWidth(row, available);
 	const pad = Math.max(0, width - left - visibleLength(fitted));
 	return `${" ".repeat(left)}${fitted}${" ".repeat(pad)}`;

--- a/src/cathedral/cathedral-editor.ts
+++ b/src/cathedral/cathedral-editor.ts
@@ -49,6 +49,7 @@ import {
 const RESET = "\u001b[0m";
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
 const SPLASH_INPUT_FRAME_WIDTH = 60;
+const ACTIVE_AUTOCOMPLETE_LEFT_OFFSET = 4; // `│ > ` before typed content.
 
 function visibleLength(text: string): number {
 	return visibleWidth(text);
@@ -171,6 +172,16 @@ function centerRow(row: string, width: number): string {
 	return `${" ".repeat(left)}${row}${" ".repeat(right)}`;
 }
 
+export function alignAutocompleteRow(row: string, width: number, options: { splash: boolean; frameWidth?: number }): string {
+	if (width <= 0) return "";
+	if (options.splash) return centerRow(row, width);
+	const left = Math.min(ACTIVE_AUTOCOMPLETE_LEFT_OFFSET, Math.max(0, width - 1));
+	const available = Math.max(0, width - left);
+	const fitted = fitAnsiToWidth(row, available);
+	const pad = Math.max(0, width - left - visibleLength(fitted));
+	return `${" ".repeat(left)}${fitted}${" ".repeat(pad)}`;
+}
+
 /**
  * Test whether a row is one of Pi's flat horizontal borders, i.e. a row
  * consisting of nothing but `─` chars (after stripping ANSI), or one of
@@ -264,12 +275,11 @@ class CathedralEditor extends CustomEditor {
 		// state implies suggestions float below the input).
 		if (bottomIdx !== -1) {
 			for (let i = bottomIdx + 1; i < innerRows.length; i++) {
-				// Pad to full width so we don't leave artifacts from previous
-				// autocomplete frames at the right edge.
-				const row = innerRows[i]!;
-				const visible = visibleLength(row);
-				const pad = Math.max(0, width - visible);
-				result.push(`${row}${" ".repeat(pad)}`);
+				// Pi emits autocomplete rows relative to its bare editor at column 0.
+				// Cathedral chrome adds a left frame + prompt (`│ > `) in active mode
+				// and centers the splash frame, so dropdown rows need the same anchor
+				// translation or slash-command suggestions appear glued to terminal col 0.
+				result.push(alignAutocompleteRow(innerRows[i]!, width, { splash, frameWidth }));
 			}
 		}
 


### PR DESCRIPTION
## Summary
- translate Pi autocomplete rows to the Cathedral input content anchor instead of terminal column 0
- center splash autocomplete rows under the centered splash invocation frame
- add unit coverage for active/splash autocomplete row alignment and truncation

Fixes #154.

## Verification
- `pnpm test`
- `pnpm test:integration`
- `pnpm visual:ci`
- `pnpm exec tsc --noEmit && pnpm build`
