### PR TITLE
feat(render): lazy frame-start + per-row column-range diff (#172)

### DIFF
--- a/scripts/bench-diff-bytes.mjs
+++ b/scripts/bench-diff-bytes.mjs
@@ -12,14 +12,18 @@
  * frame-start. Per-frame measurements use the diff layer directly to keep
  * the comparison apples-to-apples between paths.
  */
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
 import { createJiti } from "@mariozechner/jiti";
 
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(SCRIPT_DIR, "..", "src", "sumo-tui");
+
 const jiti = createJiti(import.meta.url, { moduleCache: false, tryNative: false });
-const root = "/Users/dhruvkelawala/development/sumocode/src/sumo-tui";
-const { CellBuffer } = await jiti.import(`${root}/render/buffer.ts`);
-const { diffFrames } = await jiti.import(`${root}/render/diff.ts`);
-const { cellRowToAnsi } = await jiti.import(`${root}/render/ansi-writer.ts`);
-const { TerminalSessionOwner } = await jiti.import(`${root}/runtime/terminal-controller.ts`);
+const { CellBuffer } = await jiti.import(resolve(ROOT, "render/buffer.ts"));
+const { diffFrames } = await jiti.import(resolve(ROOT, "render/diff.ts"));
+const { cellRowToAnsi } = await jiti.import(resolve(ROOT, "render/ansi-writer.ts"));
+const { TerminalSessionOwner } = await jiti.import(resolve(ROOT, "runtime/terminal-controller.ts"));
 
 class StubOut {
 	constructor() { this.bytes = 0; this.calls = 0; }

--- a/scripts/bench-diff-bytes.mjs
+++ b/scripts/bench-diff-bytes.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * Reproducible benchmark for #172 — measures stdout bytes emitted per frame
+ * under realistic SumoCode scenarios. Compares the OLD path (full-row
+ * repaint, always emit `\x1b[?2026h … \x1b[?2026l` wrapper, always re-emit
+ * cursor) against the NEW path (column-range diff + lazy frame-start +
+ * cursor cache) on the same input frames.
+ *
+ * Run: `node scripts/bench-diff-bytes.mjs`
+ *
+ * No-op tick measurements use the actual `TerminalSessionOwner` lazy
+ * frame-start. Per-frame measurements use the diff layer directly to keep
+ * the comparison apples-to-apples between paths.
+ */
+import { createJiti } from "@mariozechner/jiti";
+
+const jiti = createJiti(import.meta.url, { moduleCache: false, tryNative: false });
+const root = "/Users/dhruvkelawala/development/sumocode/src/sumo-tui";
+const { CellBuffer } = await jiti.import(`${root}/render/buffer.ts`);
+const { diffFrames } = await jiti.import(`${root}/render/diff.ts`);
+const { cellRowToAnsi } = await jiti.import(`${root}/render/ansi-writer.ts`);
+const { TerminalSessionOwner } = await jiti.import(`${root}/runtime/terminal-controller.ts`);
+
+class StubOut {
+	constructor() { this.bytes = 0; this.calls = 0; }
+	get isTTY() { return true; }
+	write(data) { this.bytes += Buffer.byteLength(data, "utf8"); this.calls += 1; return true; }
+}
+
+function frame(rows, cols, lines) {
+	const buf = new CellBuffer(rows, cols);
+	for (let r = 0; r < lines.length; r += 1) buf.paintRow(r, lines[r]);
+	return buf;
+}
+
+function bytesOldPath(prev, next, cursor) {
+	// OLD path: full-row repaint of every changed row, always emit `?2026h`
+	// wrapper, always re-emit cursor. Mirrors the writeFramePatches behaviour
+	// before #172.
+	const { rows, cols } = next.getDimensions();
+	let output = "\x1b[?2026h";
+	for (let row = 0; row < rows; row += 1) {
+		let changed = false;
+		for (let col = 0; col < cols; col += 1) {
+			const a = prev.getCell(row, col);
+			const b = next.getCell(row, col);
+			if (a.char !== b.char || a.fg !== b.fg || a.bg !== b.bg) { changed = true; break; }
+		}
+		if (changed) output += `\x1b[${row + 1};1H${cellRowToAnsi(next, row)}\x1b[K`;
+	}
+	if (cursor) output += `\x1b[${cursor.row + 1};${cursor.col + 1}H\x1b[?25h`;
+	output += "\x1b[?2026l";
+	return Buffer.byteLength(output, "utf8");
+}
+
+function bytesNewPath(prev, next, cursor, prevCursor = null) {
+	// NEW path: real `TerminalSessionOwner.writeFramePatches` with the same
+	// `lastEmittedCursor` cache it uses in production.
+	const stub = new StubOut();
+	const term = new TerminalSessionOwner({ output: stub });
+	if (prevCursor) {
+		// Seed the cache (one prior frame). The seed write is excluded from
+		// the measurement.
+		term.writeFramePatches([], prevCursor);
+		stub.bytes = 0;
+		stub.calls = 0;
+	}
+	const patches = diffFrames(prev, next);
+	term.writeFramePatches(patches, cursor);
+	return stub.bytes;
+}
+
+function row(label, oldB, newB) {
+	const delta = oldB === 0 ? "—" : `${(((oldB - newB) / oldB) * 100).toFixed(1)}%`;
+	const arrow = newB < oldB ? "↓" : newB > oldB ? "↑" : "=";
+	console.log(`  ${label.padEnd(48)} ${String(oldB).padStart(7)}B  →  ${String(newB).padStart(7)}B  ${arrow} ${delta}`);
+}
+
+console.log("\n=== Single-cell change in a 200-col row (cursor blink class) ===");
+{
+	const cols = 200;
+	const filled = " ".repeat(50) + "│" + " ".repeat(149);
+	const blinked = " ".repeat(50) + "█" + " ".repeat(149);
+	const prev = frame(1, cols, [filled]);
+	const next = frame(1, cols, [blinked]);
+	const cursor = { row: 0, col: 51 };
+	row("blink one cell", bytesOldPath(prev, next, cursor), bytesNewPath(prev, next, cursor, cursor));
+}
+
+console.log("\n=== Streaming append: 1 char at end of 200-col row ===");
+{
+	const cols = 200;
+	const a = "Hello world. " + " ".repeat(187);
+	const b = "Hello world.! " + " ".repeat(186);
+	const prev = frame(1, cols, [a]);
+	const next = frame(1, cols, [b]);
+	const cursor = { row: 0, col: 13 };
+	row("append at col 13", bytesOldPath(prev, next, cursor), bytesNewPath(prev, next, cursor, cursor));
+}
+
+console.log("\n=== Streaming append: 10 chars at end of 200-col row ===");
+{
+	const cols = 200;
+	const a = "abcdef" + " ".repeat(194);
+	const b = "abcdefghijklmnop" + " ".repeat(184);
+	const prev = frame(1, cols, [a]);
+	const next = frame(1, cols, [b]);
+	const cursor = { row: 0, col: 16 };
+	row("10 chars appended", bytesOldPath(prev, next, cursor), bytesNewPath(prev, next, cursor, cursor));
+}
+
+console.log("\n=== Idle frame (no diff, cursor unchanged) ===");
+{
+	const buf = frame(40, 200, Array(40).fill(" ".repeat(200)));
+	const cursor = { row: 5, col: 10 };
+	row("idle tick", bytesOldPath(buf, buf, cursor), bytesNewPath(buf, buf, cursor, cursor));
+}
+
+console.log("\n=== Idle frame x10 (cursor unchanged each tick) ===");
+{
+	const buf = frame(40, 200, Array(40).fill(" ".repeat(200)));
+	const cursor = { row: 5, col: 10 };
+	let oldTotal = 0;
+	for (let i = 0; i < 10; i += 1) oldTotal += bytesOldPath(buf, buf, cursor);
+	const stub = new StubOut();
+	const term = new TerminalSessionOwner({ output: stub });
+	for (let i = 0; i < 10; i += 1) {
+		term.writeFramePatches(diffFrames(buf, buf), cursor);
+	}
+	row("10 idle ticks", oldTotal, stub.bytes);
+}
+
+console.log("\n=== Cursor blink only (cursor toggles col, no patches) ===");
+{
+	const buf = frame(40, 200, Array(40).fill(" ".repeat(200)));
+	const oldB = bytesOldPath(buf, buf, { row: 5, col: 11 });
+	const newB = bytesNewPath(buf, buf, { row: 5, col: 11 }, { row: 5, col: 10 });
+	row("cursor moves 1 col", oldB, newB);
+}
+
+console.log("\n=== Single full-row change in a 40-row × 200-col frame ===");
+{
+	const cols = 200;
+	const rows = 40;
+	const before = Array(rows).fill(" ".repeat(cols));
+	const after = before.slice();
+	after[20] = "Replaced row content. " + " ".repeat(cols - 22);
+	const prev = frame(rows, cols, before);
+	const next = frame(rows, cols, after);
+	const cursor = { row: 5, col: 10 };
+	row("one row replaced", bytesOldPath(prev, next, cursor), bytesNewPath(prev, next, cursor, cursor));
+}
+
+console.log("\n=== Streaming chunk: 5 mid-row chars + cursor moves ===");
+{
+	const cols = 200;
+	const rows = 40;
+	const before = Array(rows).fill(" ".repeat(cols));
+	before[10] = "Stream output: hello" + " ".repeat(cols - 20);
+	const after = before.slice();
+	after[10] = "Stream output: hello world!" + " ".repeat(cols - 27);
+	const prev = frame(rows, cols, before);
+	const next = frame(rows, cols, after);
+	row("streaming chunk", bytesOldPath(prev, next, { row: 10, col: 27 }), bytesNewPath(prev, next, { row: 10, col: 27 }, { row: 10, col: 20 }));
+}
+
+console.log("");

--- a/src/sumo-tui/render/ansi-writer.ts
+++ b/src/sumo-tui/render/ansi-writer.ts
@@ -60,11 +60,25 @@ function styleNeedsReset(prev: StyleState, next: StyleState): boolean {
 /** Convert one retained cell row into an ANSI string, emitting SGR only when style changes. */
 export function cellRowToAnsi(buffer: CellBuffer, row: number): string {
 	const { cols } = buffer.getDimensions();
+	return cellRowSliceToAnsi(buffer, row, 0, cols - 1);
+}
+
+/**
+ * Convert a column slice of one retained cell row into an ANSI string, emitting
+ * SGR only when style changes. `startCol` and `endCol` are inclusive cell
+ * indices. Continuation cells (wide-char trailing halves) are skipped, so
+ * callers that want byte-correct output for a slice must ensure `startCol` is
+ * the head of a glyph — `rowChangeRange` in `diff.ts` handles this.
+ */
+export function cellRowSliceToAnsi(buffer: CellBuffer, row: number, startCol: number, endCol: number): string {
+	const { cols } = buffer.getDimensions();
+	const start = Math.max(0, startCol);
+	const end = Math.min(cols - 1, endCol);
 	let output = "";
 	let current: StyleState = DEFAULT_STYLE;
 	let styled = false;
 
-	for (let col = 0; col < cols; col += 1) {
+	for (let col = start; col <= end; col += 1) {
 		const cell = buffer.getCell(row, col);
 		if (cell.char === "") continue;
 		const nextStyle = styleFromCell(cell);

--- a/src/sumo-tui/render/diff.test.ts
+++ b/src/sumo-tui/render/diff.test.ts
@@ -16,18 +16,47 @@ describe("frame diff", () => {
 		expect(diffFrames(previous, next)).toEqual([]);
 	});
 
-	it("returns one row patch for one changed row", () => {
+	it("returns one row patch for one fully changed row", () => {
 		const previous = frame(["aaa", "bbb"]);
 		const next = frame(["aaa", "ccc"]);
-		expect(diffFrames(previous, next)).toEqual([{ row: 1, ansi: "ccc", type: "row" }]);
+		expect(diffFrames(previous, next)).toEqual([
+			{ row: 1, startCol: 0, ansi: "ccc", type: "row" },
+		]);
+	});
+
+	it("emits a column-range patch when only the right side of a row changes", () => {
+		const previous = frame(["abcdef", "stable"]);
+		const next = frame(["abcDEF", "stable"]);
+		const patches = diffFrames(previous, next);
+		expect(patches).toEqual([
+			{ row: 0, startCol: 3, ansi: "DEF", type: "row" },
+		]);
+	});
+
+	it("emits a column-range patch when only one cell in the middle changes", () => {
+		const previous = frame(["abcdef"]);
+		const next = frame(["abcXef"]);
+		const patches = diffFrames(previous, next);
+		expect(patches).toHaveLength(1);
+		// The slice covers exactly the changed cell — no left or right padding.
+		expect(patches[0]).toEqual({ row: 0, startCol: 3, ansi: "X", type: "row" });
+	});
+
+	it("falls back to full-row repaint when the change starts at column 0", () => {
+		const previous = frame(["abcdef"]);
+		const next = frame(["XBCdef"]);
+		const patches = diffFrames(previous, next);
+		expect(patches).toEqual([
+			{ row: 0, startCol: 0, ansi: "XBCdef", type: "row" },
+		]);
 	});
 
 	it("repaints all rows when dimensions change", () => {
 		const previous = frame(["aa"]);
 		const next = frame(["aa", "bb"]);
 		expect(diffFrames(previous, next)).toEqual([
-			{ row: 0, ansi: "aa", type: "row" },
-			{ row: 1, ansi: "bb", type: "row" },
+			{ row: 0, startCol: 0, ansi: "aa", type: "row" },
+			{ row: 1, startCol: 0, ansi: "bb", type: "row" },
 		]);
 	});
 
@@ -39,6 +68,6 @@ describe("frame diff", () => {
 		expect(patches[0]).toMatchObject({ type: "scroll", direction: "up", count: 1, top: 0, bottom: 4 });
 		expect(patches[0]?.ansi).toContain("\x1b[1;5r\x1b[1S\x1b[r");
 		expect(patches).toHaveLength(2);
-		expect(patches[1]).toEqual({ row: 4, ansi: "six", type: "row" });
+		expect(patches[1]).toEqual({ row: 4, startCol: 0, ansi: "six", type: "row" });
 	});
 });

--- a/src/sumo-tui/render/diff.ts
+++ b/src/sumo-tui/render/diff.ts
@@ -1,8 +1,25 @@
 import type { CellBuffer } from "./buffer.js";
-import { cellRowToAnsi } from "./ansi-writer.js";
+import type { Cell } from "./cell.js";
+import { cellRowToAnsi, cellRowSliceToAnsi } from "./ansi-writer.js";
 
 export interface FrameDiffPatch {
 	row: number;
+	/**
+	 * Column offset (0-indexed) where this patch starts on the row.
+	 *
+	 * - For full-row repaints (`type: "row"` with `startCol === 0`) and scroll
+	 *   patches the writer continues to emit `\x1b[K` after the ANSI to clear
+	 *   any trailing cells.
+	 * - For partial-row patches (`startCol > 0`) the writer emits ONLY the
+	 *   slice and skips the line-clear so unchanged cells to the left and
+	 *   right of the change region survive untouched.
+	 *
+	 * Borrowed from OpenTUI's per-row column-range diff (`zig/renderer.zig`
+	 * 1331-1349). Saves 50–90% of bytes per streaming tick on typical chat
+	 * updates because cursor blink + single-cell streaming changes no longer
+	 * trigger full-row repaints. See `docs/research/OPENTUI_COMPARISON.md` §A3.
+	 */
+	startCol: number;
 	ansi: string;
 	type: "row" | "scroll";
 	top?: number;
@@ -17,30 +34,68 @@ function dimensionsEqual(prev: CellBuffer, next: CellBuffer): boolean {
 	return left.rows === right.rows && left.cols === right.cols;
 }
 
-function rowsEqualAt(prev: CellBuffer, prevRow: number, next: CellBuffer, nextRow: number): boolean {
+function cellsDiffer(left: Cell, right: Cell): boolean {
+	if (left.char !== right.char || left.fg !== right.fg || left.bg !== right.bg) return true;
+	return (
+		left.attrs.bold !== right.attrs.bold ||
+		left.attrs.italic !== right.attrs.italic ||
+		left.attrs.underline !== right.attrs.underline ||
+		left.attrs.dim !== right.attrs.dim ||
+		left.attrs.inverse !== right.attrs.inverse
+	);
+}
+
+/**
+ * Find the leftmost and rightmost differing columns between two rows. Returns
+ * `null` when the rows are identical.
+ *
+ * Backs up `startCol` across wide-char continuation cells so the slice always
+ * begins at the head of a glyph (continuation cells have `char === ""` and
+ * `cellRowSliceToAnsi` would otherwise skip them, shifting the slice).
+ */
+function rowChangeRange(
+	prev: CellBuffer,
+	prevRow: number,
+	next: CellBuffer,
+	nextRow: number,
+): { startCol: number; endCol: number } | null {
 	const { cols } = prev.getDimensions();
+	let startCol = -1;
+	let endCol = -1;
 	for (let col = 0; col < cols; col += 1) {
-		const left = prev.getCell(prevRow, col);
-		const right = next.getCell(nextRow, col);
-		if (left.char !== right.char || left.fg !== right.fg || left.bg !== right.bg) return false;
-		if (
-			left.attrs.bold !== right.attrs.bold ||
-			left.attrs.italic !== right.attrs.italic ||
-			left.attrs.underline !== right.attrs.underline ||
-			left.attrs.dim !== right.attrs.dim ||
-			left.attrs.inverse !== right.attrs.inverse
-		) {
-			return false;
+		if (cellsDiffer(prev.getCell(prevRow, col), next.getCell(nextRow, col))) {
+			if (startCol === -1) startCol = col;
+			endCol = col;
 		}
 	}
-	return true;
+	if (startCol === -1) return null;
+	while (startCol > 0 && next.getCell(nextRow, startCol).char === "") startCol -= 1;
+	return { startCol, endCol };
+}
+
+function rowsEqualAt(prev: CellBuffer, prevRow: number, next: CellBuffer, nextRow: number): boolean {
+	return rowChangeRange(prev, prevRow, next, nextRow) === null;
 }
 
 function changedRowPatches(prev: CellBuffer, next: CellBuffer): FrameDiffPatch[] {
 	const { rows } = next.getDimensions();
 	const patches: FrameDiffPatch[] = [];
 	for (let row = 0; row < rows; row += 1) {
-		if (!rowsEqualAt(prev, row, next, row)) patches.push({ row, ansi: cellRowToAnsi(next, row), type: "row" });
+		const range = rowChangeRange(prev, row, next, row);
+		if (!range) continue;
+		if (range.startCol === 0) {
+			// Full-row repaint matches the legacy ansi-writer + clear-line contract.
+			patches.push({ row, startCol: 0, ansi: cellRowToAnsi(next, row), type: "row" });
+		} else {
+			// Partial-row patch: emit only the changed range. The terminal-controller
+			// skips `\x1b[K` for these so unchanged cells to the right are preserved.
+			patches.push({
+				row,
+				startCol: range.startCol,
+				ansi: cellRowSliceToAnsi(next, row, range.startCol, range.endCol),
+				type: "row",
+			});
+		}
 	}
 	return patches;
 }
@@ -65,9 +120,20 @@ function detectScroll(prev: CellBuffer, next: CellBuffer): FrameDiffPatch[] | nu
 		}
 		if (shiftedUp) {
 			const patches: FrameDiffPatch[] = [
-				{ row: 0, ansi: scrollSequence(0, rows - 1, count, "up"), type: "scroll", top: 0, bottom: rows - 1, count, direction: "up" },
+				{
+					row: 0,
+					startCol: 0,
+					ansi: scrollSequence(0, rows - 1, count, "up"),
+					type: "scroll",
+					top: 0,
+					bottom: rows - 1,
+					count,
+					direction: "up",
+				},
 			];
-			for (let row = rows - count; row < rows; row += 1) patches.push({ row, ansi: cellRowToAnsi(next, row), type: "row" });
+			for (let row = rows - count; row < rows; row += 1) {
+				patches.push({ row, startCol: 0, ansi: cellRowToAnsi(next, row), type: "row" });
+			}
 			return patches;
 		}
 
@@ -80,9 +146,20 @@ function detectScroll(prev: CellBuffer, next: CellBuffer): FrameDiffPatch[] | nu
 		}
 		if (shiftedDown) {
 			const patches: FrameDiffPatch[] = [
-				{ row: 0, ansi: scrollSequence(0, rows - 1, count, "down"), type: "scroll", top: 0, bottom: rows - 1, count, direction: "down" },
+				{
+					row: 0,
+					startCol: 0,
+					ansi: scrollSequence(0, rows - 1, count, "down"),
+					type: "scroll",
+					top: 0,
+					bottom: rows - 1,
+					count,
+					direction: "down",
+				},
 			];
-			for (let row = 0; row < count; row += 1) patches.push({ row, ansi: cellRowToAnsi(next, row), type: "row" });
+			for (let row = 0; row < count; row += 1) {
+				patches.push({ row, startCol: 0, ansi: cellRowToAnsi(next, row), type: "row" });
+			}
 			return patches;
 		}
 	}
@@ -97,12 +174,18 @@ function detectScroll(prev: CellBuffer, next: CellBuffer): FrameDiffPatch[] | nu
  * from opentui-island `src/core/frame-diff.ts:46-86`; sumo-tui adapts that
  * HostFrame/HostLine algorithm to CellBuffer rows and adds a small scroll
  * detector for shifted terminal regions.
+ *
+ * Per-row column-range patches are an additional borrow from
+ * `anomalyco/opentui` (`zig/renderer.zig` 1331-1349) — see
+ * `docs/research/OPENTUI_COMPARISON.md` §A3.
  */
 export function diffFrames(prev: CellBuffer | null | undefined, next: CellBuffer): FrameDiffPatch[] {
 	if (!prev || !dimensionsEqual(prev, next)) {
 		const { rows } = next.getDimensions();
 		const patches: FrameDiffPatch[] = [];
-		for (let row = 0; row < rows; row += 1) patches.push({ row, ansi: cellRowToAnsi(next, row), type: "row" });
+		for (let row = 0; row < rows; row += 1) {
+			patches.push({ row, startCol: 0, ansi: cellRowToAnsi(next, row), type: "row" });
+		}
 		return patches;
 	}
 

--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -150,7 +150,11 @@ describe("TerminalSessionOwner", () => {
 		expect(output.writes.length).toBe(1);
 	});
 
-	it("lazy frame-start: skips cursor reposition when only the patches change but cursor is unchanged", () => {
+	it("re-emits cursor after every patch frame even when the logical cursor is unchanged", () => {
+		// Correctness gate: the patch loop physically moves the terminal cursor
+		// to each patched row via `\x1b[r;cH`, so skipping the final cursor
+		// reposition would leave the caret parked at the end of the last patch.
+		// Cursor-write elision is only safe for true no-op frames.
 		const output = outputStub();
 		const terminal = new TerminalSessionOwner({ output });
 
@@ -159,9 +163,23 @@ describe("TerminalSessionOwner", () => {
 
 		terminal.writeFramePatches([{ row: 1, ansi: "world" }], { row: 2, col: 4 });
 
-		// Cursor sequence (`\x1b[3;5H\x1b[?25h`) should NOT appear in the second
-		// write because the cursor hasn't moved since the last emit.
-		expect(output.writes).toEqual(["\x1b[?2026h\x1b[2;1Hworld\x1b[K\x1b[?2026l"]);
+		// The cursor reposition (`\x1b[3;5H\x1b[?25h`) MUST appear even though
+		// the logical cursor didn't move, because the patch above moved the
+		// terminal cursor to row 2.
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b[2;1Hworld\x1b[K\x1b[3;5H\x1b[?25h\x1b[?2026l"]);
+	});
+
+	it("emits ONLY cursor reposition when patches=0 but cursor moved (no wrapper savings, but no patches either)", () => {
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+
+		// Seed lastEmittedCursor with the first call, then move cursor only.
+		terminal.writeFramePatches([], { row: 0, col: 0 });
+		output.writes.length = 0;
+
+		terminal.writeFramePatches([], { row: 5, col: 10 });
+
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b[6;11H\x1b[?25h\x1b[?2026l"]);
 	});
 
 	it("re-emits cursor after exitTerminal clears lastEmittedCursor", () => {

--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -116,6 +116,73 @@ describe("TerminalSessionOwner", () => {
 		expect(output.writes).toEqual(["\x1b[?2026h\x1b[2;1Hhello\x1b[K\x1b[3;5H\x1b[?25h\x1b[?2026l"]);
 	});
 
+	it("emits a partial-row patch without \\x1b[K when startCol > 0", () => {
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+
+		terminal.writeFramePatches([{ row: 1, startCol: 4, ansi: "DEF" }], null);
+
+		// Partial patches MUST skip clear-to-end-of-line so cells right of the
+		// change region survive untouched. Cursor position 5 (= startCol + 1).
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b[2;5HDEF\x1b[?2026l"]);
+		expect(output.writes[0]).not.toContain("\x1b[K");
+	});
+
+	it("lazy frame-start: emits zero bytes for a no-op tick (no patches, no cursor)", () => {
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+
+		terminal.writeFramePatches([], null);
+
+		expect(output.writes).toEqual([]);
+	});
+
+	it("lazy frame-start: emits zero bytes when the cursor lands on its last-emitted position", () => {
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+
+		// First call emits the cursor; cache lastEmittedCursor = (2, 4).
+		terminal.writeFramePatches([], { row: 2, col: 4 });
+		expect(output.writes.length).toBe(1);
+
+		// Second call with same cursor + no patches → no bytes.
+		terminal.writeFramePatches([], { row: 2, col: 4 });
+		expect(output.writes.length).toBe(1);
+	});
+
+	it("lazy frame-start: skips cursor reposition when only the patches change but cursor is unchanged", () => {
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+
+		terminal.writeFramePatches([{ row: 0, ansi: "hello" }], { row: 2, col: 4 });
+		output.writes.length = 0;
+
+		terminal.writeFramePatches([{ row: 1, ansi: "world" }], { row: 2, col: 4 });
+
+		// Cursor sequence (`\x1b[3;5H\x1b[?25h`) should NOT appear in the second
+		// write because the cursor hasn't moved since the last emit.
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b[2;1Hworld\x1b[K\x1b[?2026l"]);
+	});
+
+	it("re-emits cursor after exitTerminal clears lastEmittedCursor", () => {
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+
+		terminal.writeFramePatches([], { row: 2, col: 4 });
+		terminal.exitTerminal();
+		// After exit, lastEmittedCursor must be reset so re-entering altscreen
+		// re-emits cursor sequences.
+		output.writes.length = 0;
+
+		// Simulate fresh session re-entering: re-set isTTY by creating a new
+		// owner referencing the same output. (`exitTerminal` flips internal
+		// state; we just want to confirm a subsequent write emits cursor.)
+		const next = new TerminalSessionOwner({ output });
+		next.writeFramePatches([], { row: 2, col: 4 });
+
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b[3;5H\x1b[?25h\x1b[?2026l"]);
+	});
+
 	it("exitTerminal emits cleanup without cursor or bg reset when retained mode was never entered", () => {
 		const output = outputStub();
 		const terminal = new TerminalSessionOwner({ output });

--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -182,6 +182,32 @@ describe("TerminalSessionOwner", () => {
 		expect(output.writes).toEqual(["\x1b[?2026h\x1b[6;11H\x1b[?25h\x1b[?2026l"]);
 	});
 
+	it("invalidates the cursor cache when emitting patches with a null cursor (hardwareCursor=null path)", () => {
+		// Regression: the patch loop physically moves the terminal cursor when
+		// patches are emitted, even when no logical cursor is provided. Failing
+		// to invalidate `lastEmittedCursor` here would let the next frame (with
+		// a cursor matching the stale cache) early-return and leave the visible
+		// caret parked at the end of the last patch.
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+
+		// Frame A: seed the cache with cursor (5, 10).
+		terminal.writeFramePatches([{ row: 0, ansi: "a" }], { row: 5, col: 10 });
+
+		// Frame B: patches with null cursor. Patch loop moves the terminal
+		// cursor; logical cursor isn't tracked. Cache MUST be invalidated.
+		terminal.writeFramePatches([{ row: 1, ansi: "b" }], null);
+		output.writes.length = 0;
+
+		// Frame C: same logical cursor as frame A. With the bug, this would
+		// early-return because cursorMoved=false against the stale cache.
+		// With the fix, cache was nulled by frame B, so cursorMoved=true and
+		// we re-emit the cursor reposition.
+		terminal.writeFramePatches([], { row: 5, col: 10 });
+
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b[6;11H\x1b[?25h\x1b[?2026l"]);
+	});
+
 	it("re-emits cursor after exitTerminal clears lastEmittedCursor", () => {
 		const output = outputStub();
 		const terminal = new TerminalSessionOwner({ output });

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -218,7 +218,12 @@ export class TerminalSessionOwner {
 			// cells to the right of the change region.
 			if (startCol === 0) output += "\x1b[K";
 		}
-		if (cursor && cursorMoved) {
+		// Cursor-write elision is safe ONLY for true no-op frames. When
+		// `patches.length > 0`, every `\x1b[r;c+1H<ansi>` in the loop above
+		// physically moved the terminal cursor; skipping the reposition here
+		// would leave the visible caret parked at the end of the last patch
+		// instead of at `cursor`. Always re-emit when patches were written.
+		if (cursor && (patches.length > 0 || cursorMoved)) {
 			output += `\x1b[${cursor.row + 1};${cursor.col + 1}H\x1b[?25h`;
 			this.lastEmittedCursor = { row: cursor.row, col: cursor.col };
 		}

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -226,6 +226,14 @@ export class TerminalSessionOwner {
 		if (cursor && (patches.length > 0 || cursorMoved)) {
 			output += `\x1b[${cursor.row + 1};${cursor.col + 1}H\x1b[?25h`;
 			this.lastEmittedCursor = { row: cursor.row, col: cursor.col };
+		} else if (patches.length > 0) {
+			// Patches moved the terminal cursor without us emitting a known new
+			// position (compositor returned `hardwareCursor: null`). The cached
+			// `lastEmittedCursor` is now stale — the visible caret is at the end
+			// of the last patch, not at the cached coordinates. Invalidate so the
+			// NEXT frame with a non-null cursor re-emits its position even if it
+			// matches the stale cache.
+			this.lastEmittedCursor = null;
 		}
 		output += "\x1b[?2026l";
 		this.write(output);

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -49,6 +49,12 @@ export interface TerminalCursor {
 
 export interface TerminalPatch {
 	readonly row: number;
+	/**
+	 * Column offset (0-indexed) where this patch starts. Defaults to 0 for
+	 * full-row repaints. When > 0 the writer emits ONLY the slice and skips
+	 * the trailing `\x1b[K` so unchanged cells to the right are preserved.
+	 */
+	readonly startCol?: number;
 	readonly ansi: string;
 }
 
@@ -92,6 +98,16 @@ export class TerminalSessionOwner {
 	private backgroundPainted = false;
 	private cursorColorOverridden = false;
 	private lastCursorColor: string | undefined;
+	/**
+	 * Last cursor position we emitted to the terminal. Used to skip redundant
+	 * cursor-reposition writes when the frame doesn't move the cursor. Reset
+	 * on `exitTerminal` so a re-entered altscreen always re-emits.
+	 *
+	 * Borrowed from OpenTUI's renderer (`zig/renderer.zig` ~1180): a
+	 * "lastEmittedCursor" cache that pairs with the lazy frame-start to
+	 * suppress no-op ticks entirely.
+	 */
+	private lastEmittedCursor: TerminalCursor | null = null;
 
 	public constructor(options: TerminalSessionOwnerOptions = {}) {
 		this.output = options.output ?? process.stdout;
@@ -180,12 +196,32 @@ export class TerminalSessionOwner {
 	}
 
 	public writeFramePatches(patches: readonly TerminalPatch[], cursor: TerminalCursor | null): void {
-		if (!this.isTTY() || (patches.length === 0 && !cursor)) return;
+		if (!this.isTTY()) return;
+		// Lazy frame-start (OpenTUI port, see `lastEmittedCursor` comment): if no
+		// cells changed AND the cursor would land where it already is, emit zero
+		// bytes. Otherwise wrap the patches in `\x1b[?2026h … \x1b[?2026l` for a
+		// synchronized atomic frame.
+		const cursorMoved = cursor !== null && (
+			this.lastEmittedCursor === null ||
+			cursor.row !== this.lastEmittedCursor.row ||
+			cursor.col !== this.lastEmittedCursor.col
+		);
+		if (patches.length === 0 && !cursorMoved) return;
+
 		let output = "\x1b[?2026h";
 		for (const patch of patches) {
-			output += `\x1b[${patch.row + 1};1H${patch.ansi}\x1b[K`;
+			const startCol = patch.startCol ?? 0;
+			output += `\x1b[${patch.row + 1};${startCol + 1}H${patch.ansi}`;
+			// Only full-row patches benefit from `\x1b[K` (clear-to-end-of-line):
+			// they overwrite every cell on the row anyway. Partial-row patches
+			// (`startCol > 0`) MUST NOT emit `\x1b[K` or they would wipe correct
+			// cells to the right of the change region.
+			if (startCol === 0) output += "\x1b[K";
 		}
-		if (cursor) output += `\x1b[${cursor.row + 1};${cursor.col + 1}H\x1b[?25h`;
+		if (cursor && cursorMoved) {
+			output += `\x1b[${cursor.row + 1};${cursor.col + 1}H\x1b[?25h`;
+			this.lastEmittedCursor = { row: cursor.row, col: cursor.col };
+		}
 		output += "\x1b[?2026l";
 		this.write(output);
 	}
@@ -205,6 +241,7 @@ export class TerminalSessionOwner {
 		this.backgroundPainted = false;
 		this.cursorColorOverridden = false;
 		this.lastCursorColor = undefined;
+		this.lastEmittedCursor = null;
 		if (!this.isTTY()) return;
 		let output = "";
 		if (shouldResetCursorColor) output += CURSOR_COLOR_RESET;


### PR DESCRIPTION
## Summary

Ports two related ANSI-byte optimizations from OpenTUI's renderer (`anomalyco/opentui` `zig/renderer.zig` 1247-1393, 1304-1307, 1331-1349). See `docs/research/OPENTUI_COMPARISON.md` §A1 + §A3 + §D.

Closes #172.

## Perf benchmark

Real measurements via `node scripts/bench-diff-bytes.mjs` (committed in this PR for reproducibility, runs from any checkout). Compares OLD path (always full-row repaint + always emit `\x1b[?2026h` wrapper + always re-emit cursor) against the NEW path (column-range diff + lazy frame-start + `lastEmittedCursor` cache) on the same input frames.

| Scenario | Old | New | Reduction |
|---|---:|---:|---:|
| Cursor blink, single cell in 200-col row | **240B** | **39B** | **−83.8%** |
| Streaming append 1 char at end of 200-col row | **238B** | **37B** | **−84.5%** |
| Streaming append 10 chars | **238B** | **45B** | **−81.1%** |
| Idle tick (no change, cursor unchanged) | **29B** | **0B** | **−100%** |
| 10 idle ticks (same cursor) | **290B** | **29B** | **−90.0%** |
| Cursor moves 1 col (no patches) | 29B | 29B | 0% (genuine move, no save possible) |
| Full-row change in 40×200 frame | 239B | 239B | 0% (cursor cache doesn't apply when patches exist) |
| Streaming chunk: 5 mid-row chars + cursor move | **240B** | **44B** | **−81.7%** |

The wins concentrate exactly where they matter:
- **Cursor blink** (terminal repaints once a second by default): −84%.
- **Streaming chunks** (every assistant token): −81% to −85%.
- **Idle frames** (most ticks during a long-running session): −100% per tick after the first.

The "cursor moves 1 col" row stays flat at 29B because the cursor genuinely moved and nothing else changed — that's the lower bound for an actual cursor reposition. Full-row changes show 0% reduction because patches are emitted (cursor cache doesn't apply, by design — see "Cursor reposition correctness" below).

## Implementation

### Diff layer (`src/sumo-tui/render/diff.ts`)

- `FrameDiffPatch` widened with `startCol: number`. Full-row patches (and scroll patches) keep `startCol: 0`; partial patches set the column where the change begins.
- New `rowChangeRange()` finds leftmost + rightmost differing cells. Backs up over wide-char continuation cells so the slice always begins at the head of a glyph.
- `changedRowPatches()` emits a column-range patch when the change starts past column 0; otherwise falls back to full-row repaint (legacy behaviour, safe with `\x1b[K`).
- `cellRowToAnsi()` now thin-wraps `cellRowSliceToAnsi()`.

### Writer (`src/sumo-tui/render/ansi-writer.ts`)

- New exported `cellRowSliceToAnsi(buffer, row, startCol, endCol)` emits SGR-coalesced ANSI for a column slice.

### Terminal controller (`src/sumo-tui/runtime/terminal-controller.ts`)

- `writeFramePatches()` lazy frame-start: when there are no patches AND the cursor would land on its last-emitted position, emit zero bytes (no `\x1b[?2026h` wrapper, no cursor reposition).
- `lastEmittedCursor` cache field tracks the last cursor position so redundant repositions are suppressed when there are also no patches.
- Partial patches (`startCol > 0`) skip the trailing `\x1b[K` so cells right of the change region survive untouched.
- `exitTerminal()` resets `lastEmittedCursor = null` so re-entering altscreen always re-emits cursor.
- `TerminalPatch.startCol` is optional (defaults to 0) so existing callers don't need to change.

### Cursor reposition correctness

Cursor-write elision is **only safe when `patches.length === 0`**. When patches are emitted, every `\x1b[r;c+1H<ansi>` in the loop physically moves the terminal cursor. Skipping the final cursor reposition would leave the visible caret parked at the end of the last patch instead of at the intended cursor position. The implementation always re-emits the cursor sequence when patches were written. (Surfaced as a P1 review comment from `chatgpt-codex-connector`; addressed in commit `66b6023`.)

## Tests

- `src/sumo-tui/render/diff.test.ts` — added 3 new column-range cases (right-side change, single mid-row cell, change-starts-at-col-0 fallback) plus updated existing tests for the new `startCol` field.
- `src/sumo-tui/runtime/terminal-controller.test.ts` — added 6 new cases:
  - partial-row patch skips `\x1b[K`
  - no-op tick emits 0 bytes
  - cursor-unchanged emits 0 bytes when patches empty
  - cursor reposition always re-emitted when patches exist (correctness gate)
  - cursor-only emit for patches=0 + cursor moved
  - fresh session re-emits cursor after exitTerminal

## Verification

- `pnpm test`: 552/552 ✅
- `pnpm test:integration`: 18/18 ✅
- `pnpm exec tsc --noEmit`: clean ✅

## Conflict notes

Touches `terminal-controller.ts` (new `writeFramePatches` body, new field). PR #165 also touches this file but in a different region (`MOUSE_SGR_ENABLE_SEQUENCE` constant), so a merge is mechanical. PR #170 reads `patches.length` from the new `writeFramePatches` contract via `sumo-interactive-mode.ts` `logDiagnostic("render_patches", { patchCount })` — that contract is preserved (patches array is still the input).

## Independence from other open PRs

Can land independently of #165, #167, #168, #169, #170, #175. None of them touch the diff layer or the `writeFramePatches` body. Order doesn't matter — light merge resolution if any.

Closes #172.
