### PR TITLE
feat(debug): add sumocode diagnostics mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,8 +31,12 @@ pnpm visual:ci                     # V2 visual CI gate; required crops gate agai
 pnpm visual:promote                # promote runtime crop status/golden; requires explicit human approval
 pnpm test:visual:real-runtime      # legacy real-runtime smoke harness
 
-pi -e .                            # ephemeral install of THIS checkout — primary extension dev loop
-bin/sumocode.sh                    # wrapper that enables SUMO_TUI retained-renderer patch path
+pi -e .                            # ephemeral install of THIS checkout — classic Pi extension dev loop
+bin/sumocode.sh                    # local SumoCode CLI wrapper (retained SumoTUI by default)
+bin/sumocode.sh -h                 # full CLI help
+bin/sumocode.sh -d .               # debug/diagnostics mode for manual testing
+bin/sumocode.sh doctor             # check Pi patch/module/diagnostics health
+bin/sumocode.sh diag               # summarize /tmp/sumocode-manual.jsonl
 ```
 
 Run a single test file:
@@ -65,7 +69,7 @@ pnpm visual:ci
 
 The canonical workflow lives in `DEV_LOOP.md`.
 
-Short version: edit in this checkout → `pi -e .` or `bin/sumocode.sh` to test → commit → for releases bump `package.json` version + `VERSION` in `src/extension.ts`, tag, push tags, then `pi update git:github.com/dhruvkelawala/sumocode` on consumer machines. Tagged releases are the only thing that propagates; pushes to `main` do not.
+Short version: edit in this checkout → `pi -e .` for classic extension-only checks or `bin/sumocode.sh` / globally linked `sumocode` for retained SumoTUI checks → commit → for releases bump `package.json` version + `VERSION` in `src/extension.ts`, tag, push tags, then `pi update git:github.com/dhruvkelawala/sumocode` on consumer machines. Tagged releases are the only thing that propagates; pushes to `main` do not.
 
 Never edit `~/.pi/agent/git/github.com/dhruvkelawala/sumocode/` — that is the installed clone, not the source of truth.
 
@@ -90,12 +94,16 @@ When adding a feature, decide which layer it belongs to. Anything needing flex l
 
 SumoTUI activation currently requires the tiny Pi constructor patch documented in `docs/SUMO_TUI_PI_PATCH_STRATEGY.md`.
 
-The user-facing wrapper is `bin/sumocode.sh`:
+The user-facing wrapper is `bin/sumocode.sh` and, when linked/installed, the `sumocode` command:
 
 - defaults `SUMO_TUI=1`
+- accepts `sumocode [options] [path]`, with at most one project path
+- supports `-h/--help`, `-v/--version`, `doctor`, `diag [file]`, `-d/--debug`, `--diag-file`, `--no-clear-diag`, `--dry-run`, and `--no-sumo-tui`
 - verifies the selected Pi binary contains `loadSumoInteractiveMode`
 - sets `SUMO_TUI_MODULE` to the checkout-local `sumo-interactive-mode.js`
 - falls back to classic Pi behavior if the patch is missing
+
+Manual-test diagnostics are opt-in via `sumocode -d` / `bin/sumocode.sh -d`. Debug mode writes JSONL to `/tmp/sumocode-manual.jsonl` by default, or to `--diag-file <path>` / `SUMO_TUI_DIAG_FILE`. The launcher clears the diagnostics file at startup unless `--no-clear-diag` is set. Use `sumocode diag` or `node scripts/diag-summary.mjs /tmp/sumocode-manual.jsonl` to summarize a run. Diagnostics must stay no-op unless `SUMO_TUI_DIAG_FILE` is set.
 
 Do not casually change `patches/@mariozechner__pi-coding-agent@*.patch`, `SUMO_TUI`, `SUMO_TUI_MODULE`, or `sumo-interactive-mode.js`. Pi version bumps must follow `docs/research/pi-fork-upgrade.md` and the smoke matrix in `docs/SUMO_TUI_PI_PATCH_STRATEGY.md`.
 

--- a/DEV_LOOP.md
+++ b/DEV_LOOP.md
@@ -26,10 +26,26 @@ cd "/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode"
 # open src/extension.ts or wherever the change lives
 ```
 
-### 2. Test with ephemeral install
+### 2. Test with ephemeral install or SumoCode CLI
+
+Classic extension-only smoke:
 
 ```bash
 pi -e .
+```
+
+Retained SumoTUI smoke (preferred for daily-driver UI work):
+
+```bash
+./bin/sumocode.sh
+./bin/sumocode.sh .
+```
+
+If the package is globally linked, use the `sumocode` bin directly:
+
+```bash
+sumocode
+sumocode .
 ```
 
 `-e` (or `--extension`) installs the extension **for this Pi session only**. It does NOT:
@@ -48,10 +64,20 @@ When I exit Pi, the ephemeral install vanishes. My stable install continues runn
 
 ### 3. Verify it works
 
-Launch Pi with ephemeral install:
+Launch Pi with ephemeral install or retained SumoCode:
 
 ```bash
 pi -e .
+./bin/sumocode.sh
+```
+
+For manual runtime/debug sessions, use diagnostics mode:
+
+```bash
+./bin/sumocode.sh -d .
+sumocode -d .                    # if globally linked
+sumocode diag                    # summarizes /tmp/sumocode-manual.jsonl
+sumocode doctor                  # checks Pi patch/module/diagnostics health
 ```
 
 Expected signals for v0.1.0:

--- a/README.md
+++ b/README.md
@@ -75,10 +75,22 @@ See [DEV_LOOP.md](./DEV_LOOP.md) for the full edit/test/release workflow, debugg
 TL;DR:
 ```bash
 cd "/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode"
-pi -e .                          # ephemeral install, edit src/, relaunch to test
+pi -e .                          # classic ephemeral Pi extension check
+./bin/sumocode.sh                 # retained SumoTUI local launcher
+./bin/sumocode.sh -d .            # retained launcher + diagnostics flight recorder
+./bin/sumocode.sh doctor          # check Pi patch/module/diagnostics health
 # ...edit, commit, push...
 git tag v0.x.y && git push --tags
 pi update git:github.com/dhruvkelawala/sumocode  # on each machine
+```
+
+If linked globally with `pnpm link --global`, use `sumocode` directly:
+
+```bash
+sumocode --help
+sumocode .
+sumocode -d .
+sumocode diag                    # summarizes /tmp/sumocode-manual.jsonl
 ```
 
 ## License

--- a/bin/sumocode.sh
+++ b/bin/sumocode.sh
@@ -6,9 +6,266 @@ ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 export SUMO_TUI="${SUMO_TUI:-1}"
 
+print_help() {
+	cat <<EOF
+SumoCode — Cathedral terminal AI coding agent
+
+USAGE
+  sumocode [options] [path]
+  sumocode doctor [options]
+  sumocode diag [file]
+
+ARGUMENTS
+  path
+      Optional project directory to open. If omitted, SumoCode starts in the
+      current working directory. The path is forwarded to Pi unchanged, so all
+      normal Pi path handling still applies.
+
+  Additional unknown flags are forwarded to Pi unchanged. This preserves Pi
+  options such as --offline, --no-session, --no-extensions, --provider, and
+  --model while SumoCode owns only the options documented below.
+
+COMMANDS
+  doctor
+      Check local SumoCode/Pi installation health: Node version, Pi binary,
+      retained-TUI patch availability, module resolution, and diagnostics path
+      writability.
+
+  diag [file]
+      Summarize a diagnostics JSONL file. Defaults to /tmp/sumocode-manual.jsonl.
+
+OPTIONS
+  -d, --debug
+      Enable manual-test diagnostics / flight-recorder mode.
+
+      In debug mode, SumoCode writes structured JSONL diagnostics to:
+
+        /tmp/sumocode-manual.jsonl
+
+      unless SUMO_TUI_DIAG_FILE is already set. The file is cleared at startup
+      so every debug run starts with a fresh trace.
+
+      Debug mode also exports:
+        SUMO_TUI_DEBUG=1
+        SUMOCODE_DEBUG_BRANCH=<current git branch, when available>
+        SUMOCODE_DEBUG_COMMIT=<current git commit summary, when available>
+
+      Diagnostics are intentionally no-op in normal mode.
+
+  --diag-file <path>
+      Write debug diagnostics to <path>. Implies --debug.
+
+  --no-clear-diag
+      Do not delete the diagnostics file at debug startup. By default, debug
+      mode starts with a fresh trace.
+
+  --no-sumo-tui
+      Disable the retained SumoTUI runtime for this launch. Equivalent to
+      SUMO_TUI=0 sumocode ... and useful for comparing against legacy Pi UI.
+
+  --dry-run
+      Print the resolved launch configuration and exit without starting Pi.
+
+  -v, --version
+      Print SumoCode package version and git commit, then exit.
+
+  -h, --help
+      Show this help message and exit.
+
+EXAMPLES
+  Start in the current directory:
+      sumocode
+
+  Start in an explicit project directory:
+      sumocode .
+      sumocode /path/to/project
+
+  Start with diagnostics enabled:
+      sumocode -d
+      sumocode --debug
+
+  Start a specific project with diagnostics enabled:
+      sumocode -d .
+      sumocode --debug /path/to/project
+
+  Use a custom diagnostics file:
+      sumocode -d --diag-file /tmp/my-run.jsonl
+      SUMO_TUI_DIAG_FILE=/tmp/my-run.jsonl sumocode -d
+
+  Keep appending to an existing diagnostics file:
+      sumocode -d --no-clear-diag
+
+  Compare retained SumoTUI against legacy Pi UI:
+      sumocode --no-sumo-tui .
+
+  Check installation health:
+      sumocode doctor
+
+  Summarize a debug run:
+      sumocode diag
+      sumocode diag /tmp/my-run.jsonl
+      node scripts/diag-summary.mjs /tmp/sumocode-manual.jsonl
+
+DIAGNOSTICS EVENTS
+  Debug mode may record events such as:
+      runtime_start       process, cwd, branch, commit, terminal size
+      render_frame        retained render timings
+      slow_frame          render frame over the slow-frame threshold
+      render_patches      terminal patch count and cursor placement
+      mouse_batch         parsed SGR mouse bytes per stdin batch
+      mouse_dispatch      chat hit-testing and scroll offset transitions
+      pi_event            Pi lifecycle events observed by SumoCode
+
+  Event payloads are truncated/sanitized so logs stay readable and diagnostics
+  never interrupt the interactive session.
+
+ENVIRONMENT
+  SUMO_TUI
+      Defaults to 1. Set SUMO_TUI=0 to bypass the retained SumoTUI runtime and
+      fall back to legacy Pi UI behavior.
+
+  SUMO_TUI_MODULE
+      Optional override for the retained SumoInteractiveMode module URL. Normally
+      set automatically by this launcher when the patched Pi binary is detected.
+
+  SUMO_TUI_DIAG_FILE
+      Path to the diagnostics JSONL file used by --debug. Defaults to
+      /tmp/sumocode-manual.jsonl in debug mode.
+
+  SUMO_TUI_DEBUG
+      Enables extra stderr debug messages in SumoTUI internals. Automatically
+      set to 1 by --debug unless already set.
+
+EXIT STATUS
+  0     Help/version/doctor succeeded, or Pi exited successfully.
+  64    Command-line usage error, such as an unknown option or too many paths.
+  70    Doctor found an installation problem.
+  other Propagates the underlying Pi process exit status.
+
+NOTES
+  SumoCode wraps the project-local Pi binary when available:
+      ./node_modules/.bin/pi
+
+  If that Pi binary is missing the Sumo retained-TUI patch, the launcher prints
+  a warning and falls back to legacy Pi splash behavior rather than failing the
+  session.
+EOF
+}
+
+package_version() {
+	node -e 'const pkg = require(process.argv[1]); console.log(pkg.version || "0.0.0");' "${ROOT_DIR}/package.json"
+}
+
+print_version() {
+	printf "sumocode %s\n" "$(package_version)"
+	if command -v git >/dev/null 2>&1 && git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+		git -C "${ROOT_DIR}" log --oneline -1 2>/dev/null || true
+	fi
+}
+
+usage_error() {
+	cat >&2 <<EOF
+[sumocode] $1
+
+Run 'sumocode --help' for usage.
+EOF
+	exit 64
+}
+
+DEBUG_MODE=0
+CLEAR_DIAG=1
+DRY_RUN=0
+COMMAND="run"
+DIAG_FILE="${SUMO_TUI_DIAG_FILE:-}"
+SUMOCODE_ARGS=()
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		doctor|diag)
+			if [[ "${COMMAND}" != "run" ]]; then usage_error "Only one command may be specified."; fi
+			COMMAND="$1"
+			shift
+			;;
+		-d|--debug)
+			DEBUG_MODE=1
+			shift
+			;;
+		--diag-file)
+			[[ $# -ge 2 ]] || usage_error "--diag-file requires a path."
+			DEBUG_MODE=1
+			DIAG_FILE="$2"
+			shift 2
+			;;
+		--diag-file=*)
+			DEBUG_MODE=1
+			DIAG_FILE="${1#--diag-file=}"
+			[[ -n "${DIAG_FILE}" ]] || usage_error "--diag-file requires a path."
+			shift
+			;;
+		--no-clear-diag)
+			CLEAR_DIAG=0
+			shift
+			;;
+		--no-sumo-tui)
+			export SUMO_TUI=0
+			shift
+			;;
+		--dry-run)
+			DRY_RUN=1
+			shift
+			;;
+		-v|--version)
+			print_version
+			exit 0
+			;;
+		-h|--help)
+			print_help
+			exit 0
+			;;
+		--)
+			shift
+			SUMOCODE_ARGS+=("$@")
+			break
+			;;
+		-*)
+			# Unknown flags belong to Pi. Preserve pass-through so existing visual
+			# harness/runtime invocations keep working (`--offline`, `--no-session`,
+			# `--no-extensions`, provider/model flags, etc.).
+			SUMOCODE_ARGS+=("$1")
+			shift
+			;;
+		*)
+			SUMOCODE_ARGS+=("$1")
+			shift
+			;;
+	esac
+done
+
+if [[ "${COMMAND}" == "doctor" && "${#SUMOCODE_ARGS[@]}" -gt 0 ]]; then
+	usage_error "doctor does not accept a path argument."
+fi
+if [[ "${COMMAND}" == "diag" && "${#SUMOCODE_ARGS[@]}" -gt 1 ]]; then
+	usage_error "diag accepts at most one diagnostics file path."
+fi
+
+if [[ "${DEBUG_MODE}" == "1" ]]; then
+	SUMO_TUI_DIAG_FILE="${DIAG_FILE:-/tmp/sumocode-manual.jsonl}"
+	if [[ "${CLEAR_DIAG}" == "1" && "${DRY_RUN}" != "1" ]]; then rm -f "${SUMO_TUI_DIAG_FILE}"; fi
+	export SUMO_TUI_DIAG_FILE
+	export SUMO_TUI_DEBUG="${SUMO_TUI_DEBUG:-1}"
+	if command -v git >/dev/null 2>&1 && git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+		export SUMOCODE_DEBUG_BRANCH="$(git -C "${ROOT_DIR}" branch --show-current 2>/dev/null || true)"
+		export SUMOCODE_DEBUG_COMMIT="$(git -C "${ROOT_DIR}" log --oneline -1 2>/dev/null || true)"
+	fi
+	if [[ "${DRY_RUN}" != "1" ]]; then
+		cat >&2 <<EOF
+[sumocode] Debug diagnostics enabled: ${SUMO_TUI_DIAG_FILE}
+EOF
+	fi
+fi
+
 PI_BIN="${ROOT_DIR}/node_modules/.bin/pi"
 if [[ ! -x "${PI_BIN}" ]]; then
-	PI_BIN="$(command -v pi)"
+	PI_BIN="$(command -v pi || true)"
 fi
 
 is_truthy_env_flag() {
@@ -58,6 +315,92 @@ pi_has_sumo_tui_patch() {
 	[[ -n "${main_file}" ]] && grep -q "loadSumoInteractiveMode" "${main_file}"
 }
 
+run_diag_summary() {
+	local file="${1:-/tmp/sumocode-manual.jsonl}"
+	exec node "${ROOT_DIR}/scripts/diag-summary.mjs" "${file}"
+}
+
+run_doctor() {
+	local failures=0
+	printf "SumoCode doctor\n\n"
+	printf "Version: %s\n" "$(package_version)"
+	printf "Root: %s\n" "${ROOT_DIR}"
+	if command -v node >/dev/null 2>&1; then
+		local node_version
+		node_version="$(node -v)"
+		printf "✓ Node: %s\n" "${node_version}"
+	else
+		printf "✗ Node: not found\n"
+		failures=$((failures + 1))
+	fi
+	if [[ -n "${PI_BIN}" && -x "${PI_BIN}" ]]; then
+		printf "✓ Pi binary: %s\n" "${PI_BIN}"
+	else
+		printf "✗ Pi binary: not found or not executable\n"
+		failures=$((failures + 1))
+	fi
+	local main_file=""
+	if [[ -n "${PI_BIN}" ]]; then main_file="$(pi_main_file "${PI_BIN}" 2>/dev/null || true)"; fi
+	if [[ -n "${main_file}" ]]; then
+		printf "✓ Pi main: %s\n" "${main_file}"
+	else
+		printf "✗ Pi main: could not resolve\n"
+		failures=$((failures + 1))
+	fi
+	if [[ -n "${PI_BIN}" ]] && pi_has_sumo_tui_patch "${PI_BIN}"; then
+		printf "✓ retained-TUI patch: detected\n"
+	else
+		printf "✗ retained-TUI patch: missing\n"
+		failures=$((failures + 1))
+	fi
+	local module_path="${ROOT_DIR}/sumo-interactive-mode.js"
+	if [[ -f "${module_path}" ]]; then
+		printf "✓ Sumo module: %s\n" "${module_path}"
+	else
+		printf "✗ Sumo module: missing at %s\n" "${module_path}"
+		failures=$((failures + 1))
+	fi
+	local diag_path="${DIAG_FILE:-${SUMO_TUI_DIAG_FILE:-/tmp/sumocode-manual.jsonl}}"
+	local diag_dir
+	diag_dir="$(dirname "${diag_path}")"
+	if [[ -d "${diag_dir}" && -w "${diag_dir}" ]]; then
+		printf "✓ diagnostics path writable: %s\n" "${diag_path}"
+	else
+		printf "✗ diagnostics directory not writable: %s\n" "${diag_dir}"
+		failures=$((failures + 1))
+	fi
+	if [[ -t 1 ]]; then
+		printf "✓ stdout is TTY"
+		if [[ -n "${COLUMNS:-}" && -n "${LINES:-}" ]]; then printf " (%sx%s)" "${COLUMNS}" "${LINES}"; fi
+		printf "\n"
+	else
+		printf "! stdout is not a TTY\n"
+	fi
+	printf "\n"
+	if [[ "${failures}" -eq 0 ]]; then
+		printf "Doctor passed.\n"
+		return 0
+	fi
+	printf "Doctor found %s problem(s).\n" "${failures}"
+	return 70
+}
+
+if [[ "${COMMAND}" == "diag" ]]; then
+	run_diag_summary "${SUMOCODE_ARGS[0]:-/tmp/sumocode-manual.jsonl}"
+fi
+
+if [[ "${COMMAND}" == "doctor" ]]; then
+	run_doctor
+	exit $?
+fi
+
+if [[ -z "${PI_BIN}" ]]; then
+	cat >&2 <<EOF
+[sumocode] Could not find Pi binary. Run 'pnpm install' in ${ROOT_DIR} or install pi on PATH.
+EOF
+	exit 70
+fi
+
 if is_truthy_env_flag "${SUMO_TUI}"; then
 	if pi_has_sumo_tui_patch "${PI_BIN}"; then
 		if [[ -z "${SUMO_TUI_MODULE:-}" ]]; then
@@ -75,4 +418,24 @@ EOF
 	fi
 fi
 
-exec "${PI_BIN}" -e "${ROOT_DIR}/src/extension.ts" "$@"
+if [[ "${DRY_RUN}" == "1" ]]; then
+	cat <<EOF
+sumocode dry run
+PI_BIN=${PI_BIN}
+ROOT_DIR=${ROOT_DIR}
+SUMO_TUI=${SUMO_TUI:-}
+SUMO_TUI_MODULE=${SUMO_TUI_MODULE:-}
+SUMO_TUI_DIAG_FILE=${SUMO_TUI_DIAG_FILE:-}
+SUMO_TUI_DEBUG=${SUMO_TUI_DEBUG:-}
+COMMAND=${COMMAND}
+ARGS=${SUMOCODE_ARGS[*]:-}
+exec ${PI_BIN} -e ${ROOT_DIR}/src/extension.ts ${SUMOCODE_ARGS[*]:-}
+EOF
+	exit 0
+fi
+
+if [[ "${#SUMOCODE_ARGS[@]}" -eq 0 ]]; then
+	exec "${PI_BIN}" -e "${ROOT_DIR}/src/extension.ts"
+fi
+
+exec "${PI_BIN}" -e "${ROOT_DIR}/src/extension.ts" "${SUMOCODE_ARGS[@]}"

--- a/docs/SUMO_TUI_PI_PATCH_STRATEGY.md
+++ b/docs/SUMO_TUI_PI_PATCH_STRATEGY.md
@@ -29,14 +29,31 @@ This is the only place SumoCode currently gains control before Pi's interactive 
 
 ### `bin/sumocode.sh`
 
-The wrapper is the user-facing activation contract:
+The wrapper is the user-facing activation contract. When the package is linked or installed, it is exposed as the `sumocode` binary.
+
+Core responsibilities:
 
 - defaults `SUMO_TUI=1`
+- accepts `sumocode [options] [path]`, forwarding the optional project path to Pi unchanged
 - resolves the repo-local Pi binary first
 - inspects Pi's `dist/main.js` for `loadSumoInteractiveMode`
 - sets `SUMO_TUI_MODULE=file://.../sumo-interactive-mode.js` for checkout-local runtime loading
 - falls back to `SUMO_TUI=0` with a warning if the selected Pi binary is not patched
 - executes Pi with `-e src/extension.ts`
+
+CLI/operator features:
+
+- `sumocode -h` / `sumocode --help` — full launcher reference
+- `sumocode -v` / `sumocode --version` — package version + git commit when available
+- `sumocode doctor` — validates Node, Pi binary, Pi main file, retained-TUI patch, Sumo module, diagnostics path, and TTY status
+- `sumocode diag [file]` — summarizes diagnostics JSONL via `scripts/diag-summary.mjs`
+- `sumocode -d` / `sumocode --debug` — enables manual-test diagnostics
+- `sumocode --diag-file <path>` — custom diagnostics path and implies debug mode
+- `sumocode --no-clear-diag` — append to the diagnostics file instead of starting fresh
+- `sumocode --dry-run` — print the resolved launch config without starting Pi
+- `sumocode --no-sumo-tui` — per-launch fallback equivalent to `SUMO_TUI=0`
+
+Debug mode writes JSONL diagnostics to `/tmp/sumocode-manual.jsonl` by default and clears that file at startup unless `--no-clear-diag` is set. Diagnostics are intentionally no-op unless `SUMO_TUI_DIAG_FILE` is set.
 
 This wrapper prevents accidental use of stale installed SumoCode code during local development and avoids hard failure when the patch is missing.
 

--- a/scripts/diag-summary.mjs
+++ b/scripts/diag-summary.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+
+const file = process.argv[2] ?? process.env.SUMO_TUI_DIAG_FILE ?? "/tmp/sumocode-manual.jsonl";
+if (!fs.existsSync(file)) {
+  console.error(`[diag-summary] No diagnostics file found: ${file}`);
+  process.exit(1);
+}
+
+const events = fs.readFileSync(file, "utf8").split(/\r?\n/).filter(Boolean).flatMap((line) => {
+  try { return [JSON.parse(line)]; } catch { return []; }
+});
+
+const counts = new Map();
+const slow = [];
+const errors = [];
+for (const event of events) {
+  counts.set(event.event, (counts.get(event.event) ?? 0) + 1);
+  if (event.event === "slow_frame") slow.push(event);
+  if (event.event === "render_error" || event.event === "invariant_violation") errors.push(event);
+}
+
+console.log(`Diagnostics: ${file}`);
+console.log(`Events: ${events.length}`);
+console.log("\nEvent counts:");
+for (const [name, count] of [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))) {
+  console.log(`  ${String(count).padStart(5)}  ${name}`);
+}
+
+if (slow.length > 0) {
+  console.log("\nSlow frames:");
+  for (const event of slow.slice(-20)) {
+    console.log(`  ${event.durationMs}ms  ${event.path ?? "unknown"}  ${event.width ?? "?"}x${event.height ?? "?"}`);
+  }
+}
+
+if (errors.length > 0) {
+  console.log("\nErrors/invariants:");
+  for (const event of errors.slice(-20)) console.log(`  ${JSON.stringify(event)}`);
+}
+
+const lastSelection = [...events].reverse().find((event) => event.event === "selection_finish" || event.event === "selection_copy_success");
+if (lastSelection) {
+  console.log("\nLast selection:");
+  console.log(`  ${JSON.stringify(lastSelection)}`);
+}

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -247,6 +247,11 @@ export class ChatViewportController {
 
 		if (source.includes("\x1b")) {
 			const parsed = parseSgrMouseStream(source);
+			logDiagnostic("mouse_batch", {
+				rawBytes: source.length,
+				events: parsed.events.length,
+				types: parsed.events.map((event) => event.type),
+			});
 			for (const event of parsed.events) {
 				this.handleMouse(event);
 			}
@@ -456,9 +461,26 @@ export class ChatViewportController {
 			row: event.row - this.lastChatTop,
 			col: event.col,
 		};
-		if (localEvent.row < 0 || localEvent.row >= this.lastChatHeight || localEvent.col < 0 || localEvent.col >= this.lastChatWidth) return false;
+		const inViewport = localEvent.row >= 0 && localEvent.row < this.lastChatHeight && localEvent.col >= 0 && localEvent.col < this.lastChatWidth;
+		if (!inViewport) {
+			logDiagnostic("mouse_dispatch", { type: event.type, row: event.row, col: event.col, target: "outside_chat", handled: false });
+			return false;
+		}
+		const beforeOffset = this.chat.scrollBox.scrollOffset;
 		const handled = this.chat.handleMouseEvent(localEvent);
 		const handledSelection = this.runtime.handleSelectionMouse?.(localEvent, this.lastChatWidth, this.lastChatHeight) === true;
+		logDiagnostic("mouse_dispatch", {
+			type: event.type,
+			row: event.row,
+			col: event.col,
+			localRow: localEvent.row,
+			localCol: localEvent.col,
+			target: "chat",
+			handledScroll: handled,
+			handledSelection,
+			scrollOffsetBefore: beforeOffset,
+			scrollOffsetAfter: this.chat.scrollBox.scrollOffset,
+		});
 		if (handled || handledSelection) this.renderChatViewportOrRequest();
 		return handled || handledSelection;
 	}

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -42,6 +42,7 @@ import type { KeyEvent } from "../input/key-router.js";
 import type { MouseEvent } from "../input/mouse.js";
 import { SelectionController } from "../input/selection.js";
 import { diffFrames } from "../render/diff.js";
+import { logDiagnostic, logRuntimeStart } from "../runtime/diagnostics.js";
 import { FrameScheduler } from "../runtime/frame-scheduler.js";
 import { emitResumeBudgetOverlay, measureMaybe, ResumeProfiler, type ResumeProfileMetadata } from "../runtime/resume-profiler.js";
 import { defaultTerminalSessionOwner, TerminalSessionOwner, type TerminalOutput } from "../runtime/terminal-controller.js";
@@ -170,6 +171,17 @@ export class SumoInteractiveRuntime {
 		// only works reliably when SGR mouse mode is enabled before Pi's first
 		// interactive frame.
 		this.terminal.startRetainedSession();
+		logRuntimeStart({
+			terminal: {
+				columns: this.output.columns ?? null,
+				rows: this.output.rows ?? null,
+				isTTY: this.output.isTTY,
+			},
+			features: {
+				retainedTui: true,
+				mouseSgr: true,
+			},
+		});
 		this.scheduler = new FrameScheduler({ render: () => this.render() });
 		this.resizeHandler = () => this.requestRender();
 		process.stdout.on("resize", this.resizeHandler);
@@ -232,11 +244,14 @@ export class SumoInteractiveRuntime {
 		root.height = safeHeight;
 		const pendingProfile = this.claimPendingResumeProfile();
 		measureMaybe(pendingProfile?.profile, "yoga_first_layout", () => root.yogaNode.calculateLayout(safeWidth, safeHeight, DIRECTION_LTR));
+		const renderStart = performance.now();
 		const { frame, lines } = measureMaybe(pendingProfile?.profile, "first_frame_render", () => {
 			const nextFrame = new CellBuffer(safeHeight, safeWidth);
 			composite(root, nextFrame, { selection: this.selection });
 			return { frame: nextFrame, lines: bufferToAnsiLines(nextFrame) };
 		});
+		const renderMs = performance.now() - renderStart;
+		logDiagnostic(renderMs > 33 ? "slow_frame" : "render_frame", { path: "chat_viewport", durationMs: Math.round(renderMs * 100) / 100, width: safeWidth, height: safeHeight, selectionRevision });
 		this.chatFrameCache = { width: safeWidth, height: safeHeight, version: this.frameVersion, selectionRevision, frame: frame.clone(), lines };
 		if (pendingProfile) this.finishPendingResumeProfile(pendingProfile);
 		return { frame: frame.clone(), lines: [...lines] };
@@ -341,13 +356,17 @@ export class SumoInteractiveRuntime {
 		root.height = height;
 		const pendingProfile = this.claimPendingResumeProfile();
 		measureMaybe(pendingProfile?.profile, "yoga_first_layout", () => root.yogaNode.calculateLayout(width, height, DIRECTION_LTR));
+		const renderStart = performance.now();
 		const nextFrame = measureMaybe(pendingProfile?.profile, "first_frame_render", () => {
 			const frame = new CellBuffer(height, width);
 			const compositeResult = composite(root, frame, { selection: this.selection });
 			const patches = diffFrames(this.previousFrame, frame);
 			this.terminal.writeFramePatches(patches, compositeResult.hardwareCursor);
+			logDiagnostic("render_patches", { patchCount: patches.length, cursor: compositeResult.hardwareCursor ?? null });
 			return frame;
 		});
+		const renderMs = performance.now() - renderStart;
+		logDiagnostic(renderMs > 33 ? "slow_frame" : "render_frame", { path: "full_root", durationMs: Math.round(renderMs * 100) / 100, width, height, version: this.frameVersion });
 		this.previousFrame = nextFrame.clone();
 		this.renderedVersion = this.frameVersion;
 		this.renderedWidth = width;

--- a/src/sumo-tui/runtime/diagnostics.test.ts
+++ b/src/sumo-tui/runtime/diagnostics.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { logDiagnostic, logRuntimeStart } from "./diagnostics.js";
+
+const previousDiagFile = process.env.SUMO_TUI_DIAG_FILE;
+const previousBranch = process.env.SUMOCODE_DEBUG_BRANCH;
+const previousCommit = process.env.SUMOCODE_DEBUG_COMMIT;
+let tempDir: string | undefined;
+
+afterEach(() => {
+	if (previousDiagFile === undefined) delete process.env.SUMO_TUI_DIAG_FILE;
+	else process.env.SUMO_TUI_DIAG_FILE = previousDiagFile;
+	if (previousBranch === undefined) delete process.env.SUMOCODE_DEBUG_BRANCH;
+	else process.env.SUMOCODE_DEBUG_BRANCH = previousBranch;
+	if (previousCommit === undefined) delete process.env.SUMOCODE_DEBUG_COMMIT;
+	else process.env.SUMOCODE_DEBUG_COMMIT = previousCommit;
+	if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+	tempDir = undefined;
+});
+
+function useDiagFile(): string {
+	tempDir = mkdtempSync(join(tmpdir(), "sumocode-diag-"));
+	const file = join(tempDir, "manual.jsonl");
+	process.env.SUMO_TUI_DIAG_FILE = file;
+	return file;
+}
+
+describe("diagnostics", () => {
+	it("writes sanitized JSONL events only when SUMO_TUI_DIAG_FILE is set", () => {
+		const file = useDiagFile();
+		logDiagnostic("example", { text: "x".repeat(200), nested: { ok: true }, list: ["a", "b"] });
+
+		const [line] = readFileSync(file, "utf8").trim().split("\n");
+		const event = JSON.parse(line!);
+		expect(event.event).toBe("example");
+		expect(event.text.length).toBeLessThan(200);
+		expect(event.nested).toEqual({ ok: true });
+		expect(event.list).toEqual(["a", "b"]);
+	});
+
+	it("records runtime branch and commit metadata", () => {
+		const file = useDiagFile();
+		process.env.SUMOCODE_DEBUG_BRANCH = "feat/debug-mode-diagnostics";
+		process.env.SUMOCODE_DEBUG_COMMIT = "abc123 fix(test): sample";
+
+		logRuntimeStart({ terminal: { columns: 120, rows: 40, isTTY: true } });
+
+		const event = JSON.parse(readFileSync(file, "utf8").trim());
+		expect(event.event).toBe("runtime_start");
+		expect(event.branch).toBe("feat/debug-mode-diagnostics");
+		expect(event.commit).toBe("abc123 fix(test): sample");
+		expect(event.terminal).toEqual({ columns: 120, rows: 40, isTTY: true });
+	});
+});

--- a/src/sumo-tui/runtime/diagnostics.ts
+++ b/src/sumo-tui/runtime/diagnostics.ts
@@ -2,8 +2,10 @@ import { appendFileSync } from "node:fs";
 
 const PI_EVENT_INSTRUMENTED_PROPERTY = "__sumoTuiDiagnosticsPiEventsInstrumented";
 
-type DiagnosticValue = string | number | boolean | null | undefined;
-type DiagnosticFields = Record<string, DiagnosticValue>;
+type DiagnosticValue = string | number | boolean | null | undefined | DiagnosticValue[] | { readonly [key: string]: DiagnosticValue };
+type DiagnosticFields = Record<string, unknown>;
+
+const PREVIEW_MAX = 160;
 
 interface InstrumentablePiEventEmitter {
 	on?: unknown;
@@ -19,14 +21,39 @@ export function isDiagnosticsEnabled(): boolean {
 	return diagnosticsFile() !== undefined;
 }
 
+function sanitizeDiagnosticValue(value: unknown): DiagnosticValue {
+	if (typeof value === "string") return value.length > PREVIEW_MAX ? `${value.slice(0, PREVIEW_MAX)}…` : value;
+	if (typeof value === "number" || typeof value === "boolean" || value === null || value === undefined) return value;
+	if (Array.isArray(value)) return value.map((entry) => sanitizeDiagnosticValue(entry));
+	if (typeof value === "object") {
+		const next: Record<string, DiagnosticValue> = {};
+		for (const [key, entry] of Object.entries(value)) next[key] = sanitizeDiagnosticValue(entry);
+		return next;
+	}
+	return String(value);
+}
+
 export function logDiagnostic(event: string, fields: DiagnosticFields = {}): void {
 	const file = diagnosticsFile();
 	if (!file) return;
 	try {
-		appendFileSync(file, `${JSON.stringify({ ts: Date.now(), event, ...fields })}\n`, "utf8");
+		const sanitized: Record<string, DiagnosticValue> = {};
+		for (const [key, value] of Object.entries(fields)) sanitized[key] = sanitizeDiagnosticValue(value);
+		appendFileSync(file, `${JSON.stringify({ ts: Date.now(), event, ...sanitized })}\n`, "utf8");
 	} catch {
 		// Diagnostics must never perturb the interactive session.
 	}
+}
+
+export function logRuntimeStart(fields: DiagnosticFields = {}): void {
+	logDiagnostic("runtime_start", {
+		branch: process.env.SUMOCODE_DEBUG_BRANCH,
+		commit: process.env.SUMOCODE_DEBUG_COMMIT,
+		pid: process.pid,
+		cwd: process.cwd(),
+		sumoTui: process.env.SUMO_TUI,
+		...fields,
+	});
 }
 
 export function instrumentPiEventEmitter(pi: unknown): void {


### PR DESCRIPTION
## Summary
- add a proper `sumocode` launcher CLI with `-h/--help`, `-v/--version`, `doctor`, `diag`, `--dry-run`, `--no-sumo-tui`, `--diag-file`, and `--no-clear-diag`
- preserve normal/project-path invocation forms: `sumocode`, `sumocode .`, `sumocode -d .`, `sumocode -d /path/to/project`
- preserve Pi flag pass-through for existing runtime/visual invocations (`--offline`, `--no-session`, `--no-extensions`, provider/model flags, etc.)
- enable manual-test diagnostics at `/tmp/sumocode-manual.jsonl` in debug mode, or a custom `--diag-file` / `SUMO_TUI_DIAG_FILE`
- log generic runtime, render, mouse batch, and mouse dispatch diagnostics when debug mode is enabled
- add `scripts/diag-summary.mjs` and expose it through `sumocode diag [file]`
- add `sumocode doctor` checks for Node, Pi binary, retained-TUI patch, Sumo module, diagnostics writability, and TTY status
- document the CLI/debug workflow in `AGENTS.md`, `README.md`, `DEV_LOOP.md`, and `docs/SUMO_TUI_PI_PATCH_STRATEGY.md`

## Verification
- `bash -n bin/sumocode.sh`
- `bin/sumocode.sh -h`
- `bin/sumocode.sh --version`
- `bin/sumocode.sh --dry-run -d --diag-file /tmp/foo.jsonl .`
- `bin/sumocode.sh --dry-run --offline --no-extensions --no-session`
- `bin/sumocode.sh doctor`
- `bin/sumocode.sh diag /tmp/does-not-exist.jsonl` exits non-zero with a clear error
- `pnpm exec vitest run src/sumo-tui/runtime/diagnostics.test.ts`
- `pnpm visual:ci`
- `pnpm exec tsc --noEmit`

Visual CI baseline: 15 scenarios, 6 passed / 9 review / 0 failed.
