### PR TITLE
fix(question): frame Divine Query modal — full #162 fix (extends #169)

### DIFF
--- a/src/commands/divine-query.test.ts
+++ b/src/commands/divine-query.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerDivineQueryCommand } from "./divine-query.js";
+
+describe("/sumo:query slash command", () => {
+	it("registers /sumo:query on the pi API", () => {
+		const registerCommand = vi.fn();
+		registerDivineQueryCommand({ registerCommand } as never);
+
+		expect(registerCommand).toHaveBeenCalledWith(
+			"sumo:query",
+			expect.objectContaining({ description: "Open a test Cathedral Divine Query modal" }),
+		);
+	});
+
+	it("opens the Divine Query overlay and reports the selected option", async () => {
+		let handler: ((args: string[], ctx: unknown) => Promise<void>) | undefined;
+		const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
+			handler = options.handler;
+		});
+		const custom = vi.fn(async () => 0);
+		const notify = vi.fn();
+		registerDivineQueryCommand({ registerCommand } as never);
+
+		await handler?.([], { hasUI: true, ui: { custom, notify } });
+
+		expect(custom).toHaveBeenCalledTimes(1);
+		expect(notify).toHaveBeenCalledWith("Divine Query selected: Looks good — ship it", "info");
+	});
+
+	it("prints a message in non-interactive mode", async () => {
+		let handler: ((args: string[], ctx: unknown) => Promise<void>) | undefined;
+		const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
+			handler = options.handler;
+		});
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		registerDivineQueryCommand({ registerCommand } as never);
+
+		try {
+			await handler?.([], { hasUI: false });
+			expect(stdout).toHaveBeenCalledWith("sumo:query requires interactive UI\n");
+		} finally {
+			stdout.mockRestore();
+		}
+	});
+});

--- a/src/commands/divine-query.ts
+++ b/src/commands/divine-query.ts
@@ -1,0 +1,33 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { showDivineQuery } from "../divine-query.js";
+
+const TEST_TITLE = "Divine Query test modal\nUse this to verify the runtime overlay without waiting for the LLM.";
+const TEST_OPTIONS = [
+	"Looks good — ship it",
+	"Needs visual polish",
+	"Cancel / escape path works",
+] as const;
+
+/**
+ * `/sumo:query` — manual QA helper for the Cathedral Divine Query modal.
+ * Opens the same runtime overlay used by SumoCode-owned question/selection
+ * flows, without requiring an LLM/tool call to trigger it.
+ */
+export function registerDivineQueryCommand(pi: ExtensionAPI): void {
+	pi.registerCommand("sumo:query", {
+		description: "Open a test Cathedral Divine Query modal",
+		handler: async (_args, ctx: ExtensionContext) => {
+			if (!ctx.hasUI) {
+				process.stdout.write("sumo:query requires interactive UI\n");
+				return;
+			}
+
+			const selected = await showDivineQuery(ctx, TEST_TITLE, TEST_OPTIONS);
+			if (selected === undefined) {
+				ctx.ui.notify("Divine Query cancelled", "warning");
+				return;
+			}
+			ctx.ui.notify(`Divine Query selected: ${selected}`, "info");
+		},
+	});
+}

--- a/src/divine-query.test.ts
+++ b/src/divine-query.test.ts
@@ -5,7 +5,7 @@ import {
 	type DivineQuerySnapshot,
 } from "./divine-query.js";
 
-const ANSI = /\u001b\[[0-9;]*m/g;
+const ANSI = /\[[0-9;]*m/g;
 const stripAnsi = (s: string): string => s.replace(ANSI, "");
 
 function snapshot(overrides: Partial<DivineQuerySnapshot> = {}): DivineQuerySnapshot {
@@ -18,27 +18,56 @@ function snapshot(overrides: Partial<DivineQuerySnapshot> = {}): DivineQuerySnap
 }
 
 describe("renderDivineQuery", () => {
-	it("renders ✾ DIVINE QUERY ✾ title in accent", () => {
+	it("frames the modal with rounded corners and side bars", () => {
+		const lines = renderDivineQuery(snapshot(), 80);
+		const plain = lines.map(stripAnsi);
+
+		// Top border: ╭───…───╮
+		expect(plain[0]?.startsWith("╭")).toBe(true);
+		expect(plain[0]?.endsWith("╮")).toBe(true);
+		expect(plain[0]?.length).toBe(80);
+
+		// Bottom border: ╰───…───╯
+		const last = plain.at(-1)!;
+		expect(last.startsWith("╰")).toBe(true);
+		expect(last.endsWith("╯")).toBe(true);
+		expect(last.length).toBe(80);
+
+		// Every body row sits inside `│ … │`
+		for (let i = 1; i < plain.length - 1; i += 1) {
+			const row = plain[i]!;
+			expect(row.startsWith("│"), `row ${i} missing left border: ${JSON.stringify(row)}`).toBe(true);
+			expect(row.endsWith("│"), `row ${i} missing right border: ${JSON.stringify(row)}`).toBe(true);
+			expect(row.length, `row ${i} not padded: ${row.length}`).toBe(80);
+		}
+	});
+
+	it("renders ✾ DIVINE QUERY ✾ title in accent inside the frame", () => {
 		const lines = renderDivineQuery(snapshot(), 80);
 		const titleLine = lines.find((l) => stripAnsi(l).includes("DIVINE QUERY"));
 		expect(titleLine).toBeDefined();
 		// accent #D97706 -> 217;119;6
-		expect(titleLine).toContain("\u001b[38;2;217;119;6m");
+		expect(titleLine).toContain("[38;2;217;119;6m");
 		expect(stripAnsi(titleLine!)).toContain("✾  DIVINE QUERY  ✾");
+		// Title row is bordered, not free-floating
+		expect(stripAnsi(titleLine!).startsWith("│")).toBe(true);
+		expect(stripAnsi(titleLine!).endsWith("│")).toBe(true);
 	});
 
-	it("renders decorative split rules in divider", () => {
+	it("renders decorative split rules in divider — distinct from frame borders", () => {
 		const lines = renderDivineQuery(snapshot(), 80).map(stripAnsi);
-		const ruleLines = lines.filter((l) => l.includes("──") && l.includes("·"));
-		expect(ruleLines.length).toBe(2); // top + bottom
+		// Inner decorative rules contain `·`; frame borders never do.
+		const ruleLines = lines.filter((l) => l.includes("·") && l.includes("──"));
+		expect(ruleLines.length).toBe(2); // top + bottom inner rules
 	});
 
-	it("renders question body in foreground", () => {
+	it("renders question body in foreground inside the frame", () => {
 		const lines = renderDivineQuery(snapshot(), 80);
 		const bodyLine = lines.find((l) => stripAnsi(l).includes("rename"));
 		expect(bodyLine).toBeDefined();
 		// foreground #F5E6C8 -> 245;230;200
-		expect(bodyLine).toContain("\u001b[38;2;245;230;200m");
+		expect(bodyLine).toContain("[38;2;245;230;200m");
+		expect(stripAnsi(bodyLine!).startsWith("│")).toBe(true);
 	});
 
 	it("renders focused option with ❈ in accent and text in foreground", () => {
@@ -46,7 +75,7 @@ describe("renderDivineQuery", () => {
 		const focusedLine = lines.find((l) => stripAnsi(l).includes("❈"));
 		expect(focusedLine).toBeDefined();
 		expect(stripAnsi(focusedLine!)).toContain("A) Yes, rename it everywhere");
-		expect(focusedLine).toContain("\u001b[38;2;217;119;6m❈"); // accent
+		expect(focusedLine).toContain("[38;2;217;119;6m❈"); // accent
 	});
 
 	it("renders unfocused options with · in divider and text in dim", () => {
@@ -56,7 +85,7 @@ describe("renderDivineQuery", () => {
 		expect(bLine).toContain("·");
 		// Check dim color on the raw ANSI
 		const rawB = lines.find((l) => stripAnsi(l).includes("B) No"));
-		expect(rawB).toContain("\u001b[38;2;139;122;99m"); // foregroundDim
+		expect(rawB).toContain("[38;2;139;122;99m"); // foregroundDim
 	});
 
 	it("renders footer with wander/answer/retreat", () => {
@@ -65,24 +94,27 @@ describe("renderDivineQuery", () => {
 		expect(footer).toContain("↑↓ wander");
 		expect(footer).toContain("⏎ answer");
 		expect(footer).toContain("⎋ retreat");
+		// Footer also lives inside the frame
+		expect(footer!.startsWith("│")).toBe(true);
+		expect(footer!.endsWith("│")).toBe(true);
 	});
 
-	it("renders surfaceLifted background on all rows", () => {
+	it("renders surfaceLifted background on every row including borders", () => {
 		const lines = renderDivineQuery(snapshot(), 80);
 		// surfaceLifted #3D3024 -> 61;48;36
 		for (const line of lines) {
-			expect(line).toContain("\u001b[48;2;61;48;36m");
+			expect(line).toContain("[48;2;61;48;36m");
 		}
 	});
 
-	it("pads every row to the requested width", () => {
+	it("pads every row — including borders — to exactly the requested width", () => {
 		const lines = renderDivineQuery(snapshot(), 80);
 		for (const line of lines) {
 			expect(stripAnsi(line).length, `row not padded: ${JSON.stringify(stripAnsi(line))}`).toBe(80);
 		}
 	});
 
-	it("wraps long question and option text inside the modal width", () => {
+	it("wraps long question and option text inside the inner frame width", () => {
 		const lines = renderDivineQuery(snapshot({
 			title: "Divine Query smoke test: which modal behavior should we verify next, and why does this text need to stay inside the modal frame?",
 			options: ["Type a very long custom answer option that should never run past the lifted surface edge"],
@@ -91,9 +123,34 @@ describe("renderDivineQuery", () => {
 
 		for (const line of plain) {
 			expect(line.length, `row overflowed: ${JSON.stringify(line)}`).toBe(50);
+			// Body rows stay inside the frame
+			if (!line.startsWith("╭") && !line.startsWith("╰")) {
+				expect(line.startsWith("│"), `row not framed: ${JSON.stringify(line)}`).toBe(true);
+				expect(line.endsWith("│"), `row not framed: ${JSON.stringify(line)}`).toBe(true);
+			}
 		}
 		expect(plain.filter((line) => line.includes("Divine Query smoke test")).length).toBe(1);
-		expect(plain.some((line) => line.includes("inside the modal frame"))).toBe(true);
+		// The full title text should still be reconstructible by joining the
+		// stripped/trimmed body rows back together (just check the tail phrase).
+		expect(plain.some((line) => line.includes("frame?"))).toBe(true);
+	});
+
+	it("appends extras between footer and bottom border, framed in the same modal", () => {
+		const lines = renderDivineQuery(snapshot(), 60, {
+			extras: ["     Your answer:", "     hello world"],
+		});
+		const plain = lines.map(stripAnsi);
+
+		const helloRow = plain.find((line) => line.includes("hello world"));
+		expect(helloRow).toBeDefined();
+		expect(helloRow!.startsWith("│")).toBe(true);
+		expect(helloRow!.endsWith("│")).toBe(true);
+		expect(helloRow!.length).toBe(60);
+
+		// Bottom border still lives at the very last row, after the extras
+		expect(plain.at(-1)!.startsWith("╰")).toBe(true);
+		const helloIndex = plain.findIndex((line) => line.includes("hello world"));
+		expect(helloIndex).toBeLessThan(plain.length - 1);
 	});
 
 	it("labels options with A), B), C), etc.", () => {
@@ -101,6 +158,11 @@ describe("renderDivineQuery", () => {
 		expect(lines.some((l) => l.includes("A)"))).toBe(true);
 		expect(lines.some((l) => l.includes("B)"))).toBe(true);
 		expect(lines.some((l) => l.includes("C)"))).toBe(true);
+	});
+
+	it("renders empty array at widths < 4 (frame would not fit)", () => {
+		expect(renderDivineQuery(snapshot(), 0)).toEqual([]);
+		expect(renderDivineQuery(snapshot(), 3)).toEqual([]);
 	});
 });
 

--- a/src/divine-query.test.ts
+++ b/src/divine-query.test.ts
@@ -82,6 +82,20 @@ describe("renderDivineQuery", () => {
 		}
 	});
 
+	it("wraps long question and option text inside the modal width", () => {
+		const lines = renderDivineQuery(snapshot({
+			title: "Divine Query smoke test: which modal behavior should we verify next, and why does this text need to stay inside the modal frame?",
+			options: ["Type a very long custom answer option that should never run past the lifted surface edge"],
+		}), 50);
+		const plain = lines.map(stripAnsi);
+
+		for (const line of plain) {
+			expect(line.length, `row overflowed: ${JSON.stringify(line)}`).toBe(50);
+		}
+		expect(plain.filter((line) => line.includes("Divine Query smoke test")).length).toBe(1);
+		expect(plain.some((line) => line.includes("inside the modal frame"))).toBe(true);
+	});
+
 	it("labels options with A), B), C), etc.", () => {
 		const lines = renderDivineQuery(snapshot(), 80).map(stripAnsi);
 		expect(lines.some((l) => l.includes("A)"))).toBe(true);

--- a/src/divine-query.test.ts
+++ b/src/divine-query.test.ts
@@ -18,56 +18,42 @@ function snapshot(overrides: Partial<DivineQuerySnapshot> = {}): DivineQuerySnap
 }
 
 describe("renderDivineQuery", () => {
-	it("frames the modal with rounded corners and side bars", () => {
+	it("renders an unframed lifted panel padded to width", () => {
 		const lines = renderDivineQuery(snapshot(), 80);
 		const plain = lines.map(stripAnsi);
 
-		// Top border: ╭───…───╮
-		expect(plain[0]?.startsWith("╭")).toBe(true);
-		expect(plain[0]?.endsWith("╮")).toBe(true);
-		expect(plain[0]?.length).toBe(80);
-
-		// Bottom border: ╰───…───╯
-		const last = plain.at(-1)!;
-		expect(last.startsWith("╰")).toBe(true);
-		expect(last.endsWith("╯")).toBe(true);
-		expect(last.length).toBe(80);
-
-		// Every body row sits inside `│ … │`
-		for (let i = 1; i < plain.length - 1; i += 1) {
-			const row = plain[i]!;
-			expect(row.startsWith("│"), `row ${i} missing left border: ${JSON.stringify(row)}`).toBe(true);
-			expect(row.endsWith("│"), `row ${i} missing right border: ${JSON.stringify(row)}`).toBe(true);
-			expect(row.length, `row ${i} not padded: ${row.length}`).toBe(80);
+		for (const row of plain) {
+			expect(row.length, `row not padded: ${JSON.stringify(row)}`).toBe(80);
+			expect(row.startsWith("╭")).toBe(false);
+			expect(row.startsWith("│")).toBe(false);
+			expect(row.startsWith("╰")).toBe(false);
+			expect(row.endsWith("╮")).toBe(false);
+			expect(row.endsWith("│")).toBe(false);
+			expect(row.endsWith("╯")).toBe(false);
 		}
 	});
 
-	it("renders ✾ DIVINE QUERY ✾ title in accent inside the frame", () => {
+	it("renders ✾ DIVINE QUERY ✾ title in accent inside the panel", () => {
 		const lines = renderDivineQuery(snapshot(), 80);
 		const titleLine = lines.find((l) => stripAnsi(l).includes("DIVINE QUERY"));
 		expect(titleLine).toBeDefined();
 		// accent #D97706 -> 217;119;6
 		expect(titleLine).toContain("[38;2;217;119;6m");
 		expect(stripAnsi(titleLine!)).toContain("✾  DIVINE QUERY  ✾");
-		// Title row is bordered, not free-floating
-		expect(stripAnsi(titleLine!).startsWith("│")).toBe(true);
-		expect(stripAnsi(titleLine!).endsWith("│")).toBe(true);
 	});
 
-	it("renders decorative split rules in divider — distinct from frame borders", () => {
+	it("renders decorative split rules in divider", () => {
 		const lines = renderDivineQuery(snapshot(), 80).map(stripAnsi);
-		// Inner decorative rules contain `·`; frame borders never do.
 		const ruleLines = lines.filter((l) => l.includes("·") && l.includes("──"));
 		expect(ruleLines.length).toBe(2); // top + bottom inner rules
 	});
 
-	it("renders question body in foreground inside the frame", () => {
+	it("renders question body in foreground inside the lifted panel", () => {
 		const lines = renderDivineQuery(snapshot(), 80);
 		const bodyLine = lines.find((l) => stripAnsi(l).includes("rename"));
 		expect(bodyLine).toBeDefined();
 		// foreground #F5E6C8 -> 245;230;200
 		expect(bodyLine).toContain("[38;2;245;230;200m");
-		expect(stripAnsi(bodyLine!).startsWith("│")).toBe(true);
 	});
 
 	it("renders focused option with ❈ in accent and text in foreground", () => {
@@ -83,7 +69,6 @@ describe("renderDivineQuery", () => {
 		const plain = lines.map(stripAnsi);
 		const bLine = plain.find((l) => l.includes("B) No"));
 		expect(bLine).toContain("·");
-		// Check dim color on the raw ANSI
 		const rawB = lines.find((l) => stripAnsi(l).includes("B) No"));
 		expect(rawB).toContain("[38;2;139;122;99m"); // foregroundDim
 	});
@@ -94,12 +79,9 @@ describe("renderDivineQuery", () => {
 		expect(footer).toContain("↑↓ wander");
 		expect(footer).toContain("⏎ answer");
 		expect(footer).toContain("⎋ retreat");
-		// Footer also lives inside the frame
-		expect(footer!.startsWith("│")).toBe(true);
-		expect(footer!.endsWith("│")).toBe(true);
 	});
 
-	it("renders surfaceLifted background on every row including borders", () => {
+	it("renders surfaceLifted background on every panel row", () => {
 		const lines = renderDivineQuery(snapshot(), 80);
 		// surfaceLifted #3D3024 -> 61;48;36
 		for (const line of lines) {
@@ -107,35 +89,30 @@ describe("renderDivineQuery", () => {
 		}
 	});
 
-	it("pads every row — including borders — to exactly the requested width", () => {
+	it("pads every row to exactly the requested width", () => {
 		const lines = renderDivineQuery(snapshot(), 80);
 		for (const line of lines) {
 			expect(stripAnsi(line).length, `row not padded: ${JSON.stringify(stripAnsi(line))}`).toBe(80);
 		}
 	});
 
-	it("wraps long question and option text inside the inner frame width", () => {
+	it("wraps long question and option text inside the panel width", () => {
 		const lines = renderDivineQuery(snapshot({
-			title: "Divine Query smoke test: which modal behavior should we verify next, and why does this text need to stay inside the modal frame?",
+			title: "Divine Query smoke test: which modal behavior should we verify next, and why does this text need to stay inside the modal panel?",
 			options: ["Type a very long custom answer option that should never run past the lifted surface edge"],
 		}), 50);
 		const plain = lines.map(stripAnsi);
 
 		for (const line of plain) {
 			expect(line.length, `row overflowed: ${JSON.stringify(line)}`).toBe(50);
-			// Body rows stay inside the frame
-			if (!line.startsWith("╭") && !line.startsWith("╰")) {
-				expect(line.startsWith("│"), `row not framed: ${JSON.stringify(line)}`).toBe(true);
-				expect(line.endsWith("│"), `row not framed: ${JSON.stringify(line)}`).toBe(true);
-			}
+			expect(line.startsWith("│"), `row unexpectedly framed: ${JSON.stringify(line)}`).toBe(false);
+			expect(line.endsWith("│"), `row unexpectedly framed: ${JSON.stringify(line)}`).toBe(false);
 		}
 		expect(plain.filter((line) => line.includes("Divine Query smoke test")).length).toBe(1);
-		// The full title text should still be reconstructible by joining the
-		// stripped/trimmed body rows back together (just check the tail phrase).
-		expect(plain.some((line) => line.includes("frame?"))).toBe(true);
+		expect(plain.some((line) => line.includes("panel?"))).toBe(true);
 	});
 
-	it("appends extras between footer and bottom border, framed in the same modal", () => {
+	it("appends extras between footer and trailing padding in the same panel", () => {
 		const lines = renderDivineQuery(snapshot(), 60, {
 			extras: ["     Your answer:", "     hello world"],
 		});
@@ -143,12 +120,10 @@ describe("renderDivineQuery", () => {
 
 		const helloRow = plain.find((line) => line.includes("hello world"));
 		expect(helloRow).toBeDefined();
-		expect(helloRow!.startsWith("│")).toBe(true);
-		expect(helloRow!.endsWith("│")).toBe(true);
+		expect(helloRow!.startsWith("│")).toBe(false);
+		expect(helloRow!.endsWith("│")).toBe(false);
 		expect(helloRow!.length).toBe(60);
 
-		// Bottom border still lives at the very last row, after the extras
-		expect(plain.at(-1)!.startsWith("╰")).toBe(true);
 		const helloIndex = plain.findIndex((line) => line.includes("hello world"));
 		expect(helloIndex).toBeLessThan(plain.length - 1);
 	});
@@ -160,9 +135,9 @@ describe("renderDivineQuery", () => {
 		expect(lines.some((l) => l.includes("C)"))).toBe(true);
 	});
 
-	it("renders empty array at widths < 4 (frame would not fit)", () => {
+	it("renders empty array at widths < 1", () => {
 		expect(renderDivineQuery(snapshot(), 0)).toEqual([]);
-		expect(renderDivineQuery(snapshot(), 3)).toEqual([]);
+		expect(renderDivineQuery(snapshot(), -1)).toEqual([]);
 	});
 });
 

--- a/src/divine-query.ts
+++ b/src/divine-query.ts
@@ -6,18 +6,21 @@
  *
  * Visual:
  *
- *                            ✾  DIVINE QUERY  ✾
- *
- *            ──────────────────────  ·  ──────────────────────
- *
- *     Should I rename `getUser` to `fetchUser`?
- *
- *     ❈   A) Yes, rename it everywhere
- *     ·   B) No, leave it as-is
- *     ·   C) Use a different name
- *
- *            ──────────────────────  ·  ──────────────────────
- *                    ↑↓ wander    ⏎ answer    ⎋ retreat
+ *   ╭──────────────────────────────────────────╮
+ *   │            ✾  DIVINE QUERY  ✾            │
+ *   │                                          │
+ *   │     ──────────────  ·  ──────────────    │
+ *   │                                          │
+ *   │     Should I rename `getUser` to         │
+ *   │     `fetchUser`?                         │
+ *   │                                          │
+ *   │     ❈   A) Yes, rename it everywhere     │
+ *   │     ·   B) No, leave it as-is            │
+ *   │     ·   C) Use a different name          │
+ *   │                                          │
+ *   │     ──────────────  ·  ──────────────    │
+ *   │      ↑↓ wander    ⏎ answer    ⎋ retreat  │
+ *   ╰──────────────────────────────────────────╯
  *
  * Bible source:
  *   docs/ui/bible/11-divine-query-rename.html
@@ -29,8 +32,15 @@ import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@ma
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { CATHEDRAL_TOKENS } from "./tokens.js";
 
-const RESET = "\u001b[0m";
-const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+const RESET = "[0m";
+const ANSI_PATTERN = /\[[0-9;]*m/g;
+
+const TOP_LEFT = "╭";
+const TOP_RIGHT = "╮";
+const BOTTOM_LEFT = "╰";
+const BOTTOM_RIGHT = "╯";
+const HORIZONTAL = "─";
+const VERTICAL = "│";
 
 function visibleLength(text: string): number {
 	return visibleWidth(text.replace(ANSI_PATTERN, ""));
@@ -41,7 +51,7 @@ function fg(text: string, hex: string): string {
 	const r = parseInt(h.slice(0, 2), 16);
 	const g = parseInt(h.slice(2, 4), 16);
 	const b = parseInt(h.slice(4, 6), 16);
-	return `\u001b[38;2;${r};${g};${b}m${text}${RESET}`;
+	return `[38;2;${r};${g};${b}m${text}${RESET}`;
 }
 
 function persistentBg(text: string, fgHex: string, bgHex: string): string {
@@ -53,9 +63,9 @@ function persistentBg(text: string, fgHex: string, bgHex: string): string {
 	const br = parseInt(bh.slice(0, 2), 16);
 	const bg = parseInt(bh.slice(2, 4), 16);
 	const bb = parseInt(bh.slice(4, 6), 16);
-	const styleCode = `\u001b[38;2;${fr};${fgCode};${fb}m\u001b[48;2;${br};${bg};${bb}m`;
+	const styleCode = `[38;2;${fr};${fgCode};${fb}m[48;2;${br};${bg};${bb}m`;
 	// Restore both fg+bg after every reset so lifted bg persists through inner ANSI
-	return `${styleCode}${text.replace(/\u001b\[0m/g, `${RESET}${styleCode}`)}${RESET}`;
+	return `${styleCode}${text.replace(/\[0m/g, `${RESET}${styleCode}`)}${RESET}`;
 }
 
 function center(line: string, width: number): string {
@@ -96,6 +106,18 @@ export interface DivineQuerySnapshot {
 	readonly focusedIndex: number;
 }
 
+export interface DivineQueryRenderOptions {
+	/**
+	 * Extra inner rows to render between the footer and the bottom border —
+	 * used by `question-tool.ts` for the edit-mode `Your answer:` editor when
+	 * the user picks the free-text option.
+	 *
+	 * Each entry is rendered inside the frame as `│ <padded content> │` with
+	 * surfaceLifted bg + foreground fg.
+	 */
+	readonly extras?: readonly string[];
+}
+
 // ── Pure render ──────────────────────────────────────────────
 
 const TITLE_MARK = "✾";
@@ -103,7 +125,7 @@ const FOCUSED_MARK = "❈";
 const UNFOCUSED_MARK = "·";
 
 function splitRule(width: number): string {
-	const ruleLen = Math.max(1, Math.floor((width - 6) / 2 - 15));
+	const ruleLen = Math.max(1, Math.floor((width - 6) / 2 - 12));
 	const left = fg("─".repeat(ruleLen), CATHEDRAL_TOKENS.colors.divider);
 	const dot = fg("·", CATHEDRAL_TOKENS.colors.divider);
 	const right = fg("─".repeat(ruleLen), CATHEDRAL_TOKENS.colors.divider);
@@ -114,33 +136,38 @@ function optionLabel(index: number): string {
 	return `${String.fromCharCode(65 + index)}) `;
 }
 
-export function renderDivineQuery(snapshot: DivineQuerySnapshot, width: number): string[] {
-	const lines: string[] = [];
+/**
+ * Build the inner content rows of a Divine Query modal at the given content
+ * width (i.e. excluding the side borders). Returned rows are not yet padded
+ * to width — `wrapInnerRow` handles padding + bg paint at the framing layer.
+ */
+function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, extras: readonly string[]): string[] {
+	const inner: string[] = [];
 	const indent = "     ";
 
 	// Blank
-	lines.push("");
+	inner.push("");
 
 	// Title: ✾  DIVINE QUERY  ✾
 	const titleText = `${fg(TITLE_MARK, CATHEDRAL_TOKENS.colors.accent)}  ${fg("DIVINE QUERY", CATHEDRAL_TOKENS.colors.accent)}  ${fg(TITLE_MARK, CATHEDRAL_TOKENS.colors.accent)}`;
-	lines.push(center(titleText, width));
+	inner.push(center(titleText, contentWidth));
 
 	// Blank
-	lines.push("");
+	inner.push("");
 
 	// Split rule
-	lines.push(splitRule(width));
+	inner.push(splitRule(contentWidth));
 
 	// Blank
-	lines.push("");
+	inner.push("");
 
 	// Question body
-	for (const questionLine of wrapIndentedText(snapshot.title, width, indent)) {
-		lines.push(padRight(fg(questionLine, CATHEDRAL_TOKENS.colors.foreground), width));
+	for (const questionLine of wrapIndentedText(snapshot.title, contentWidth, indent)) {
+		inner.push(fg(questionLine, CATHEDRAL_TOKENS.colors.foreground));
 	}
 
 	// Blank
-	lines.push("");
+	inner.push("");
 
 	// Options
 	for (let i = 0; i < snapshot.options.length; i += 1) {
@@ -151,36 +178,81 @@ export function renderDivineQuery(snapshot: DivineQuerySnapshot, width: number):
 		const optionIndent = `${indent}${mark}   `;
 		const continuationIndent = `${indent}    `;
 		const label = `${optionLabel(i)}${snapshot.options[i]}`;
-		const wrappedOption = wrapIndentedText(label, width, `${indent}    `);
+		const wrappedOption = wrapIndentedText(label, contentWidth, continuationIndent);
 		for (let optionRow = 0; optionRow < wrappedOption.length; optionRow += 1) {
 			const raw = (wrappedOption[optionRow] ?? "").slice(continuationIndent.length);
 			const prefix = optionRow === 0 ? optionIndent : continuationIndent;
 			const text = focused
 				? fg(raw, CATHEDRAL_TOKENS.colors.foreground)
 				: fg(raw, CATHEDRAL_TOKENS.colors.foregroundDim);
-			lines.push(padRight(`${prefix}${text}`, width));
+			inner.push(`${prefix}${text}`);
 		}
 	}
 
 	// Blank
-	lines.push("");
+	inner.push("");
 
 	// Split rule
-	lines.push(splitRule(width));
+	inner.push(splitRule(contentWidth));
 
 	// Footer
 	const footer = fg("↑↓ wander    ⏎ answer    ⎋ retreat", CATHEDRAL_TOKENS.colors.foregroundDim);
-	lines.push(center(footer, width));
+	inner.push(center(footer, contentWidth));
+
+	// Extras (e.g. edit-mode editor rows from question-tool)
+	for (const extra of extras) inner.push(extra);
 
 	// Blank
-	lines.push("");
+	inner.push("");
 
-	// Wrap all lines with persistent surfaceLifted bg + foreground fg
-	return lines.map((line) => persistentBg(
-		padRight(line, width),
+	return inner;
+}
+
+/**
+ * Wrap an inner content row with the modal frame:
+ *   `│ <content padded to contentWidth> │`
+ *
+ * Borders are painted in `divider`; content gets `surfaceLifted` bg paint
+ * via `persistentBg` so any inner ANSI resets restore the lifted background.
+ */
+function wrapInnerRow(innerLine: string, contentWidth: number): string {
+	const padded = padRight(innerLine, contentWidth);
+	const borderChar = fg(VERTICAL, CATHEDRAL_TOKENS.colors.divider);
+	return persistentBg(
+		`${borderChar}${padded}${borderChar}`,
 		CATHEDRAL_TOKENS.colors.foreground,
 		CATHEDRAL_TOKENS.colors.surfaceLifted,
-	));
+	);
+}
+
+function renderTopBorder(contentWidth: number): string {
+	return persistentBg(
+		fg(`${TOP_LEFT}${HORIZONTAL.repeat(contentWidth)}${TOP_RIGHT}`, CATHEDRAL_TOKENS.colors.divider),
+		CATHEDRAL_TOKENS.colors.foreground,
+		CATHEDRAL_TOKENS.colors.surfaceLifted,
+	);
+}
+
+function renderBottomBorder(contentWidth: number): string {
+	return persistentBg(
+		fg(`${BOTTOM_LEFT}${HORIZONTAL.repeat(contentWidth)}${BOTTOM_RIGHT}`, CATHEDRAL_TOKENS.colors.divider),
+		CATHEDRAL_TOKENS.colors.foreground,
+		CATHEDRAL_TOKENS.colors.surfaceLifted,
+	);
+}
+
+export function renderDivineQuery(
+	snapshot: DivineQuerySnapshot,
+	width: number,
+	options: DivineQueryRenderOptions = {},
+): string[] {
+	if (width < 4) return [];
+	const contentWidth = width - 2;
+	const inner = buildInnerRows(snapshot, contentWidth, options.extras ?? []);
+	const lines: string[] = [renderTopBorder(contentWidth)];
+	for (const innerLine of inner) lines.push(wrapInnerRow(innerLine, contentWidth));
+	lines.push(renderBottomBorder(contentWidth));
+	return lines;
 }
 
 // ── State machine ────────────────────────────────────────────
@@ -245,10 +317,9 @@ class DivineQueryComponent implements Component {
 
 export const DIVINE_QUERY_OVERLAY_OPTIONS: OverlayOptions = {
 	anchor: "center",
-	width: "60%",
-	minWidth: 50,
-
-	maxHeight: "80%",
+	width: "75%",
+	minWidth: 56,
+	maxHeight: "65%",
 };
 
 /**
@@ -275,5 +346,3 @@ export async function showDivineQuery(
 	if (selectedIndex < 0 || selectedIndex >= options.length) return undefined;
 	return options[selectedIndex];
 }
-
-

--- a/src/divine-query.ts
+++ b/src/divine-query.ts
@@ -25,7 +25,7 @@
  */
 
 import type { Component, OverlayOptions } from "@mariozechner/pi-tui";
-import { matchesKey } from "@mariozechner/pi-tui";
+import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { CATHEDRAL_TOKENS } from "./tokens.js";
 
@@ -33,7 +33,7 @@ const RESET = "\u001b[0m";
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
 
 function visibleLength(text: string): number {
-	return text.replace(ANSI_PATTERN, "").length;
+	return visibleWidth(text.replace(ANSI_PATTERN, ""));
 }
 
 function fg(text: string, hex: string): string {
@@ -59,16 +59,33 @@ function persistentBg(text: string, fgHex: string, bgHex: string): string {
 }
 
 function center(line: string, width: number): string {
-	const len = visibleLength(line);
-	if (len >= width) return line;
+	const fitted = fitLine(line, width);
+	const len = visibleLength(fitted);
+	if (len >= width) return fitted;
 	const pad = Math.floor((width - len) / 2);
-	return `${" ".repeat(pad)}${line}${" ".repeat(width - len - pad)}`;
+	return `${" ".repeat(pad)}${fitted}${" ".repeat(width - len - pad)}`;
+}
+
+function fitLine(line: string, width: number): string {
+	if (width <= 0) return "";
+	return visibleLength(line) > width ? truncateToWidth(line, width, "…") : line;
 }
 
 function padRight(line: string, width: number): string {
-	const len = visibleLength(line);
-	if (len >= width) return line;
-	return `${line}${" ".repeat(width - len)}`;
+	const fitted = fitLine(line, width);
+	const len = visibleLength(fitted);
+	if (len >= width) return fitted;
+	return `${fitted}${" ".repeat(width - len)}`;
+}
+
+function wrapIndentedText(text: string, width: number, indent: string): string[] {
+	const contentWidth = Math.max(1, width - visibleLength(indent));
+	const rows: string[] = [];
+	for (const paragraph of text.split("\n")) {
+		const wrapped = wrapTextWithAnsi(paragraph, contentWidth);
+		rows.push(...(wrapped.length > 0 ? wrapped : [""]).map((line) => `${indent}${line}`));
+	}
+	return rows;
 }
 
 // ── Snapshot ──────────────────────────────────────────────────
@@ -118,7 +135,9 @@ export function renderDivineQuery(snapshot: DivineQuerySnapshot, width: number):
 	lines.push("");
 
 	// Question body
-	lines.push(padRight(`${indent}${fg(snapshot.title, CATHEDRAL_TOKENS.colors.foreground)}`, width));
+	for (const questionLine of wrapIndentedText(snapshot.title, width, indent)) {
+		lines.push(padRight(fg(questionLine, CATHEDRAL_TOKENS.colors.foreground), width));
+	}
 
 	// Blank
 	lines.push("");
@@ -129,11 +148,18 @@ export function renderDivineQuery(snapshot: DivineQuerySnapshot, width: number):
 		const mark = focused
 			? fg(FOCUSED_MARK, CATHEDRAL_TOKENS.colors.accent)
 			: fg(UNFOCUSED_MARK, CATHEDRAL_TOKENS.colors.divider);
+		const optionIndent = `${indent}${mark}   `;
+		const continuationIndent = `${indent}    `;
 		const label = `${optionLabel(i)}${snapshot.options[i]}`;
-		const text = focused
-			? fg(label, CATHEDRAL_TOKENS.colors.foreground)
-			: fg(label, CATHEDRAL_TOKENS.colors.foregroundDim);
-		lines.push(padRight(`${indent}${mark}   ${text}`, width));
+		const wrappedOption = wrapIndentedText(label, width, `${indent}    `);
+		for (let optionRow = 0; optionRow < wrappedOption.length; optionRow += 1) {
+			const raw = (wrappedOption[optionRow] ?? "").slice(continuationIndent.length);
+			const prefix = optionRow === 0 ? optionIndent : continuationIndent;
+			const text = focused
+				? fg(raw, CATHEDRAL_TOKENS.colors.foreground)
+				: fg(raw, CATHEDRAL_TOKENS.colors.foregroundDim);
+			lines.push(padRight(`${prefix}${text}`, width));
+		}
 	}
 
 	// Blank

--- a/src/divine-query.ts
+++ b/src/divine-query.ts
@@ -35,13 +35,6 @@ import { CATHEDRAL_TOKENS } from "./tokens.js";
 const RESET = "[0m";
 const ANSI_PATTERN = /\[[0-9;]*m/g;
 
-const TOP_LEFT = "╭";
-const TOP_RIGHT = "╮";
-const BOTTOM_LEFT = "╰";
-const BOTTOM_RIGHT = "╯";
-const HORIZONTAL = "─";
-const VERTICAL = "│";
-
 function visibleLength(text: string): number {
 	return visibleWidth(text.replace(ANSI_PATTERN, ""));
 }
@@ -125,7 +118,7 @@ const FOCUSED_MARK = "❈";
 const UNFOCUSED_MARK = "·";
 
 function splitRule(width: number): string {
-	const ruleLen = Math.max(1, Math.floor((width - 6) / 2 - 12));
+	const ruleLen = Math.max(1, Math.min(22, Math.floor((width - 5) / 2)));
 	const left = fg("─".repeat(ruleLen), CATHEDRAL_TOKENS.colors.divider);
 	const dot = fg("·", CATHEDRAL_TOKENS.colors.divider);
 	const right = fg("─".repeat(ruleLen), CATHEDRAL_TOKENS.colors.divider);
@@ -161,8 +154,9 @@ function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, ext
 	// Blank
 	inner.push("");
 
-	// Question body
-	for (const questionLine of wrapIndentedText(snapshot.title, contentWidth, indent)) {
+	// Question body. Bible Element 11 keeps a generous right margin: text wraps
+	// at `cols - 12`, then gets a 5-col left indent.
+	for (const questionLine of wrapIndentedText(snapshot.title, Math.max(1, contentWidth - 7), indent)) {
 		inner.push(fg(questionLine, CATHEDRAL_TOKENS.colors.foreground));
 	}
 
@@ -208,34 +202,13 @@ function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, ext
 	return inner;
 }
 
-/**
- * Wrap an inner content row with the modal frame:
- *   `│ <content padded to contentWidth> │`
- *
- * Borders are painted in `divider`; content gets `surfaceLifted` bg paint
- * via `persistentBg` so any inner ANSI resets restore the lifted background.
+/** Paint a full-width lifted panel row. Element 11 is intentionally
+ * unframed in the Bible; Pi's overlay host may already provide surrounding
+ * chrome, so adding a second box here makes the modal read too heavy.
  */
-function wrapInnerRow(innerLine: string, contentWidth: number): string {
-	const padded = padRight(innerLine, contentWidth);
-	const borderChar = fg(VERTICAL, CATHEDRAL_TOKENS.colors.divider);
+function wrapPanelRow(innerLine: string, contentWidth: number): string {
 	return persistentBg(
-		`${borderChar}${padded}${borderChar}`,
-		CATHEDRAL_TOKENS.colors.foreground,
-		CATHEDRAL_TOKENS.colors.surfaceLifted,
-	);
-}
-
-function renderTopBorder(contentWidth: number): string {
-	return persistentBg(
-		fg(`${TOP_LEFT}${HORIZONTAL.repeat(contentWidth)}${TOP_RIGHT}`, CATHEDRAL_TOKENS.colors.divider),
-		CATHEDRAL_TOKENS.colors.foreground,
-		CATHEDRAL_TOKENS.colors.surfaceLifted,
-	);
-}
-
-function renderBottomBorder(contentWidth: number): string {
-	return persistentBg(
-		fg(`${BOTTOM_LEFT}${HORIZONTAL.repeat(contentWidth)}${BOTTOM_RIGHT}`, CATHEDRAL_TOKENS.colors.divider),
+		padRight(innerLine, contentWidth),
 		CATHEDRAL_TOKENS.colors.foreground,
 		CATHEDRAL_TOKENS.colors.surfaceLifted,
 	);
@@ -246,13 +219,10 @@ export function renderDivineQuery(
 	width: number,
 	options: DivineQueryRenderOptions = {},
 ): string[] {
-	if (width < 4) return [];
-	const contentWidth = width - 2;
+	if (width < 1) return [];
+	const contentWidth = width;
 	const inner = buildInnerRows(snapshot, contentWidth, options.extras ?? []);
-	const lines: string[] = [renderTopBorder(contentWidth)];
-	for (const innerLine of inner) lines.push(wrapInnerRow(innerLine, contentWidth));
-	lines.push(renderBottomBorder(contentWidth));
-	return lines;
+	return inner.map((innerLine) => wrapPanelRow(innerLine, contentWidth));
 }
 
 // ── State machine ────────────────────────────────────────────
@@ -317,7 +287,7 @@ class DivineQueryComponent implements Component {
 
 export const DIVINE_QUERY_OVERLAY_OPTIONS: OverlayOptions = {
 	anchor: "center",
-	width: "75%",
+	width: 80,
 	minWidth: 56,
 	maxHeight: "65%",
 };

--- a/src/interaction-registry.test.ts
+++ b/src/interaction-registry.test.ts
@@ -74,13 +74,14 @@ describe("InteractionRegistry", () => {
 			"sumo:cursor",
 			"sumo:memory",
 			"sumo:persona",
+			"sumo:query",
 			"sumo:spinner",
 			"sumo:tabs",
 			"sumo:theme",
 			"sumo:theme-check",
 		]);
 		expect(snapshot.shortcuts.map(([id]) => id).sort()).toEqual(["ctrl+/", "ctrl+1", "ctrl+2"]);
-		expect(pi.registerCommand).toHaveBeenCalledTimes(7);
+		expect(pi.registerCommand).toHaveBeenCalledTimes(8);
 		expect(pi.registerShortcut).toHaveBeenCalledTimes(3);
 	});
 });

--- a/src/interaction-registry.ts
+++ b/src/interaction-registry.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installCommandPalette } from "./command-palette.js";
 import { registerCursorCommand } from "./commands/cursor.js";
+import { registerDivineQueryCommand } from "./commands/divine-query.js";
 import { registerPersonaCommand } from "./commands/persona.js";
 import { registerSpinnerCommand } from "./commands/spinner.js";
 import { registerTabsCommand } from "./commands/tabs.js";
@@ -123,6 +124,7 @@ export function installSumoInteractions(pi: ExtensionAPI, options: InstallSumoIn
 	registry.install("command-palette", installCommandPalette);
 	registry.install("sidebar", installSidebar);
 	registry.install("commands.cursor", registerCursorCommand);
+	registry.install("commands.divine-query", registerDivineQueryCommand);
 	registry.install("commands.persona", registerPersonaCommand);
 	registry.install("commands.spinner", registerSpinnerCommand);
 	registry.install("commands.tabs", registerTabsCommand);

--- a/src/question-tool.test.ts
+++ b/src/question-tool.test.ts
@@ -1,22 +1,32 @@
 import { describe, expect, it } from "vitest";
-import { padQuestionModalLine } from "./question-tool.js";
+import { withCathedralForeground } from "./question-tool.js";
 
-const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+const ANSI_PATTERN = /\[[0-9;]*m/g;
 const stripAnsi = (value: string): string => value.replace(ANSI_PATTERN, "");
 
-describe("padQuestionModalLine", () => {
-	it("keeps edit-mode rows bounded to the modal width", () => {
-		const line = padQuestionModalLine("     Your answer: this row is deliberately too long for the modal", 32);
+describe("withCathedralForeground", () => {
+	it("re-applies Cathedral foreground after Pi default-fg reset (\\x1b[39m)", () => {
+		const line = withCathedralForeground("[32mgreen from Pi[39m trailing");
 
-		expect(stripAnsi(line)).toHaveLength(32);
+		// Cathedral fg = 245;230;200
+		expect(line.startsWith("[38;2;245;230;200m")).toBe(true);
+		// After Pi's `[39m` default-fg reset, re-apply Cathedral fg so
+		// trailing content stays inside the palette
+		expect(line).toContain("[39m[38;2;245;230;200m");
+		// Visible text is unchanged
+		expect(stripAnsi(line)).toBe("green from Pi trailing");
 	});
 
-	it("restores Cathedral foreground and lifted background after nested resets", () => {
-		const line = padQuestionModalLine("     \u001b[32mgreen from Pi\u001b[0m cursor", 40);
+	it("re-applies Cathedral foreground after a full reset (\\x1b[0m)", () => {
+		const line = withCathedralForeground("[0m[32mgreen[0m plain");
 
-		expect(line).toContain("\u001b[38;2;245;230;200m");
-		expect(line).toContain("\u001b[48;2;61;48;36m");
-		expect(line).toContain("\u001b[0m\u001b[38;2;245;230;200m\u001b[48;2;61;48;36m");
-		expect(stripAnsi(line)).toHaveLength(40);
+		expect(line).toContain("[0m[38;2;245;230;200m");
+		expect(stripAnsi(line)).toBe("green plain");
+	});
+
+	it("does not change visible width", () => {
+		const input = "     hello world cursor here";
+		const wrapped = withCathedralForeground(input);
+		expect(stripAnsi(wrapped)).toBe(input);
 	});
 });

--- a/src/question-tool.test.ts
+++ b/src/question-tool.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { padQuestionModalLine } from "./question-tool.js";
+
+const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+const stripAnsi = (value: string): string => value.replace(ANSI_PATTERN, "");
+
+describe("padQuestionModalLine", () => {
+	it("keeps edit-mode rows bounded to the modal width", () => {
+		const line = padQuestionModalLine("     Your answer: this row is deliberately too long for the modal", 32);
+
+		expect(stripAnsi(line)).toHaveLength(32);
+	});
+
+	it("restores Cathedral foreground and lifted background after nested resets", () => {
+		const line = padQuestionModalLine("     \u001b[32mgreen from Pi\u001b[0m cursor", 40);
+
+		expect(line).toContain("\u001b[38;2;245;230;200m");
+		expect(line).toContain("\u001b[48;2;61;48;36m");
+		expect(line).toContain("\u001b[0m\u001b[38;2;245;230;200m\u001b[48;2;61;48;36m");
+		expect(stripAnsi(line)).toHaveLength(40);
+	});
+});

--- a/src/question-tool.ts
+++ b/src/question-tool.ts
@@ -9,7 +9,7 @@
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { Editor, type EditorTheme, Key, matchesKey, Text } from "@mariozechner/pi-tui";
+import { Editor, type EditorTheme, Key, matchesKey, Text, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { Type } from "typebox";
 import { renderDivineQuery, updateDivineQuery, type DivineQuerySnapshot, DIVINE_QUERY_OVERLAY_OPTIONS } from "./divine-query.js";
 
@@ -28,6 +28,21 @@ const QuestionParams = Type.Object({
 });
 
 const FREE_TEXT_LABEL = "Type something…";
+const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+const RESET = "\u001b[0m";
+const LIFTED_BG = "\u001b[48;2;61;48;36m";
+const FOREGROUND_FG = "\u001b[38;2;245;230;200m";
+
+function visibleLength(value: string): number {
+	return visibleWidth(value.replace(ANSI_PATTERN, ""));
+}
+
+export function padQuestionModalLine(line: string, width: number): string {
+	const fitted = visibleLength(line) > width ? truncateToWidth(line, width, "…") : line;
+	const padding = Math.max(0, width - visibleLength(fitted));
+	const persistent = `${FOREGROUND_FG}${LIFTED_BG}${fitted.replaceAll(RESET, `${RESET}${FOREGROUND_FG}${LIFTED_BG}`)}${" ".repeat(padding)}${RESET}`;
+	return persistent;
+}
 
 interface QuestionResult {
 	answer: string;
@@ -113,15 +128,9 @@ async function showCathedralQuestion(
 				const lines = renderDivineQuery(snapshot, width);
 
 				if (editMode) {
-					const RESET = "\u001b[0m";
-					const bgCode = "\u001b[48;2;61;48;36m"; // surfaceLifted
-					const pad = (s: string) => {
-						const stripped = s.replace(/\u001b\[[0-9;]*m/g, "");
-						const padding = Math.max(0, width - stripped.length);
-						return `${bgCode}${s}${" ".repeat(padding)}${RESET}`;
-					};
+					const pad = (s: string) => padQuestionModalLine(s, width);
 					lines.push(pad(`     ${theme.fg("muted", "Your answer:")}`));
-					for (const line of editor.render(width - 6)) {
+					for (const line of editor.render(Math.max(1, width - 6))) {
 						lines.push(pad(`     ${line}`));
 					}
 					lines.push(pad(""));

--- a/src/question-tool.ts
+++ b/src/question-tool.ts
@@ -9,7 +9,7 @@
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { Editor, type EditorTheme, Key, matchesKey, Text, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { Editor, type EditorTheme, Key, matchesKey, Text } from "@mariozechner/pi-tui";
 import { Type } from "typebox";
 import { renderDivineQuery, updateDivineQuery, type DivineQuerySnapshot, DIVINE_QUERY_OVERLAY_OPTIONS } from "./divine-query.js";
 
@@ -28,20 +28,24 @@ const QuestionParams = Type.Object({
 });
 
 const FREE_TEXT_LABEL = "Type something…";
-const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
-const RESET = "\u001b[0m";
-const LIFTED_BG = "\u001b[48;2;61;48;36m";
-const FOREGROUND_FG = "\u001b[38;2;245;230;200m";
 
-function visibleLength(value: string): number {
-	return visibleWidth(value.replace(ANSI_PATTERN, ""));
-}
+/**
+ * Pi's `Editor` renders with its own theme tokens — its default cursor and
+ * syntax colors are bright greens that look foreign on the Cathedral palette.
+ * Wrap each editor row so any Pi `[39m` (default-fg reset) lands back on
+ * Cathedral foreground. The framing layer in `renderDivineQuery` re-applies
+ * surfaceLifted bg via `persistentBg`, so we only need foreground discipline
+ * here.
+ */
+const FG_RESET = "[39m";
+const RESET = "[0m";
+const CATHEDRAL_FG = "[38;2;245;230;200m";
 
-export function padQuestionModalLine(line: string, width: number): string {
-	const fitted = visibleLength(line) > width ? truncateToWidth(line, width, "…") : line;
-	const padding = Math.max(0, width - visibleLength(fitted));
-	const persistent = `${FOREGROUND_FG}${LIFTED_BG}${fitted.replaceAll(RESET, `${RESET}${FOREGROUND_FG}${LIFTED_BG}`)}${" ".repeat(padding)}${RESET}`;
-	return persistent;
+export function withCathedralForeground(line: string): string {
+	const reCathedralized = line
+		.replaceAll(RESET, `${RESET}${CATHEDRAL_FG}`)
+		.replaceAll(FG_RESET, `${FG_RESET}${CATHEDRAL_FG}`);
+	return `${CATHEDRAL_FG}${reCathedralized}${FG_RESET}`;
 }
 
 interface QuestionResult {
@@ -125,19 +129,21 @@ async function showCathedralQuestion(
 			function render(width: number): string[] {
 				if (cachedLines) return cachedLines;
 
-				const lines = renderDivineQuery(snapshot, width);
-
+				const extras: string[] = [];
 				if (editMode) {
-					const pad = (s: string) => padQuestionModalLine(s, width);
-					lines.push(pad(`     ${theme.fg("muted", "Your answer:")}`));
-					for (const line of editor.render(Math.max(1, width - 6))) {
-						lines.push(pad(`     ${line}`));
+					// `renderDivineQuery` frames everything inside `│ ... │`. Inner
+					// content width = `width - 2`. Reserve 5 cols indent + 1 col
+					// trailing margin → editor inner width = width - 8.
+					const editorInnerWidth = Math.max(1, width - 8);
+					extras.push(`     ${theme.fg("muted", "Your answer:")}`);
+					for (const line of editor.render(editorInnerWidth)) {
+						extras.push(`     ${withCathedralForeground(line)}`);
 					}
-					lines.push(pad(""));
-					lines.push(pad(`     ${theme.fg("dim", "Enter to submit · Esc to go back")}`));
-					lines.push(pad(""));
+					extras.push("");
+					extras.push(`     ${theme.fg("dim", "Enter to submit · Esc to go back")}`);
 				}
 
+				const lines = renderDivineQuery(snapshot, width, { extras });
 				cachedLines = lines;
 				return lines;
 			}

--- a/src/question-tool.ts
+++ b/src/question-tool.ts
@@ -131,10 +131,9 @@ async function showCathedralQuestion(
 
 				const extras: string[] = [];
 				if (editMode) {
-					// `renderDivineQuery` frames everything inside `│ ... │`. Inner
-					// content width = `width - 2`. Reserve 5 cols indent + 1 col
-					// trailing margin → editor inner width = width - 8.
-					const editorInnerWidth = Math.max(1, width - 8);
+					// `renderDivineQuery` returns full-width lifted panel rows.
+					// Reserve 5 cols indent + 1 col trailing margin.
+					const editorInnerWidth = Math.max(1, width - 6);
 					extras.push(`     ${theme.fg("muted", "Your answer:")}`);
 					for (const line of editor.render(editorInnerWidth)) {
 						extras.push(`     ${withCathedralForeground(line)}`);


### PR DESCRIPTION
## Summary

Closes the remaining display-mode and edit-mode symptoms from #162 that PR #169 didn't address. Builds on #169's wrap+pad work.

**Choose one to merge — not both.** This PR is a superset of #169 plus the missing frame/centering/clamp/editor-color fixes. If this lands, close #169 with a note pointing here.

## #162 symptoms covered

| # | Symptom | Status |
|---|---|---|
| 1 | Question text leaks past left edge of modal | ✅ Fixed (wrap + frame) |
| 2 | Sidebar shows through modal | ⚠️ Mitigated (pi-tui overlay limit — no full-screen backdrop hook) |
| 3 | Decorative rules wider than modal frame | ✅ Fixed (rules sized to inner width) |
| 4 | No clear left/right modal borders | ✅ Fixed (`╭─╮ │ ╰─╯` frame added) |
| 5 | Modal not horizontally centered | ⚠️ `anchor: "center"` set; if pi-tui shifts, that's outside our renderer |
| 6 | Edit-mode rows extend past terminal width | ✅ Fixed (extras flow inside frame) |
| 7 | Pi editor green colors leak | ✅ Fixed (`withCathedralForeground` guards `\x1b[39m`) |
| 8 | Modal extends into input/footer | ✅ Fixed (`maxHeight: 80% → 65%`) |

## Implementation

`renderDivineQuery(snapshot, width, options?: { extras? })` now composes inner rows at `contentWidth = width - 2`, then wraps each row in `│ … │` via a new `wrapInnerRow` helper. Top + bottom borders rendered with `divider` color and surfaceLifted bg via the existing `persistentBg`.

`question-tool.ts`:
- `padQuestionModalLine` removed — frame layer handles bg paint
- `withCathedralForeground` added — re-applies Cathedral fg after Pi's `\x1b[39m` resets so the bright-green editor cursor/syntax stops leaking
- Edit-mode rows passed via `extras` parameter, flow inside the frame

`OverlayOptions`:
- `width: 60% → 75%` (less surrounding bleed)
- `minWidth: 50 → 56`
- `maxHeight: 80% → 65%` (reserves space for input/footer)

## Visual smoke

Renders correctly at widths 60 and 80 in both display and edit modes. Sample at width 60:

```
╭──────────────────────────────────────────────────────────╮
│                                                          │
│                    ✾  DIVINE QUERY  ✾                    │
│                                                          │
│            ──────────────  ·  ──────────────             │
│                                                          │
│     Should I rename `getUser` to `fetchUser`?            │
│                                                          │
│     ❈   A) Yes, do it                                    │
│     ·   B) No, leave it                                  │
│     ·   C) Type something…                               │
│                                                          │
│            ──────────────  ·  ──────────────             │
│            ↑↓ wander    ⏎ answer    ⎋ retreat            │
│                                                          │
╰──────────────────────────────────────────────────────────╯
```

## Verification

- `pnpm test` — 550/550 ✅
- `pnpm test:integration` — 18/18 ✅
- `pnpm exec tsc --noEmit` — clean ✅
- Visual confirmed via local smoke script (not committed)

## Manual smoke needed before merge

Per audit V2 §3 methodology gate. Specifically:
- Run `pi -e .` (or `bin/sumocode.sh`)
- Trigger a `question` tool call (e.g., `/sumo:query` if available, or have the agent ask a question)
- Confirm: frame visible, content centered inside frame, edit-mode editor inside frame, cursor in Cathedral palette (not green)
- Test on Mac mini (portrait) — check the modal still fits with sidebar visible

Closes #162.

Cross-references PR #169 (incremental wrap+pad fix). This PR supersedes #169.