### PR TITLE
feat(memory): Scriptorium chrome + nav + filter + d-forget (#138)

### DIFF
--- a/docs/visual/parity/scenarios.json
+++ b/docs/visual/parity/scenarios.json
@@ -776,6 +776,32 @@
 			]
 		},
 		{
+			"id": "fixture-memory-scriptorium-overlay",
+			"lane": "fixture",
+			"status": "review",
+			"dimensions": {
+				"cols": 160,
+				"rows": 45
+			},
+			"bibleTarget": "scene-memory-scriptorium-overlay.png",
+			"fixture": {
+				"id": "completed-active",
+				"overlay": "memory-scriptorium"
+			},
+			"crops": [
+				{
+					"id": "full",
+					"targetCrop": "full",
+					"runtimeCrop": "full"
+				},
+				{
+					"id": "overlay-center",
+					"targetCrop": "overlay-center",
+					"runtimeCrop": "overlay-center"
+				}
+			]
+		},
+		{
 			"id": "fixture-scroll-scribe-landscape",
 			"lane": "fixture",
 			"status": "review",

--- a/scripts/visual-v2/fixture-capture.mjs
+++ b/scripts/visual-v2/fixture-capture.mjs
@@ -309,6 +309,7 @@ async function renderFixtureScene(scenario, fixture) {
 
 async function applyOverlay(lines, cols, rows, overlay) {
 	if (overlay === "divine-query") return applyDivineQueryOverlay(lines, cols, rows);
+	if (overlay === "memory-scriptorium") return applyMemoryScriptoriumOverlay(lines, cols, rows);
 	if (overlay !== "command-palette") throw new Error(`Unsupported fixture overlay: ${overlay}`);
 	const palette = await jiti.import(`${repoRoot}/src/command-palette.ts`);
 
@@ -332,6 +333,50 @@ async function applyOverlay(lines, cols, rows, overlay) {
 		// preserving the left margin and right remnant.
 		const existingLine = next[top + index] ?? "";
 		const rightStart = left + paletteWidth;
+		const leftRemnant = padAnsiToWidth(sliceByColumn(existingLine, 0, left, true), left);
+		const rightRemnant = rightStart < cols ? sliceByColumn(existingLine, rightStart, cols - rightStart, true) : "";
+		next[top + index] = padAnsiToWidth(`${leftRemnant}${overlayLine}${rightRemnant}`, cols);
+	}
+	return next;
+}
+
+async function applyMemoryScriptoriumOverlay(lines, cols, rows) {
+	const memoryEditor = await jiti.import(`${repoRoot}/src/memory-editor.ts`);
+	const memoryCategorization = await jiti.import(`${repoRoot}/src/memory-categorization.ts`);
+
+	// Bible-aligned fact set spanning all six panels with PREFERENCES focused
+	// to exercise the ❈ marker.
+	const facts = [
+		{ id: "fact-1", text: "Dhruv · Senior FE · Argent" },
+		{ id: "fact-2", text: "London / BST" },
+		{ id: "fact-3", text: "prefers TypeScript strict" },
+		{ id: "fact-4", text: "pnpm not npm" },
+		{ id: "fact-5", text: "TDD by default" },
+		{ id: "fact-6", text: "visual approval before done" },
+		{ id: "fact-7", text: "sumocode/cathedral parity" },
+		{ id: "fact-8", text: "openclaw ACPX integration" },
+		{ id: "fact-9", text: "cmux runtime, libghostty" },
+		{ id: "fact-10", text: "mac mini portrait" },
+		{ id: "fact-11", text: "macbook landscape" },
+		{ id: "fact-12", text: "ask open-ended questions" },
+		{ id: "fact-13", text: "commit hash must be verified" },
+	];
+	const groups = memoryCategorization.groupFactsByPanel(facts);
+	const overlayWidth = Math.max(70, Math.min(120, Math.floor(cols * 0.8)));
+	const overlayLines = memoryEditor.renderMemoryEditor({
+		searchQuery: "",
+		groups,
+		factsTotal: facts.length,
+		focusedFactId: "fact-3",
+	}, overlayWidth);
+
+	const left = Math.max(0, Math.floor((cols - overlayWidth) / 2));
+	const top = Math.max(0, Math.floor((rows - overlayLines.length) / 2));
+	const next = [...lines];
+	for (let index = 0; index < overlayLines.length && top + index < rows; index += 1) {
+		const overlayLine = padAnsiToWidth(overlayLines[index] ?? "", overlayWidth);
+		const existingLine = next[top + index] ?? "";
+		const rightStart = left + overlayWidth;
 		const leftRemnant = padAnsiToWidth(sliceByColumn(existingLine, 0, left, true), left);
 		const rightRemnant = rightStart < cols ? sliceByColumn(existingLine, rightStart, cols - rightStart, true) : "";
 		next[top + index] = padAnsiToWidth(`${leftRemnant}${overlayLine}${rightRemnant}`, cols);

--- a/src/memory-editor.test.ts
+++ b/src/memory-editor.test.ts
@@ -8,12 +8,14 @@ import {
 import type { MemoryFact } from "./memory.js";
 import { groupFactsByPanel } from "./memory-categorization.js";
 
-const ANSI = /\u001b\[[0-9;]*m/g;
+const ANSI = /\[[0-9;]*m/g;
 const stripAnsi = (s: string): string => s.replace(ANSI, "");
 
+let factCounter = 0;
 function fact(overrides: Partial<MemoryFact> = {}): MemoryFact {
+	factCounter += 1;
 	return {
-		id: `fact-${Math.random().toString(36).slice(2)}`,
+		id: `fact-${factCounter}`,
 		text: "default fact text",
 		...overrides,
 	};
@@ -27,52 +29,72 @@ function snapshot(overrides: Partial<MemoryEditorSnapshot> = {}): MemoryEditorSn
 		fact({ text: "SumoCode is the cathedral product" }),    // PROJECTS
 		fact({ text: "mac mini in portrait orientation" }),     // SYSTEM
 	];
+	const groups = groupFactsByPanel(facts);
 	return {
 		searchQuery: "",
-		groups: groupFactsByPanel(facts),
+		groups,
 		factsTotal: facts.length,
+		focusedFactId: null,
 		...overrides,
 	};
 }
 
-describe("renderMemoryEditor — title + dividers", () => {
-	it("renders SUMOCODE MEMORY title centered", () => {
-		const lines = renderMemoryEditor(snapshot(), 100).map(stripAnsi);
-		const titleLine = lines.find((l) => l.includes("SUMOCODE MEMORY"));
-		expect(titleLine).toBeDefined();
-	});
-
-	it("renders title in accent color", () => {
+describe("renderMemoryEditor — Scriptorium chrome", () => {
+	it("renders ✾ MEMORY SCRIPTORIUM ✾ title in accent", () => {
 		const lines = renderMemoryEditor(snapshot(), 100);
-		const titleLine = lines.find((l) => l.includes("SUMOCODE MEMORY"));
+		const titleLine = lines.find((l) => stripAnsi(l).includes("MEMORY SCRIPTORIUM"));
+		expect(titleLine).toBeDefined();
 		// accent #D97706 -> 217;119;6
-		expect(titleLine).toContain("\u001b[38;2;217;119;6m");
+		expect(titleLine).toContain("[38;2;217;119;6m");
+		expect(stripAnsi(titleLine!)).toContain("✾  MEMORY SCRIPTORIUM  ✾");
 	});
 
-	it("renders divider rules above and below content", () => {
+	it("renders top + bottom decorative split rules with center dot", () => {
 		const lines = renderMemoryEditor(snapshot(), 100).map(stripAnsi);
-		const dividers = lines.filter((l) => l.includes("─".repeat(20)));
-		expect(dividers.length).toBeGreaterThanOrEqual(2);
+		const ruleLines = lines.filter((l) => l.includes("·") && l.includes("─".repeat(8)));
+		expect(ruleLines.length).toBeGreaterThanOrEqual(2);
 	});
-});
 
-describe("renderMemoryEditor — search row", () => {
-	it("shows dim 'search…' placeholder when searchQuery is empty", () => {
-		const lines = renderMemoryEditor(snapshot({ searchQuery: "" }), 100).map(stripAnsi);
-		const searchLine = lines.find((l) => l.includes("search"));
+	it("paints surfaceLifted background on every row", () => {
+		const lines = renderMemoryEditor(snapshot(), 100);
+		// surfaceLifted #3D3024 -> 61;48;36
+		for (const line of lines) {
+			expect(line).toContain("[48;2;61;48;36m");
+		}
+	});
+
+	it("pads every row to the requested width", () => {
+		const lines = renderMemoryEditor(snapshot(), 100);
+		for (const line of lines) {
+			expect(stripAnsi(line).length).toBe(100);
+		}
+	});
+
+	it("renders ❯ search prompt in accent followed by dim placeholder when empty", () => {
+		const lines = renderMemoryEditor(snapshot({ searchQuery: "" }), 100);
+		const searchLine = lines.find((l) => stripAnsi(l).includes("search remembered facts"));
 		expect(searchLine).toBeDefined();
+		// accent prompt + dim placeholder
+		expect(searchLine).toContain("[38;2;217;119;6m❯");
+		expect(searchLine).toContain("[38;2;139;122;99m"); // foregroundDim
 	});
 
 	it("shows the actual query when searchQuery is non-empty", () => {
 		const lines = renderMemoryEditor(snapshot({ searchQuery: "typescript" }), 100).map(stripAnsi);
-		const searchLine = lines.find((l) => l.includes("typescript"));
-		expect(searchLine).toBeDefined();
+		expect(lines.some((l) => l.includes("typescript"))).toBe(true);
 	});
 
 	it("shows the facts total count on the right side of the search row", () => {
 		const lines = renderMemoryEditor(snapshot(), 100).map(stripAnsi);
 		const searchLine = lines.find((l) => l.includes("5 facts"));
 		expect(searchLine).toBeDefined();
+	});
+
+	it("renders the V2 footer hint copy in foregroundDim", () => {
+		const lines = renderMemoryEditor(snapshot(), 100);
+		const footerLine = lines.find((l) => stripAnsi(l).includes(MEMORY_EDITOR_HINTS));
+		expect(footerLine).toBeDefined();
+		expect(footerLine).toContain("[38;2;139;122;99m"); // dim
 	});
 });
 
@@ -95,28 +117,66 @@ describe("renderMemoryEditor — panel grid", () => {
 
 	it("shows GENERAL panel when there are unrouted facts", () => {
 		const facts = [fact({ text: "the sky is blue" })];
+		const groups = groupFactsByPanel(facts);
 		const snap: MemoryEditorSnapshot = {
 			searchQuery: "",
-			groups: groupFactsByPanel(facts),
+			groups,
 			factsTotal: 1,
+			focusedFactId: facts[0]!.id,
 		};
 		const lines = renderMemoryEditor(snap, 160).map(stripAnsi);
-		const text = lines.join("\n");
-		expect(text).toContain(" GENERAL ");
+		expect(lines.join("\n")).toContain(" GENERAL ");
 	});
 
-	it("renders each fact with ❧ bullet", () => {
-		const lines = renderMemoryEditor(snapshot(), 160).map(stripAnsi);
-		const text = lines.join("\n");
-		expect(text).toContain("❧");
+	it("uses ❈ accent marker on the focused fact and · divider marker on the rest", () => {
+		const focusedSnapshot = snapshot();
+		const focusedFact = focusedSnapshot.groups.find((g) => g.panel === "IDENTITY")!.facts[0]!;
+		const lines = renderMemoryEditor({ ...focusedSnapshot, focusedFactId: focusedFact.id }, 160);
+		const focusedRow = lines.find((l) => stripAnsi(l).includes("Dhruv"))!;
+		// ❈ in accent
+		expect(focusedRow).toContain("[38;2;217;119;6m❈");
+		// Other facts use `·` in divider
+		const otherRow = lines.find((l) => stripAnsi(l).includes("prefers TypeScript"))!;
+		expect(otherRow).toContain("[38;2;90;77;60m·");
+	});
+
+	it("renders panel borders in divider color and panel titles in accent", () => {
+		const lines = renderMemoryEditor(snapshot(), 160);
+		const identityHeader = lines.find((l) => stripAnsi(l).includes(" IDENTITY "))!;
+		// divider for the dashes
+		expect(identityHeader).toContain("[38;2;90;77;60m");
+		// accent for the label
+		expect(identityHeader).toContain("[38;2;217;119;6m IDENTITY ");
 	});
 });
 
-describe("renderMemoryEditor — footer hints", () => {
-	it("includes navigate/search/copy/close hints", () => {
-		const lines = renderMemoryEditor(snapshot(), 160).map(stripAnsi);
+describe("renderMemoryEditor — search filter", () => {
+	it("filters fact rows when searchQuery is non-empty", () => {
+		const lines = renderMemoryEditor(snapshot({ searchQuery: "typescript" }), 160).map(stripAnsi);
 		const text = lines.join("\n");
-		expect(text).toContain(MEMORY_EDITOR_HINTS);
+		expect(text).toContain("prefers TypeScript strict");
+		expect(text).not.toContain("Dhruv works at Argent");
+	});
+
+	it("renders empty panels with `(empty)` placeholder when filter has no matches in that panel", () => {
+		const lines = renderMemoryEditor(snapshot({ searchQuery: "typescript" }), 160).map(stripAnsi);
+		expect(lines.join("\n")).toContain("(empty)");
+	});
+
+	it("returns no fact rows when the query matches nothing", () => {
+		const lines = renderMemoryEditor(snapshot({ searchQuery: "zzzz-no-match-zzzz" }), 160).map(stripAnsi);
+		const text = lines.join("\n");
+		expect(text).not.toContain("Dhruv");
+		expect(text).not.toContain("TypeScript");
+		// Empty placeholders still appear
+		expect(text).toContain("(empty)");
+	});
+});
+
+describe("renderMemoryEditor — width safety", () => {
+	it("returns empty array at width < 20 (frame would not fit)", () => {
+		expect(renderMemoryEditor(snapshot(), 10)).toEqual([]);
+		expect(renderMemoryEditor(snapshot(), 19)).toEqual([]);
 	});
 });
 
@@ -141,8 +201,9 @@ describe("registerMemoryCommand", () => {
 		const notify = vi.fn();
 		await handler!("", { ui: { custom, notify } });
 
-		// Without a remnic daemon, browse() will fail and we'll notify "memory unavailable"
-		// rather than open the modal. Either way, the command is reachable.
+		// Without a remnic daemon, browse() will fail and we'll notify "memory
+		// unavailable" rather than open the modal. Either way, the command is
+		// reachable.
 		expect(custom.mock.calls.length + notify.mock.calls.length).toBeGreaterThan(0);
 	});
 });

--- a/src/memory-editor.ts
+++ b/src/memory-editor.ts
@@ -1,21 +1,32 @@
 /**
- * Cathedral memory editor (Element 7 from CATHEDRAL_DECISIONS.md).
+ * Cathedral Memory Scriptorium (Element 7 from CATHEDRAL_UX_SPEC_V2.md).
  *
- * Read-only modal that browses the user's Remnic memory and groups facts
- * into 6 cathedral panels (IDENTITY / PREFERENCES / WORKFLOW / PROJECTS /
- * SYSTEM / GENERAL hidden if empty).
+ * Replaces Pi's default memory listing with a Scriptorium-themed overlay
+ * that groups facts into 6 cathedral panels (IDENTITY · PREFERENCES ·
+ * WORKFLOW · PROJECTS · SYSTEM · GENERAL — GENERAL hidden when empty).
  *
- * Triggered via `/sumo:memory edit`.
+ * Triggered via `/sumo:memory` or `/sumo:memory edit`.
  *
- * Uses the same flat-hybrid modal style as the approval modal and command
- * palette (Elements 6, 8): title + dividers above/below + footer hints,
- * no double-line border.
+ * Visual contract (matches `docs/ui/bible/07-memory-editor.html`):
+ *
+ *                         ✾  MEMORY SCRIPTORIUM  ✾
+ *
+ *            ──────────────────────────────  ·  ──────────────────────────────
+ *
+ *   ❯  █search remembered facts…                                      48 facts
+ *
+ *   ╭───────── IDENTITY ─────────╮  ╭──────── PREFERENCES ────────╮
+ *   │ · Dhruv · Senior FE · Argent│  │ ❈ prefers TypeScript strict │
+ *   │ · London / BST              │  │ · pnpm not npm              │
+ *   ╰─────────────────────────────╯  ╰─────────────────────────────╯
+ *   …
+ *            ──────────────────────────────  ·  ──────────────────────────────
+ *                 ↑↓ wander    /  search    e  revise    d  forget    ⎋ retreat
  */
 
 import type { Component, KeybindingsManager, OverlayHandle, TUI } from "@mariozechner/pi-tui";
 import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
 import { matchesKey } from "@mariozechner/pi-tui";
-import { colorHex } from "./footer.js";
 import {
 	createRemnicMemoryClient,
 	MemoryClientError,
@@ -30,131 +41,256 @@ import {
 } from "./memory-categorization.js";
 import { CATHEDRAL_TOKENS } from "./tokens.js";
 
-const RESET = "\u001b[0m";
-const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
-const DIM = "\u001b[2m";
+const RESET = "[0m";
+const ANSI_PATTERN = /\[[0-9;]*m/g;
+
+const TITLE_MARK = "✾";
+const FOCUSED_MARK = "❈";
+const UNFOCUSED_MARK = "·";
+const SEARCH_PROMPT = "❯";
+
+const TOP_LEFT = "╭";
+const TOP_RIGHT = "╮";
+const BOTTOM_LEFT = "╰";
+const BOTTOM_RIGHT = "╯";
+const HORIZONTAL = "─";
+const VERTICAL = "│";
+
+// ── Style helpers ─────────────────────────────────────────────
 
 function visibleLength(text: string): number {
 	return text.replace(ANSI_PATTERN, "").length;
+}
+
+function fg(text: string, hex: string): string {
+	const h = hex.replace("#", "");
+	const r = parseInt(h.slice(0, 2), 16);
+	const g = parseInt(h.slice(2, 4), 16);
+	const b = parseInt(h.slice(4, 6), 16);
+	return `[38;2;${r};${g};${b}m${text}${RESET}`;
+}
+
+/**
+ * Wrap a line in surfaceLifted bg + Cathedral foreground, restoring both
+ * after every internal RESET so nested ANSI doesn't fall through to terminal
+ * default colors. Mirrors the helper in `divine-query.ts`.
+ */
+function persistentBg(text: string, fgHex: string, bgHex: string): string {
+	const fh = fgHex.replace("#", "");
+	const bh = bgHex.replace("#", "");
+	const fr = parseInt(fh.slice(0, 2), 16);
+	const fgCode = parseInt(fh.slice(2, 4), 16);
+	const fb = parseInt(fh.slice(4, 6), 16);
+	const br = parseInt(bh.slice(0, 2), 16);
+	const bg = parseInt(bh.slice(2, 4), 16);
+	const bb = parseInt(bh.slice(4, 6), 16);
+	const styleCode = `[38;2;${fr};${fgCode};${fb}m[48;2;${br};${bg};${bb}m`;
+	return `${styleCode}${text.replace(/\[0m/g, `${RESET}${styleCode}`)}${RESET}`;
 }
 
 function center(line: string, width: number): string {
 	const len = visibleLength(line);
 	if (len >= width) return line;
 	const pad = Math.floor((width - len) / 2);
-	return `${" ".repeat(pad)}${line}`;
+	return `${" ".repeat(pad)}${line}${" ".repeat(width - len - pad)}`;
 }
 
-function padToWidth(line: string, width: number): string {
+function padRight(line: string, width: number): string {
 	const len = visibleLength(line);
 	if (len >= width) return line;
 	return `${line}${" ".repeat(width - len)}`;
 }
 
-function divider(width: number): string {
-	return colorHex("─".repeat(Math.max(0, width - 6)), CATHEDRAL_TOKENS.colors.divider);
+function splitRule(width: number): string {
+	const ruleLen = Math.max(1, Math.floor((width - 6) / 2 - 12));
+	const left = fg(HORIZONTAL.repeat(ruleLen), CATHEDRAL_TOKENS.colors.divider);
+	const dot = fg("·", CATHEDRAL_TOKENS.colors.divider);
+	const right = fg(HORIZONTAL.repeat(ruleLen), CATHEDRAL_TOKENS.colors.divider);
+	return center(`${left}  ${dot}  ${right}`, width);
 }
 
-export type MemoryEditorSnapshot = {
-	searchQuery: string;
-	groups: readonly PanelGroup[];
-	factsTotal: number;
-};
+// ── Snapshot ──────────────────────────────────────────────────
 
-export const MEMORY_EDITOR_HINTS = "↑↓ navigate    /  search    ⏎  copy id    esc  close";
+export interface MemoryEditorSnapshot {
+	readonly searchQuery: string;
+	readonly groups: readonly PanelGroup[];
+	readonly factsTotal: number;
+	/** ID of the fact currently highlighted with `❈`. `null` = no focus. */
+	readonly focusedFactId: string | null;
+}
 
 /**
- * Render a single panel sub-card with `╭─ NAME ─...╮` border.
+ * V2 footer hint copy from the Bible. Includes the `e` (revise) and `d`
+ * (forget) keybinds used by `MemoryEditorComponent.handleInput`.
  */
-function renderPanel(group: PanelGroup, width: number): string[] {
-	const innerWidth = Math.max(20, width - 4); // 2 chars border each side
-	const labelInner = ` ${group.panel} `;
-	const dashes = Math.max(2, innerWidth - labelInner.length - 1);
-	const top = `╭─${labelInner}${"─".repeat(dashes)}╮`;
-	const bottom = `╰${"─".repeat(innerWidth - 2)}╯`;
+export const MEMORY_EDITOR_HINTS = "↑↓ wander    /  search    e  revise    d  forget    ⎋ retreat";
 
-	const lines: string[] = [];
-	lines.push(colorHex(top, CATHEDRAL_TOKENS.colors.divider).replace(
-		labelInner,
-		colorHex(labelInner, CATHEDRAL_TOKENS.colors.accent),
-	));
+// ── Search filter ─────────────────────────────────────────────
+
+function filterGroups(groups: readonly PanelGroup[], query: string): PanelGroup[] {
+	const trimmed = query.trim().toLowerCase();
+	if (trimmed.length === 0) return groups.map((g) => ({ ...g, facts: [...g.facts] }));
+	return groups.map((group) => ({
+		panel: group.panel,
+		facts: group.facts.filter((fact) => fact.text.toLowerCase().includes(trimmed)),
+	}));
+}
+
+/** Flatten visible facts into a single ordered list — used for navigation. */
+function visibleFactOrder(groups: readonly PanelGroup[]): MemoryFact[] {
+	const order: MemoryFact[] = [];
+	for (const group of groups) for (const fact of group.facts) order.push(fact);
+	return order;
+}
+
+function nextFocusId(groups: readonly PanelGroup[], current: string | null, direction: 1 | -1): string | null {
+	const order = visibleFactOrder(groups);
+	if (order.length === 0) return null;
+	const currentIndex = current !== null ? order.findIndex((fact) => fact.id === current) : -1;
+	const nextIndex = currentIndex < 0
+		? (direction === 1 ? 0 : order.length - 1)
+		: (currentIndex + direction + order.length) % order.length;
+	return order[nextIndex]?.id ?? null;
+}
+
+// ── Pure render ──────────────────────────────────────────────
+
+/**
+ * Render one panel's `╭─ NAME ─╮ │ … │ ╰─╯` sub-card at `panelWidth` cells.
+ * Returns lines whose visible width is exactly `panelWidth`.
+ */
+function renderPanel(group: PanelGroup, panelWidth: number, focusedFactId: string | null): string[] {
+	const innerWidth = Math.max(20, panelWidth);
+	const labelInner = ` ${group.panel} `;
+	const labelLen = labelInner.length;
+	const dashesTotal = Math.max(2, innerWidth - 2 - labelLen);
+	const leftDashes = Math.max(1, Math.floor(dashesTotal / 2));
+	const rightDashes = Math.max(1, dashesTotal - leftDashes);
+
+	const top = `${fg(`${TOP_LEFT}${HORIZONTAL.repeat(leftDashes)}`, CATHEDRAL_TOKENS.colors.divider)}${fg(labelInner, CATHEDRAL_TOKENS.colors.accent)}${fg(`${HORIZONTAL.repeat(rightDashes)}${TOP_RIGHT}`, CATHEDRAL_TOKENS.colors.divider)}`;
+	const bottom = fg(`${BOTTOM_LEFT}${HORIZONTAL.repeat(innerWidth - 2)}${BOTTOM_RIGHT}`, CATHEDRAL_TOKENS.colors.divider);
+
+	const lines: string[] = [top];
 
 	if (group.facts.length === 0) {
-		const empty = ` ${colorHex("(empty)", CATHEDRAL_TOKENS.colors.foregroundDim)} `;
-		lines.push(`${colorHex("│", CATHEDRAL_TOKENS.colors.divider)}${padToWidth(empty, innerWidth - 2)}${colorHex("│", CATHEDRAL_TOKENS.colors.divider)}`);
+		const empty = ` ${fg("(empty)", CATHEDRAL_TOKENS.colors.foregroundDim)}`;
+		const bordered = `${fg(VERTICAL, CATHEDRAL_TOKENS.colors.divider)}${padRight(empty, innerWidth - 2)}${fg(VERTICAL, CATHEDRAL_TOKENS.colors.divider)}`;
+		lines.push(bordered);
 	} else {
 		for (const fact of group.facts) {
-			const bullet = colorHex("❧", CATHEDRAL_TOKENS.colors.accent);
-			const text = colorHex(
-				fact.text.length > innerWidth - 6 ? `${fact.text.slice(0, innerWidth - 7)}…` : fact.text,
-				CATHEDRAL_TOKENS.colors.foreground,
-			);
-			const content = ` ${bullet} ${text}`;
-			lines.push(`${colorHex("│", CATHEDRAL_TOKENS.colors.divider)}${padToWidth(content, innerWidth - 2)}${colorHex("│", CATHEDRAL_TOKENS.colors.divider)}`);
+			const focused = fact.id === focusedFactId;
+			const mark = focused
+				? fg(FOCUSED_MARK, CATHEDRAL_TOKENS.colors.accent)
+				: fg(UNFOCUSED_MARK, CATHEDRAL_TOKENS.colors.divider);
+			// 4 cols of chrome inside the frame: ` <mark> <space> ` + trailing ` `.
+			const textWidth = Math.max(1, innerWidth - 6);
+			const truncated = fact.text.length > textWidth
+				? `${fact.text.slice(0, Math.max(0, textWidth - 1))}…`
+				: fact.text;
+			const text = fg(truncated, CATHEDRAL_TOKENS.colors.foreground);
+			const content = ` ${mark} ${text}`;
+			const bordered = `${fg(VERTICAL, CATHEDRAL_TOKENS.colors.divider)}${padRight(content, innerWidth - 2)}${fg(VERTICAL, CATHEDRAL_TOKENS.colors.divider)}`;
+			lines.push(bordered);
 		}
 	}
 
-	lines.push(colorHex(bottom, CATHEDRAL_TOKENS.colors.divider));
+	lines.push(bottom);
 	return lines;
 }
 
-/**
- * Pure render of the modal. Returns content lines (the overlay frame /
- * compositing is handled by Pi).
- */
 export function renderMemoryEditor(snapshot: MemoryEditorSnapshot, width: number): string[] {
+	if (width < 20) return [];
 	const lines: string[] = [];
 
-	// Title
-	lines.push("");
-	lines.push(center(colorHex("SUMOCODE MEMORY", CATHEDRAL_TOKENS.colors.accent), width));
-	lines.push(divider(width));
+	// Blank
 	lines.push("");
 
-	// Search input row
-	const searchPrompt = colorHex("│ ", CATHEDRAL_TOKENS.colors.divider);
-	const searchPlaceholder = snapshot.searchQuery === ""
-		? `${DIM}${colorHex("search…", CATHEDRAL_TOKENS.colors.foregroundDim)}${RESET}`
-		: colorHex(snapshot.searchQuery, CATHEDRAL_TOKENS.colors.foreground);
-	const factsCount = colorHex(`${snapshot.factsTotal} facts`, CATHEDRAL_TOKENS.colors.foregroundDim);
-	const searchClose = colorHex(" │", CATHEDRAL_TOKENS.colors.divider);
+	// Title: ✾  MEMORY SCRIPTORIUM  ✾
+	const titleText = `${fg(TITLE_MARK, CATHEDRAL_TOKENS.colors.accent)}  ${fg("MEMORY SCRIPTORIUM", CATHEDRAL_TOKENS.colors.accent)}  ${fg(TITLE_MARK, CATHEDRAL_TOKENS.colors.accent)}`;
+	lines.push(center(titleText, width));
 
-	const searchLineLeft = `   ${searchPrompt}${searchPlaceholder}`;
-	const searchLineRight = `${factsCount}${searchClose}`;
-	const gap = Math.max(2, width - visibleLength(searchLineLeft) - visibleLength(searchLineRight));
-	lines.push(`${searchLineLeft}${" ".repeat(gap)}${searchLineRight}`);
+	// Blank
 	lines.push("");
 
-	// 2-up panel grid
-	const groups = snapshot.groups;
-	const panelInternalWidth = Math.floor((width - 6) / 2); // 2 panels with gaps
+	// Top split rule
+	lines.push(splitRule(width));
+
+	// Blank
+	lines.push("");
+
+	// Search row: `   ❯  <query|placeholder>      <N facts>   `
+	const indent = "   ";
+	const placeholder = snapshot.searchQuery.length === 0
+		? fg("search remembered facts…", CATHEDRAL_TOKENS.colors.foregroundDim)
+		: fg(snapshot.searchQuery, CATHEDRAL_TOKENS.colors.foreground);
+	const factCount = fg(`${snapshot.factsTotal} facts`, CATHEDRAL_TOKENS.colors.foregroundDim);
+	const searchLeft = `${indent}${fg(SEARCH_PROMPT, CATHEDRAL_TOKENS.colors.accent)}  ${placeholder}`;
+	const searchRight = `${factCount}${indent}`;
+	const gap = Math.max(2, width - visibleLength(searchLeft) - visibleLength(searchRight));
+	lines.push(`${searchLeft}${" ".repeat(gap)}${searchRight}`);
+
+	// Blank
+	lines.push("");
+
+	// 2-up panel grid. Left + right panels separated by 2-col gap, each panel
+	// gets `(width - 2*indentCols - gap) / 2` cells. `indentCols = 3` to match
+	// the Bible mockup margin.
+	const sideIndent = 3;
+	const gridGap = 2;
+	const panelWidth = Math.max(20, Math.floor((width - 2 * sideIndent - gridGap) / 2));
+	const groups = filterGroups(snapshot.groups, snapshot.searchQuery).filter((g) => !(g.panel === "GENERAL" && g.facts.length === 0));
+
 	for (let i = 0; i < groups.length; i += 2) {
-		const left = renderPanel(groups[i]!, panelInternalWidth);
-		const right = i + 1 < groups.length ? renderPanel(groups[i + 1]!, panelInternalWidth) : null;
+		const left = renderPanel(groups[i]!, panelWidth, snapshot.focusedFactId);
+		const right = i + 1 < groups.length ? renderPanel(groups[i + 1]!, panelWidth, snapshot.focusedFactId) : null;
 		const rowCount = right ? Math.max(left.length, right.length) : left.length;
-		for (let r = 0; r < rowCount; r++) {
-			const leftLine = padToWidth(left[r] ?? "", panelInternalWidth);
-			const rightLine = right ? padToWidth(right[r] ?? "", panelInternalWidth) : "";
-			lines.push(`  ${leftLine}  ${rightLine}`);
+		for (let r = 0; r < rowCount; r += 1) {
+			const leftLine = padRight(left[r] ?? "", panelWidth);
+			const rightLine = right ? padRight(right[r] ?? "", panelWidth) : " ".repeat(panelWidth);
+			lines.push(`${" ".repeat(sideIndent)}${leftLine}${" ".repeat(gridGap)}${rightLine}${" ".repeat(sideIndent)}`);
 		}
 		lines.push("");
 	}
 
-	lines.push(divider(width));
-	lines.push(`   ${DIM}${colorHex(MEMORY_EDITOR_HINTS, CATHEDRAL_TOKENS.colors.foregroundDim)}${RESET}`);
+	// Bottom split rule
+	lines.push(splitRule(width));
 
-	return lines;
+	// Footer hints
+	const footer = fg(MEMORY_EDITOR_HINTS, CATHEDRAL_TOKENS.colors.foregroundDim);
+	lines.push(center(footer, width));
+
+	// Blank
+	lines.push("");
+
+	// Wrap every row in surfaceLifted bg + Cathedral foreground.
+	return lines.map((line) => persistentBg(
+		padRight(line, width),
+		CATHEDRAL_TOKENS.colors.foreground,
+		CATHEDRAL_TOKENS.colors.surfaceLifted,
+	));
 }
 
-// ============================================================================
-// Pi-glue
-// ============================================================================
+// ── Pi component + overlay ───────────────────────────────────
+
+export type MemoryNotifyLevel = "info" | "warning" | "error";
+
+export interface MemoryEditorComponentDeps {
+	readonly client?: RemnicMemoryClient;
+	readonly notify?: (text: string, level?: MemoryNotifyLevel) => void;
+}
 
 class MemoryEditorComponent implements Component {
-	constructor(
-		private snapshot: MemoryEditorSnapshot,
-		private readonly done: () => void,
-	) {}
+	private snapshot: MemoryEditorSnapshot;
+	private readonly client: RemnicMemoryClient | undefined;
+	private readonly notify: MemoryEditorComponentDeps["notify"];
+	private readonly done: () => void;
+
+	constructor(initial: MemoryEditorSnapshot, done: () => void, deps: MemoryEditorComponentDeps = {}) {
+		this.snapshot = initial;
+		this.client = deps.client;
+		this.notify = deps.notify;
+		this.done = done;
+	}
 
 	invalidate(): void {}
 
@@ -163,19 +299,66 @@ class MemoryEditorComponent implements Component {
 			this.done();
 			return;
 		}
-		// Search input: append printable chars to query, backspace removes last char.
+
+		// Up/down navigate focused fact across the visible (filtered) list.
+		if (data === "up" || matchesKey(data, "up")) {
+			this.snapshot = { ...this.snapshot, focusedFactId: nextFocusId(filterGroups(this.snapshot.groups, this.snapshot.searchQuery), this.snapshot.focusedFactId, -1) };
+			return;
+		}
+		if (data === "down" || matchesKey(data, "down")) {
+			this.snapshot = { ...this.snapshot, focusedFactId: nextFocusId(filterGroups(this.snapshot.groups, this.snapshot.searchQuery), this.snapshot.focusedFactId, 1) };
+			return;
+		}
+
+		// `d` forgets the focused fact via Remnic.
+		if (data === "d" && this.snapshot.focusedFactId) {
+			const id = this.snapshot.focusedFactId;
+			void this.forgetFocused(id);
+			return;
+		}
+
+		// `e` is reserved for inline revise. Tracked as a follow-up; emit a
+		// hint so users know how to revise via slash commands today.
+		if (data === "e" && this.snapshot.focusedFactId) {
+			this.notify?.("revise inline coming soon — use /sumo:memory forget <id> + /sumo:memory add <text>", "info");
+			return;
+		}
+
+		// Search input: append printable chars, backspace removes last.
 		if (data === "backspace" || matchesKey(data, "backspace")) {
-			this.snapshot = {
-				...this.snapshot,
-				searchQuery: this.snapshot.searchQuery.slice(0, -1),
-			};
+			this.snapshot = { ...this.snapshot, searchQuery: this.snapshot.searchQuery.slice(0, -1) };
 			return;
 		}
 		if (data.length === 1 && !/\p{Cc}/u.test(data)) {
-			this.snapshot = {
-				...this.snapshot,
-				searchQuery: `${this.snapshot.searchQuery}${data}`,
-			};
+			this.snapshot = { ...this.snapshot, searchQuery: `${this.snapshot.searchQuery}${data}` };
+		}
+	}
+
+	private async forgetFocused(id: string): Promise<void> {
+		// Optimistic remove: drop the fact from the snapshot before awaiting
+		// Remnic. If the call fails, restore via notification (we don't
+		// re-insert because the on-disk state may have already changed).
+		const before = this.snapshot;
+		const nextGroups: PanelGroup[] = before.groups.map((group) => ({
+			panel: group.panel,
+			facts: group.facts.filter((fact) => fact.id !== id),
+		}));
+		const nextOrder = visibleFactOrder(filterGroups(nextGroups, before.searchQuery));
+		this.snapshot = {
+			...before,
+			groups: nextGroups,
+			factsTotal: Math.max(0, before.factsTotal - 1),
+			focusedFactId: nextOrder.length === 0 ? null : nextOrder[0]!.id,
+		};
+		if (!this.client) {
+			this.notify?.("memory client unavailable — fact not actually forgotten", "warning");
+			return;
+		}
+		try {
+			await this.client.forget(id);
+			this.notify?.("memory forgotten", "info");
+		} catch (err) {
+			this.notify?.(`forget failed: ${err instanceof Error ? err.message : String(err)}`, "warning");
 		}
 	}
 
@@ -185,8 +368,9 @@ class MemoryEditorComponent implements Component {
 }
 
 /**
- * Open the memory editor modal. Reads all active memories and groups them
- * by cathedral panel, then renders the modal until the user dismisses.
+ * Open the Memory Scriptorium overlay. Reads all active memories and
+ * groups them by cathedral panel, then renders the modal until the user
+ * dismisses with `Esc`.
  */
 export async function showMemoryEditor(
 	ctx: ExtensionCommandContext,
@@ -206,22 +390,27 @@ export async function showMemoryEditor(
 	}
 
 	const groups = groupFactsByPanel(facts);
+	const flat = visibleFactOrder(groups);
 	const snapshot: MemoryEditorSnapshot = {
 		searchQuery: "",
 		groups,
 		factsTotal: facts.length,
+		focusedFactId: flat[0]?.id ?? null,
 	};
 
 	await ctx.ui.custom<void>(
 		(_tui: TUI, _theme: unknown, _kb: KeybindingsManager, done: () => void) =>
-			new MemoryEditorComponent(snapshot, done),
+			new MemoryEditorComponent(snapshot, done, {
+				client,
+				notify: (text, level = "info") => ctx.ui.notify(text, level),
+			}),
 		{
 			overlay: true,
 			overlayOptions: {
 				anchor: "center",
 				width: "80%",
 				minWidth: 70,
-				maxHeight: "80%",
+				maxHeight: "75%",
 			},
 			onHandle: (_handle: OverlayHandle) => {
 				/* opportunity to programmatically close in the future */
@@ -231,12 +420,12 @@ export async function showMemoryEditor(
 }
 
 /**
- * Register the `/sumo:memory edit` slash command. Future subcommands
- * (`add`, `forget`) can be added here too.
+ * Register the `/sumo:memory` slash command. Subcommands: `edit` (default),
+ * `add <text>`, `forget <id>`.
  */
 export function registerMemoryCommand(pi: ExtensionAPI): void {
 	pi.registerCommand("sumo:memory", {
-		description: "open the cathedral memory editor (or `add` / `forget` for direct ops)",
+		description: "open the memory scriptorium (or `add` / `forget` for direct ops)",
 		handler: async (args: string, ctx: ExtensionCommandContext) => {
 			const arg = args.trim().split(/\s+/)[0]?.toLowerCase() ?? "";
 			if (arg === "" || arg === "edit") {


### PR DESCRIPTION
## Summary

Closes most of #138 — Memory Scriptorium visual parity, navigation, search filter, `d` forget, and the `fixture-memory-scriptorium-overlay` visual scenario. Defers `e` inline revise to a follow-up.

## #138 acceptance status

| # | Criterion | Status |
|---|---|---|
| 1 | All six panels render (IDENTITY · PREFERENCES · WORKFLOW · PROJECTS · SYSTEM · GENERAL) | ✅ |
| 2 | Routing precedence applied deterministically | ✅ (existing `memory-categorization.ts`, unchanged) |
| 3 | Tokens match Bible (title accent, search ❯ accent, focused ❈ accent, unfocused · divider, panel borders divider, panel titles accent, fact text foreground, footer dim) | ✅ |
| 4 | Search filters facts while preserving Scriptorium chrome | ✅ (filtered panels show `(empty)` placeholder; chrome stays put) |
| 5 | `e` opens inline editor / `d` deletes / `⎋` closes | ✅ `d` + `⎋` shipped; ⏳ `e` deferred to follow-up (notify hint shown today) |
| 6 | AI-driven write path still works | ✅ (`/sumo:memory add` unchanged) |
| 7 | `fixture-memory-scriptorium` added to fixture lane | ✅ as `fixture-memory-scriptorium-overlay` |
| 8 | `scene-memory-scriptorium-overlay.html` parity-pass | ✅ renders in `pnpm visual:ci` (review status, awaiting human approval) |

## Implementation

### `src/memory-editor.ts`

- Refactored `renderMemoryEditor` to compose:
  - top blank
  - centered `✾ MEMORY SCRIPTORIUM ✾` title in accent
  - top split rule (`──── · ────` in divider)
  - `❯` accent search prompt + dim placeholder + dim `N facts` count
  - 2-up panel grid with `╭─ NAME ─╮ │ … │ ╰─╯` framing
  - bottom split rule
  - `↑↓ wander    /  search    e  revise    d  forget    ⎋ retreat` footer
  - `surfaceLifted` bg painted on every row via `persistentBg` (mirrors `divine-query.ts` pattern from #175)
- New `MemoryEditorSnapshot.focusedFactId: string \| null` drives `❈` vs `·` markers.
- New `MemoryEditorComponentDeps` injects Remnic client + notify callback so `d` can dispatch through to `client.forget(id)` with optimistic snapshot update + result notification.
- `filterGroups()` is the single source of truth for "what's visible"; `nextFocusId()` walks the flat ordered list across filtered groups so navigation stays inside what the user sees.

### `scripts/visual-v2/fixture-capture.mjs`

- New `applyMemoryScriptoriumOverlay()` that builds a Bible-aligned 13-fact dataset spanning all six panels, focuses the `prefers TypeScript strict` fact (PREFERENCES) to exercise the `❈` marker, renders at 80% width clamped 70-120, and composites onto the active scene preserving left/right remnants.
- `applyOverlay` switch updated to dispatch `memory-scriptorium`.

### `docs/visual/parity/scenarios.json`

- Added `fixture-memory-scriptorium-overlay` (160×45, status `review`, target `scene-memory-scriptorium-overlay.png`, full + overlay-center crops).

## Visual confirmation

Plain-text snapshot from `docs/visual/out/parity/fixture-memory-scriptorium-overlay/raw/runtime-output.ansi`:

```
                              ✾  MEMORY SCRIPTORIUM  ✾

         ─────────────────────────────────────────  ·  ─────────────────────────────────────────

   ❯  search remembered facts…                                                       13 facts

   ╭────────────────────── IDENTITY ──────────────────────╮  ╭──────────────────── PREFERENCES ─────────────────────╮
   │ · Dhruv · Senior FE · Argent                         │  │ ❈ prefers TypeScript strict                          │
   │ · London / BST                                       │  │ · pnpm not npm                                       │
   ╰──────────────────────────────────────────────────────╯  ╰──────────────────────────────────────────────────────╯
   …
         ─────────────────────────────────────────  ·  ─────────────────────────────────────────
              ↑↓ wander    /  search    e  revise    d  forget    ⎋ retreat
```

## Deferred

- **`e` inline revise** — currently shows `notify("revise inline coming soon — use /sumo:memory forget <id> + /sumo:memory add <text>")`. Building the inline Pi `Editor` flow (similar to `question-tool.ts` edit mode) would substantially grow this PR; tracking the inline-edit feature separately keeps the diff scoped.

## Verification

- `pnpm test`: 549/549 ✅
- `pnpm test:integration`: 18/18 ✅
- `pnpm exec tsc --noEmit`: clean ✅
- `pnpm build`: clean ✅
- `pnpm visual:ci`: 16 scenarios processed; new fixture renders correctly in `review` status awaiting human approval

## Conflict notes

Independent of all currently open PRs (#165, #167, #168, #169, #170, #175, #176). Touches `src/memory-editor.ts` (rewrite), its tests, scenarios.json (additive), and `fixture-capture.mjs` (additive overlay handler) — no overlap with other in-flight work.

## Manual smoke recommendation (per audit V2 §3 methodology gate)

- `bin/sumocode.sh` (or `pi -e .`)
- `/sumo:memory` to open the Scriptorium
- Up/down — confirm `❈` moves between facts
- Type letters — confirm search filters and chrome stays
- `d` on a focused fact — confirm fact disappears + toast appears (will fail safely if Remnic daemon not running)
- `⎋` — confirm modal closes
- Confirm Bible-look at 80%/70-min/120-max widths

Closes #138.