### PR TITLE
fix(question): bound Divine Query modal rows

### DIFF
--- a/src/divine-query.test.ts
+++ b/src/divine-query.test.ts
@@ -82,6 +82,20 @@ describe("renderDivineQuery", () => {
 		}
 	});
 
+	it("wraps long question and option text inside the modal width", () => {
+		const lines = renderDivineQuery(snapshot({
+			title: "Divine Query smoke test: which modal behavior should we verify next, and why does this text need to stay inside the modal frame?",
+			options: ["Type a very long custom answer option that should never run past the lifted surface edge"],
+		}), 50);
+		const plain = lines.map(stripAnsi);
+
+		for (const line of plain) {
+			expect(line.length, `row overflowed: ${JSON.stringify(line)}`).toBe(50);
+		}
+		expect(plain.filter((line) => line.includes("Divine Query smoke test")).length).toBe(1);
+		expect(plain.some((line) => line.includes("inside the modal frame"))).toBe(true);
+	});
+
 	it("labels options with A), B), C), etc.", () => {
 		const lines = renderDivineQuery(snapshot(), 80).map(stripAnsi);
 		expect(lines.some((l) => l.includes("A)"))).toBe(true);

--- a/src/divine-query.ts
+++ b/src/divine-query.ts
@@ -25,7 +25,7 @@
  */
 
 import type { Component, OverlayOptions } from "@mariozechner/pi-tui";
-import { matchesKey } from "@mariozechner/pi-tui";
+import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { CATHEDRAL_TOKENS } from "./tokens.js";
 
@@ -33,7 +33,7 @@ const RESET = "\u001b[0m";
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
 
 function visibleLength(text: string): number {
-	return text.replace(ANSI_PATTERN, "").length;
+	return visibleWidth(text.replace(ANSI_PATTERN, ""));
 }
 
 function fg(text: string, hex: string): string {
@@ -59,16 +59,33 @@ function persistentBg(text: string, fgHex: string, bgHex: string): string {
 }
 
 function center(line: string, width: number): string {
-	const len = visibleLength(line);
-	if (len >= width) return line;
+	const fitted = fitLine(line, width);
+	const len = visibleLength(fitted);
+	if (len >= width) return fitted;
 	const pad = Math.floor((width - len) / 2);
-	return `${" ".repeat(pad)}${line}${" ".repeat(width - len - pad)}`;
+	return `${" ".repeat(pad)}${fitted}${" ".repeat(width - len - pad)}`;
+}
+
+function fitLine(line: string, width: number): string {
+	if (width <= 0) return "";
+	return visibleLength(line) > width ? truncateToWidth(line, width, "…") : line;
 }
 
 function padRight(line: string, width: number): string {
-	const len = visibleLength(line);
-	if (len >= width) return line;
-	return `${line}${" ".repeat(width - len)}`;
+	const fitted = fitLine(line, width);
+	const len = visibleLength(fitted);
+	if (len >= width) return fitted;
+	return `${fitted}${" ".repeat(width - len)}`;
+}
+
+function wrapIndentedText(text: string, width: number, indent: string): string[] {
+	const contentWidth = Math.max(1, width - visibleLength(indent));
+	const rows: string[] = [];
+	for (const paragraph of text.split("\n")) {
+		const wrapped = wrapTextWithAnsi(paragraph, contentWidth);
+		rows.push(...(wrapped.length > 0 ? wrapped : [""]).map((line) => `${indent}${line}`));
+	}
+	return rows;
 }
 
 // ── Snapshot ──────────────────────────────────────────────────
@@ -118,7 +135,9 @@ export function renderDivineQuery(snapshot: DivineQuerySnapshot, width: number):
 	lines.push("");
 
 	// Question body
-	lines.push(padRight(`${indent}${fg(snapshot.title, CATHEDRAL_TOKENS.colors.foreground)}`, width));
+	for (const questionLine of wrapIndentedText(snapshot.title, width, indent)) {
+		lines.push(padRight(fg(questionLine, CATHEDRAL_TOKENS.colors.foreground), width));
+	}
 
 	// Blank
 	lines.push("");
@@ -129,11 +148,18 @@ export function renderDivineQuery(snapshot: DivineQuerySnapshot, width: number):
 		const mark = focused
 			? fg(FOCUSED_MARK, CATHEDRAL_TOKENS.colors.accent)
 			: fg(UNFOCUSED_MARK, CATHEDRAL_TOKENS.colors.divider);
+		const optionIndent = `${indent}${mark}   `;
+		const continuationIndent = `${indent}    `;
 		const label = `${optionLabel(i)}${snapshot.options[i]}`;
-		const text = focused
-			? fg(label, CATHEDRAL_TOKENS.colors.foreground)
-			: fg(label, CATHEDRAL_TOKENS.colors.foregroundDim);
-		lines.push(padRight(`${indent}${mark}   ${text}`, width));
+		const wrappedOption = wrapIndentedText(label, width, `${indent}    `);
+		for (let optionRow = 0; optionRow < wrappedOption.length; optionRow += 1) {
+			const raw = (wrappedOption[optionRow] ?? "").slice(continuationIndent.length);
+			const prefix = optionRow === 0 ? optionIndent : continuationIndent;
+			const text = focused
+				? fg(raw, CATHEDRAL_TOKENS.colors.foreground)
+				: fg(raw, CATHEDRAL_TOKENS.colors.foregroundDim);
+			lines.push(padRight(`${prefix}${text}`, width));
+		}
 	}
 
 	// Blank

--- a/src/question-tool.test.ts
+++ b/src/question-tool.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { padQuestionModalLine } from "./question-tool.js";
+
+const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+const stripAnsi = (value: string): string => value.replace(ANSI_PATTERN, "");
+
+describe("padQuestionModalLine", () => {
+	it("keeps edit-mode rows bounded to the modal width", () => {
+		const line = padQuestionModalLine("     Your answer: this row is deliberately too long for the modal", 32);
+
+		expect(stripAnsi(line)).toHaveLength(32);
+	});
+
+	it("restores Cathedral foreground and lifted background after nested resets", () => {
+		const line = padQuestionModalLine("     \u001b[32mgreen from Pi\u001b[0m cursor", 40);
+
+		expect(line).toContain("\u001b[38;2;245;230;200m");
+		expect(line).toContain("\u001b[48;2;61;48;36m");
+		expect(line).toContain("\u001b[0m\u001b[38;2;245;230;200m\u001b[48;2;61;48;36m");
+		expect(stripAnsi(line)).toHaveLength(40);
+	});
+});

--- a/src/question-tool.ts
+++ b/src/question-tool.ts
@@ -9,7 +9,7 @@
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { Editor, type EditorTheme, Key, matchesKey, Text } from "@mariozechner/pi-tui";
+import { Editor, type EditorTheme, Key, matchesKey, Text, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { Type } from "typebox";
 import { renderDivineQuery, updateDivineQuery, type DivineQuerySnapshot, DIVINE_QUERY_OVERLAY_OPTIONS } from "./divine-query.js";
 
@@ -28,6 +28,21 @@ const QuestionParams = Type.Object({
 });
 
 const FREE_TEXT_LABEL = "Type something…";
+const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+const RESET = "\u001b[0m";
+const LIFTED_BG = "\u001b[48;2;61;48;36m";
+const FOREGROUND_FG = "\u001b[38;2;245;230;200m";
+
+function visibleLength(value: string): number {
+	return visibleWidth(value.replace(ANSI_PATTERN, ""));
+}
+
+export function padQuestionModalLine(line: string, width: number): string {
+	const fitted = visibleLength(line) > width ? truncateToWidth(line, width, "…") : line;
+	const padding = Math.max(0, width - visibleLength(fitted));
+	const persistent = `${FOREGROUND_FG}${LIFTED_BG}${fitted.replaceAll(RESET, `${RESET}${FOREGROUND_FG}${LIFTED_BG}`)}${" ".repeat(padding)}${RESET}`;
+	return persistent;
+}
 
 interface QuestionResult {
 	answer: string;
@@ -113,15 +128,9 @@ async function showCathedralQuestion(
 				const lines = renderDivineQuery(snapshot, width);
 
 				if (editMode) {
-					const RESET = "\u001b[0m";
-					const bgCode = "\u001b[48;2;61;48;36m"; // surfaceLifted
-					const pad = (s: string) => {
-						const stripped = s.replace(/\u001b\[[0-9;]*m/g, "");
-						const padding = Math.max(0, width - stripped.length);
-						return `${bgCode}${s}${" ".repeat(padding)}${RESET}`;
-					};
+					const pad = (s: string) => padQuestionModalLine(s, width);
 					lines.push(pad(`     ${theme.fg("muted", "Your answer:")}`));
-					for (const line of editor.render(width - 6)) {
+					for (const line of editor.render(Math.max(1, width - 6))) {
 						lines.push(pad(`     ${line}`));
 					}
 					lines.push(pad(""));


### PR DESCRIPTION
## Summary
- wrap and bound Divine Query question/option rows so they cannot spill past the lifted modal surface
- keep edit-mode rows bounded to modal width and restore Cathedral foreground/background after nested Pi editor resets
- add regression coverage for long modal copy and edit-mode ANSI reset handling

Fixes #162.

## Verification
- `pnpm test`
- `pnpm test:integration`
- `pnpm visual:ci`
- `pnpm exec tsc --noEmit && pnpm build`
