### PR TITLE
perf(tui): coalesce chat viewport renders

### DIFF
--- a/scripts/diag-summary.mjs
+++ b/scripts/diag-summary.mjs
@@ -14,10 +14,14 @@ const events = fs.readFileSync(file, "utf8").split(/\r?\n/).filter(Boolean).flat
 const counts = new Map();
 const slow = [];
 const errors = [];
+const renderSamples = [];
+const renderStats = [];
 for (const event of events) {
   counts.set(event.event, (counts.get(event.event) ?? 0) + 1);
   if (event.event === "slow_frame") slow.push(event);
   if (event.event === "render_error" || event.event === "invariant_violation") errors.push(event);
+  if (event.event === "render_sample") renderSamples.push(event);
+  if (event.event === "render_stats") renderStats.push(event);
 }
 
 console.log(`Diagnostics: ${file}`);
@@ -31,6 +35,113 @@ if (slow.length > 0) {
   console.log("\nSlow frames:");
   for (const event of slow.slice(-20)) {
     console.log(`  ${event.durationMs}ms  ${event.path ?? "unknown"}  ${event.width ?? "?"}x${event.height ?? "?"}`);
+  }
+}
+
+if (renderStats.length > 0) {
+  // Aggregate per-target render durations + IO + counters across all flushed windows.
+  const totals = new Map();
+  const ioTotals = new Map();
+  let getBranchCalls = 0;
+  let usageHits = 0;
+  let usageMisses = 0;
+  let branchHits = 0;
+  let branchMisses = 0;
+  let piEvents = 0;
+  let keystrokes = 0;
+  let keystrokeBytes = 0;
+  const keystrokeLat = { count: 0, totalMs: 0, maxMs: 0 };
+  let totalWindowsMs = 0;
+  for (const stat of renderStats) {
+    totalWindowsMs += stat.windowMs ?? 0;
+    getBranchCalls += stat.getBranchCalls ?? 0;
+    usageHits += stat.sessionCacheHits ?? 0;
+    usageMisses += stat.sessionCacheMisses ?? 0;
+    branchHits += stat.branchCacheHits ?? 0;
+    branchMisses += stat.branchCacheMisses ?? 0;
+    piEvents += stat.piEvents ?? 0;
+    keystrokes += stat.keystrokes ?? 0;
+    keystrokeBytes += stat.keystrokeBytes ?? 0;
+    if (stat.keystrokeLatency) {
+      keystrokeLat.count += stat.keystrokeLatency.count ?? 0;
+      keystrokeLat.totalMs += stat.keystrokeLatency.totalMs ?? 0;
+      keystrokeLat.maxMs = Math.max(keystrokeLat.maxMs, stat.keystrokeLatency.maxMs ?? 0);
+    }
+    for (const [target, bucket] of Object.entries(stat.targets ?? {})) {
+      const acc = totals.get(target) ?? { count: 0, totalMs: 0, maxMs: 0 };
+      acc.count += bucket.count ?? 0;
+      acc.totalMs += bucket.totalMs ?? 0;
+      acc.maxMs = Math.max(acc.maxMs, bucket.maxMs ?? 0);
+      totals.set(target, acc);
+    }
+    for (const [stream, bucket] of Object.entries(stat.io ?? {})) {
+      const acc = ioTotals.get(stream) ?? { writes: 0, bytes: 0, writeMs: 0, maxWriteMs: 0, maxBytes: 0 };
+      acc.writes += bucket.writes ?? 0;
+      acc.bytes += bucket.bytes ?? 0;
+      acc.writeMs += bucket.writeMs ?? 0;
+      acc.maxWriteMs = Math.max(acc.maxWriteMs, bucket.maxWriteMs ?? 0);
+      acc.maxBytes = Math.max(acc.maxBytes, bucket.maxBytes ?? 0);
+      ioTotals.set(stream, acc);
+    }
+  }
+  const totalSeconds = totalWindowsMs / 1000;
+  console.log(`\nRender hot paths (across ${renderStats.length} windows / ~${totalSeconds.toFixed(1)}s):`);
+  console.log(`  ${"target".padEnd(28)} ${"count".padStart(7)} ${"avg/ms".padStart(8)} ${"max/ms".padStart(8)} ${"total/ms".padStart(10)} ${"renders/s".padStart(10)}`);
+  const sorted = [...totals.entries()].sort((a, b) => b[1].totalMs - a[1].totalMs);
+  for (const [target, bucket] of sorted) {
+    const avg = bucket.count > 0 ? bucket.totalMs / bucket.count : 0;
+    const rps = totalSeconds > 0 ? bucket.count / totalSeconds : 0;
+    console.log(
+      `  ${target.padEnd(28)} ${String(bucket.count).padStart(7)} ${avg.toFixed(2).padStart(8)} ${bucket.maxMs.toFixed(2).padStart(8)} ${bucket.totalMs.toFixed(1).padStart(10)} ${rps.toFixed(1).padStart(10)}`,
+    );
+  }
+  const grandTotalRenderMs = sorted.reduce((acc, [, bucket]) => acc + bucket.totalMs, 0);
+  const renderShare = totalWindowsMs > 0 ? (grandTotalRenderMs / totalWindowsMs) * 100 : 0;
+  console.log(`  ${"".padEnd(28)} ${"".padStart(7)} ${"".padStart(8)} ${"".padStart(8)} ${grandTotalRenderMs.toFixed(1).padStart(10)} (${renderShare.toFixed(1)}% of wall)`);
+
+  if (ioTotals.size > 0) {
+    console.log(`\nstdout/stderr writes (per stream, totals across the trace):`);
+    console.log(`  ${"stream".padEnd(8)} ${"writes".padStart(8)} ${"bytes".padStart(10)} ${"avgB".padStart(7)} ${"maxB".padStart(8)} ${"writeMs".padStart(10)} ${"avg/ms".padStart(8)} ${"max/ms".padStart(8)} ${"writes/s".padStart(10)} ${"bytes/s".padStart(10)}`);
+    for (const [stream, bucket] of ioTotals) {
+      const avgMs = bucket.writes > 0 ? bucket.writeMs / bucket.writes : 0;
+      const avgB = bucket.writes > 0 ? bucket.bytes / bucket.writes : 0;
+      const wps = totalSeconds > 0 ? bucket.writes / totalSeconds : 0;
+      const bps = totalSeconds > 0 ? bucket.bytes / totalSeconds : 0;
+      console.log(
+        `  ${stream.padEnd(8)} ${String(bucket.writes).padStart(8)} ${String(bucket.bytes).padStart(10)} ${avgB.toFixed(0).padStart(7)} ${String(bucket.maxBytes).padStart(8)} ${bucket.writeMs.toFixed(1).padStart(10)} ${avgMs.toFixed(2).padStart(8)} ${bucket.maxWriteMs.toFixed(2).padStart(8)} ${wps.toFixed(1).padStart(10)} ${bps.toFixed(0).padStart(10)}`,
+      );
+    }
+    const stdoutBucket = ioTotals.get("stdout");
+    if (stdoutBucket) {
+      const stdoutShare = totalWindowsMs > 0 ? (stdoutBucket.writeMs / totalWindowsMs) * 100 : 0;
+      console.log(`  stdout share of wall-clock: ${stdoutShare.toFixed(1)}%`);
+    }
+  }
+
+  if (keystrokes > 0) {
+    const kps = totalSeconds > 0 ? keystrokes / totalSeconds : 0;
+    console.log(`\nKeystrokes: ${keystrokes} (${keystrokeBytes} bytes) → ${kps.toFixed(1)}/s`);
+    if (keystrokeLat.count > 0) {
+      const avgLat = keystrokeLat.totalMs / keystrokeLat.count;
+      console.log(`  keystroke→paint latency: avg=${avgLat.toFixed(1)}ms  max=${keystrokeLat.maxMs.toFixed(1)}ms  (${keystrokeLat.count} samples)`);
+    }
+  }
+
+  const usageTotal = usageHits + usageMisses;
+  const usageHitRate = usageTotal > 0 ? ((usageHits / usageTotal) * 100).toFixed(1) : "n/a";
+  const branchTotal = branchHits + branchMisses;
+  const branchHitRate = branchTotal > 0 ? ((branchHits / branchTotal) * 100).toFixed(1) : "n/a";
+  console.log(`\nSession usage cache: ${usageHits} hits / ${usageMisses} misses (${usageHitRate}% hit)`);
+  console.log(`Git branch cache:    ${branchHits} hits / ${branchMisses} misses (${branchHitRate}% hit)`);
+  console.log(`getBranch() raw calls: ${getBranchCalls}  |  pi events: ${piEvents}`);
+}
+
+if (renderSamples.length > 0) {
+  // Top 20 slowest individual renders.
+  const sorted = [...renderSamples].sort((a, b) => (b.durationMs ?? 0) - (a.durationMs ?? 0));
+  console.log(`\nSlowest individual renders (top ${Math.min(20, sorted.length)} of ${renderSamples.length}):`);
+  for (const event of sorted.slice(0, 20)) {
+    console.log(`  ${String(event.durationMs).padStart(6)}ms  ${event.target.padEnd(28)} w=${event.width} lines=${event.lines}`);
   }
 }
 

--- a/src/cathedral/cathedral-editor.ts
+++ b/src/cathedral/cathedral-editor.ts
@@ -39,6 +39,7 @@ import type {
 } from "@mariozechner/pi-coding-agent";
 import { CustomEditor } from "@mariozechner/pi-coding-agent";
 import { CURSOR_MARKER, truncateToWidth, visibleWidth, type EditorTheme, type TUI } from "@mariozechner/pi-tui";
+import { sessionHasMessages as cachedSessionHasMessages } from "../session-cache.js";
 import { CATHEDRAL_TOKENS } from "../tokens.js";
 import {
 	INPUT_FRAME_LABEL_ACTIVE,
@@ -294,7 +295,7 @@ class CathedralEditor extends CustomEditor {
 
 function sessionHasMessages(ctx: ExtensionContext): boolean {
 	try {
-		return ctx.sessionManager.getBranch().some((entry) => entry.type === "message");
+		return cachedSessionHasMessages(ctx);
 	} catch {
 		return false;
 	}

--- a/src/cathedral/input-hints.ts
+++ b/src/cathedral/input-hints.ts
@@ -14,7 +14,8 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { Component } from "@mariozechner/pi-tui";
 import { visibleWidth } from "@mariozechner/pi-tui";
-import { formatCwd, resolveGitBranch } from "../footer.js";
+import { formatCwd } from "../footer.js";
+import { getGitBranch, sessionHasMessages as cachedSessionHasMessages } from "../session-cache.js";
 import { INPUT_FRAME_HINT_AWAITING, renderInputHints } from "./input-frame.js";
 
 const SPLASH_INPUT_FRAME_WIDTH = 60;
@@ -55,13 +56,13 @@ function activeContextHint(ctx: ExtensionContext): string | undefined {
 	const cwd = ctx.cwd;
 	if (!cwd) return undefined;
 	const project = formatCwd(cwd);
-	const branch = resolveGitBranch(cwd);
+	const branch = getGitBranch(ctx);
 	return branch ? `${project} (${branch})` : project;
 }
 
 function sessionHasMessages(ctx: ExtensionContext): boolean {
 	try {
-		return ctx.sessionManager.getBranch().some((entry) => entry.type === "message");
+		return cachedSessionHasMessages(ctx);
 	} catch {
 		return false;
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,8 @@ import { installAltscreen } from "./cathedral/altscreen.js";
 import { installCathedralEditor } from "./cathedral/cathedral-editor.js";
 import { installSumoInteractions } from "./interaction-registry.js";
 import { installFooter } from "./footer.js";
+import { installRenderDiagnostics } from "./render-diagnostics.js";
+import { installSessionCache } from "./session-cache.js";
 import { installSplash } from "./splash.js";
 import { installTopChrome } from "./top-chrome.js";
 import { installWorkingIndicator } from "./working-indicator.js";
@@ -90,6 +92,14 @@ export default function sumocode(pi: ExtensionAPI): void {
 		return;
 	}
 
+	// Render diagnostics must install BEFORE any consumer so its `setFooter` /
+	// `setHeader` / `setEditorComponent` / `setWidget` wrappers are in place
+	// when those modules wire their components. No-op unless `SUMO_TUI_DIAG_FILE`
+	// is set (i.e. `sumocode -d`).
+	installRenderDiagnostics(pi);
+	// Cache must install before any consumer (footer/sidebar/top-chrome) so its
+	// invalidation handlers run alongside their state updates on lifecycle events.
+	installSessionCache(pi);
 	installAltscreen(pi);
 	installTopChrome(pi);
 	installSplash(pi);

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -9,6 +9,7 @@ import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
  * as a direct dep. Mirrors the upstream definition exactly.
  */
 export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+import { getSessionUsage as getCachedSessionUsage, sessionHasMessages as cachedSessionHasMessages } from "./session-cache.js";
 import { CATHEDRAL_TOKENS, type SumoCodeState } from "./tokens.js";
 import { VOICE } from "./voice.js";
 
@@ -237,7 +238,7 @@ function createSnapshot(pi: ExtensionAPI, ctx: ExtensionContext, branch: string 
 
 function sessionHasMessages(ctx: ExtensionContext): boolean {
 	try {
-		return ctx.sessionManager.getBranch().some((entry) => entry.type === "message");
+		return cachedSessionHasMessages(ctx);
 	} catch {
 		return false;
 	}
@@ -293,18 +294,8 @@ function getContextWindow(ctx: ExtensionContext): number {
 }
 
 function getSessionUsage(ctx: ExtensionContext): Usage {
-	let input = 0;
-	let output = 0;
-	let cost = 0;
-
-	for (const entry of ctx.sessionManager.getBranch()) {
-		if (entry.type !== "message" || entry.message.role !== "assistant") continue;
-		input += entry.message.usage.input;
-		output += entry.message.usage.output;
-		cost += entry.message.usage.cost.total;
-	}
-
-	return { input, output, cost };
+	const cached = getCachedSessionUsage(ctx);
+	return { input: cached.input, output: cached.output, cost: cached.cost };
 }
 
 function defaultGitRunner(args: string[], cwd: string): string {

--- a/src/render-diagnostics.test.ts
+++ b/src/render-diagnostics.test.ts
@@ -1,0 +1,177 @@
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+type SessionStartHandler = (event: unknown, ctx: ExtensionContext) => void;
+
+function makePi(): { pi: ExtensionAPI; fireSessionStart: (ctx: ExtensionContext) => void } {
+	let handler: SessionStartHandler | undefined;
+	const pi = {
+		on: vi.fn((eventName: string, h: SessionStartHandler) => {
+			if (eventName === "session_start") handler = h;
+		}),
+	} as unknown as ExtensionAPI;
+	return {
+		pi,
+		fireSessionStart: (ctx: ExtensionContext) => handler?.({ type: "session_start" }, ctx),
+	};
+}
+
+type RegisteredFactories = {
+	footer?: (...args: unknown[]) => unknown;
+	header?: (...args: unknown[]) => unknown;
+	editor?: (...args: unknown[]) => unknown;
+	widgets: Map<string, (...args: unknown[]) => unknown>;
+};
+
+function makeCtx(): {
+	ctx: ExtensionContext;
+	registered: RegisteredFactories;
+	getBranchSpy: ReturnType<typeof vi.fn>;
+} {
+	// Capture what the wrapper passes through to the underlying ctx.ui setters,
+	// because instrumentUi mutates the methods on ctx.ui in-place — keeping a
+	// separate spy reference would also be mutated.
+	const registered: RegisteredFactories = { widgets: new Map() };
+	const ui = {
+		setFooter: (factory: (...args: unknown[]) => unknown): void => {
+			registered.footer = factory;
+		},
+		setHeader: (factory: (...args: unknown[]) => unknown): void => {
+			registered.header = factory;
+		},
+		setEditorComponent: (factory: (...args: unknown[]) => unknown): void => {
+			registered.editor = factory;
+		},
+		setWidget: (key: string, content: (...args: unknown[]) => unknown): void => {
+			registered.widgets.set(key, content);
+		},
+	};
+	const getBranchSpy = vi.fn(() => []);
+	const ctx = {
+		hasUI: true,
+		cwd: "/tmp",
+		ui,
+		sessionManager: { getBranch: getBranchSpy },
+	} as unknown as ExtensionContext;
+	return { ctx, registered, getBranchSpy };
+}
+
+describe("render-diagnostics — disabled (no SUMO_TUI_DIAG_FILE)", () => {
+	beforeEach(() => {
+		delete process.env.SUMO_TUI_DIAG_FILE;
+		vi.resetModules();
+	});
+
+	it("does not subscribe to events or wrap ui surfaces", async () => {
+		const { installRenderDiagnostics } = await import("./render-diagnostics.js");
+		const { pi } = makePi();
+		installRenderDiagnostics(pi);
+		expect((pi.on as ReturnType<typeof vi.fn>).mock.calls.length).toBe(0);
+	});
+});
+
+describe("render-diagnostics — enabled", () => {
+	let dir: string;
+	let file: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "sumo-diag-"));
+		file = join(dir, "diag.jsonl");
+		process.env.SUMO_TUI_DIAG_FILE = file;
+		vi.resetModules();
+	});
+
+	afterEach(() => {
+		delete process.env.SUMO_TUI_DIAG_FILE;
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	function readEvents(): Array<Record<string, unknown>> {
+		const text = readFileSync(file, "utf8").trim();
+		if (!text) return [];
+		return text.split("\n").map((line) => JSON.parse(line) as Record<string, unknown>);
+	}
+
+	it("wraps setFooter so component.render gets timed and writes a render_sample for slow renders", async () => {
+		const { installRenderDiagnostics } = await import("./render-diagnostics.js");
+		const { pi, fireSessionStart } = makePi();
+		const { ctx, registered } = makeCtx();
+
+		installRenderDiagnostics(pi);
+		fireSessionStart(ctx);
+
+		const slowRender = vi.fn(() => {
+			const target = Date.now() + 6;
+			while (Date.now() < target) {
+				// burn cpu so duration crosses the 4ms slow threshold
+			}
+			return ["row1", "row2"];
+		});
+		const factory = vi.fn(() => ({ render: slowRender }));
+
+		(ctx.ui as unknown as { setFooter: (factory: unknown) => void }).setFooter(factory);
+
+		expect(registered.footer).toBeTypeOf("function");
+		const component = registered.footer!({}, {}, {}) as { render: (w: number) => string[] };
+
+		const result = component.render(80);
+		expect(result).toEqual(["row1", "row2"]);
+		expect(slowRender).toHaveBeenCalledWith(80);
+
+		const events = readEvents();
+		const samples = events.filter((event) => event.event === "render_sample");
+		expect(samples.length).toBeGreaterThan(0);
+		expect(samples[0]?.target).toBe("footer");
+		expect(samples[0]?.width).toBe(80);
+		expect(samples[0]?.lines).toBe(2);
+	});
+
+	it("wraps sessionManager.getBranch and counts calls", async () => {
+		const { installRenderDiagnostics } = await import("./render-diagnostics.js");
+		const { pi, fireSessionStart } = makePi();
+		const { ctx, getBranchSpy } = makeCtx();
+
+		installRenderDiagnostics(pi);
+		fireSessionStart(ctx);
+
+		// Calling getBranch through ctx.sessionManager should still return the underlying value.
+		const branch = (ctx.sessionManager as unknown as { getBranch: () => unknown[] }).getBranch();
+		expect(branch).toEqual([]);
+		expect(getBranchSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("setEditorComponent wrapping preserves identity (instance methods survive)", async () => {
+		const { installRenderDiagnostics } = await import("./render-diagnostics.js");
+		const { pi, fireSessionStart } = makePi();
+		const { ctx, registered } = makeCtx();
+
+		installRenderDiagnostics(pi);
+		fireSessionStart(ctx);
+
+		class Editor {
+			public extra = "preserved";
+			render(_width: number): string[] {
+				return ["editor-row"];
+			}
+			customMethod(): string {
+				return "still here";
+			}
+		}
+		const editor = new Editor();
+		const factory = (): Editor => editor;
+
+		(ctx.ui as unknown as { setEditorComponent: (factory: unknown) => void }).setEditorComponent(factory);
+		expect(registered.editor).toBeTypeOf("function");
+		const result = registered.editor!({}, {}, {}) as Editor;
+
+		// Same instance — only `render` is patched.
+		expect(result).toBe(editor);
+		expect(result.extra).toBe("preserved");
+		expect(result.customMethod()).toBe("still here");
+		expect(result.render(60)).toEqual(["editor-row"]);
+	});
+});

--- a/src/render-diagnostics.ts
+++ b/src/render-diagnostics.ts
@@ -1,0 +1,621 @@
+/**
+ * Per-render timing instrumentation for SumoCode chrome.
+ *
+ * Activates only when `SUMO_TUI_DIAG_FILE` is set (i.e. `sumocode -d`). Wraps
+ * `ctx.ui.setFooter / setHeader / setEditorComponent / setWidget` so every
+ * `render(width)` call from Pi's draw cycle is timed and aggregated.
+ *
+ * Output (JSONL into the diagnostics file):
+ *   • `render_sample` — one entry per render, written sparsely (only when
+ *     `durationMs >= SLOW_RENDER_THRESHOLD_MS`) so the file does not balloon.
+ *   • `render_stats` — emitted once per `STATS_FLUSH_MS` interval with per-target
+ *     count, total ms, max ms, plus session-branch traversal counters (so we
+ *     can verify the session-cache actually works).
+ *
+ * Design:
+ *   - Zero overhead when diagnostics are disabled — `installRenderDiagnostics`
+ *     short-circuits.
+ *   - Non-invasive — patches `render` on the returned component (and `getBranch`
+ *     on the session manager) but keeps prototypes/identity intact, so
+ *     `CathedralEditor` keeps working.
+ *   - Must install BEFORE consumers (`installFooter`, `installSidebar`, etc.)
+ *     so its `setFooter` etc. wrappers are in place when those modules wire
+ *     their components.
+ */
+
+import { createRequire } from "node:module";
+import { performance } from "node:perf_hooks";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { isDiagnosticsEnabled, logDiagnostic } from "./sumo-tui/runtime/diagnostics.js";
+
+/** Render durations >= this (ms) get logged individually as `render_sample`. */
+const SLOW_RENDER_THRESHOLD_MS = 4;
+/** stdout.write durations >= this (ms) get logged individually as `stdout_slow`. */
+const SLOW_STDOUT_THRESHOLD_MS = 4;
+/** Keystroke->paint latencies >= this (ms) get logged individually. */
+const SLOW_KEYSTROKE_THRESHOLD_MS = 32;
+/** stdin handler durations >= this get logged individually as `stdin_handler_slow`. */
+const SLOW_STDIN_HANDLER_THRESHOLD_MS = 16;
+/** Event-loop lag samples >= this get logged individually as `event_loop_lag`. */
+const SLOW_EVENT_LOOP_LAG_MS = 50;
+/** How often (ms) the event-loop-lag probe schedules itself. */
+const EVENT_LOOP_PROBE_MS = 100;
+/** Module._load samples >= this get logged individually as `module_load_slow`. */
+const SLOW_MODULE_LOAD_MS = 8;
+/** How often (ms) to emit aggregated `render_stats`. */
+const STATS_FLUSH_MS = 1_000;
+
+type Bucket = {
+	count: number;
+	totalMs: number;
+	maxMs: number;
+};
+
+type RenderTarget = "footer" | "header" | "editor" | `widget:${string}`;
+
+type IoBucket = {
+	writes: number;
+	bytes: number;
+	writeMs: number;
+	maxWriteMs: number;
+	maxBytes: number;
+};
+
+type LatencyBucket = {
+	count: number;
+	totalMs: number;
+	maxMs: number;
+};
+
+type ModuleLoadStats = {
+	count: number;
+	totalMs: number;
+	maxMs: number;
+	slowestSpec: string | undefined;
+};
+
+class RenderStats {
+	private readonly buckets = new Map<RenderTarget, Bucket>();
+	private getBranchCalls = 0;
+	private cacheUsageHits = 0;
+	private cacheUsageMisses = 0;
+	private cacheBranchHits = 0;
+	private cacheBranchMisses = 0;
+	private piEvents = 0;
+	private keystrokes = 0;
+	private keystrokeBytes = 0;
+	private readonly stdoutByStream = new Map<"stdout" | "stderr", IoBucket>();
+	private readonly keystrokeLatency: LatencyBucket = { count: 0, totalMs: 0, maxMs: 0 };
+	private readonly stdinHandlerLatency: LatencyBucket = { count: 0, totalMs: 0, maxMs: 0 };
+	private readonly eventLoopLag: LatencyBucket = { count: 0, totalMs: 0, maxMs: 0 };
+	private readonly moduleLoad: ModuleLoadStats = { count: 0, totalMs: 0, maxMs: 0, slowestSpec: undefined };
+	private flushTimer: ReturnType<typeof setInterval> | undefined;
+
+	public start(): void {
+		if (this.flushTimer) return;
+		this.flushTimer = setInterval(() => this.flush(), STATS_FLUSH_MS);
+		// Don't keep the process alive for diagnostics flushing.
+		this.flushTimer.unref?.();
+	}
+
+	public stop(): void {
+		if (this.flushTimer) clearInterval(this.flushTimer);
+		this.flushTimer = undefined;
+		this.flush();
+	}
+
+	public recordRender(target: RenderTarget, durationMs: number, width: number, lines: number): void {
+		const bucket = this.buckets.get(target) ?? { count: 0, totalMs: 0, maxMs: 0 };
+		bucket.count += 1;
+		bucket.totalMs += durationMs;
+		if (durationMs > bucket.maxMs) bucket.maxMs = durationMs;
+		this.buckets.set(target, bucket);
+
+		if (durationMs >= SLOW_RENDER_THRESHOLD_MS) {
+			logDiagnostic("render_sample", { target, durationMs: round(durationMs), width, lines });
+		}
+	}
+
+	public recordGetBranch(): void {
+		this.getBranchCalls += 1;
+	}
+
+	public recordCacheUsageHit(): void {
+		this.cacheUsageHits += 1;
+	}
+
+	public recordCacheUsageMiss(): void {
+		this.cacheUsageMisses += 1;
+	}
+
+	public recordCacheBranchHit(): void {
+		this.cacheBranchHits += 1;
+	}
+
+	public recordCacheBranchMiss(): void {
+		this.cacheBranchMisses += 1;
+	}
+
+	public recordPiEvent(): void {
+		this.piEvents += 1;
+	}
+
+	public recordKeystroke(bytes: number): void {
+		this.keystrokes += 1;
+		this.keystrokeBytes += bytes;
+	}
+
+	public recordKeystrokeLatency(durationMs: number, bytes: number): void {
+		this.keystrokeLatency.count += 1;
+		this.keystrokeLatency.totalMs += durationMs;
+		if (durationMs > this.keystrokeLatency.maxMs) this.keystrokeLatency.maxMs = durationMs;
+		if (durationMs >= SLOW_KEYSTROKE_THRESHOLD_MS) {
+			logDiagnostic("keystroke_slow", { durationMs: round(durationMs), bytes });
+		}
+	}
+
+	public recordStdinHandler(durationMs: number, bytes: number): void {
+		this.stdinHandlerLatency.count += 1;
+		this.stdinHandlerLatency.totalMs += durationMs;
+		if (durationMs > this.stdinHandlerLatency.maxMs) this.stdinHandlerLatency.maxMs = durationMs;
+		if (durationMs >= SLOW_STDIN_HANDLER_THRESHOLD_MS) {
+			logDiagnostic("stdin_handler_slow", { durationMs: round(durationMs), bytes });
+		}
+	}
+
+	public recordEventLoopLag(actualMs: number, expectedMs: number): void {
+		const lag = Math.max(0, actualMs - expectedMs);
+		this.eventLoopLag.count += 1;
+		this.eventLoopLag.totalMs += lag;
+		if (lag > this.eventLoopLag.maxMs) this.eventLoopLag.maxMs = lag;
+		if (lag >= SLOW_EVENT_LOOP_LAG_MS) {
+			logDiagnostic("event_loop_lag", { lagMs: round(lag), actualMs: round(actualMs), expectedMs });
+		}
+	}
+
+	public recordModuleLoad(spec: string, durationMs: number): void {
+		this.moduleLoad.count += 1;
+		this.moduleLoad.totalMs += durationMs;
+		if (durationMs > this.moduleLoad.maxMs) {
+			this.moduleLoad.maxMs = durationMs;
+			this.moduleLoad.slowestSpec = spec;
+		}
+		if (durationMs >= SLOW_MODULE_LOAD_MS) {
+			logDiagnostic("module_load_slow", { spec, durationMs: round(durationMs) });
+		}
+	}
+
+	public recordWrite(stream: "stdout" | "stderr", bytes: number, durationMs: number): void {
+		const bucket = this.stdoutByStream.get(stream) ?? { writes: 0, bytes: 0, writeMs: 0, maxWriteMs: 0, maxBytes: 0 };
+		bucket.writes += 1;
+		bucket.bytes += bytes;
+		bucket.writeMs += durationMs;
+		if (durationMs > bucket.maxWriteMs) bucket.maxWriteMs = durationMs;
+		if (bytes > bucket.maxBytes) bucket.maxBytes = bytes;
+		this.stdoutByStream.set(stream, bucket);
+
+		if (durationMs >= SLOW_STDOUT_THRESHOLD_MS) {
+			logDiagnostic("stdout_slow", { stream, bytes, durationMs: round(durationMs) });
+		}
+	}
+
+	private flush(): void {
+		const nothingToReport =
+			this.buckets.size === 0 &&
+			this.getBranchCalls === 0 &&
+			this.cacheUsageHits === 0 &&
+			this.cacheUsageMisses === 0 &&
+			this.cacheBranchHits === 0 &&
+			this.cacheBranchMisses === 0 &&
+			this.piEvents === 0 &&
+			this.keystrokes === 0 &&
+			this.stdoutByStream.size === 0 &&
+			this.keystrokeLatency.count === 0 &&
+			this.stdinHandlerLatency.count === 0 &&
+			this.eventLoopLag.count === 0 &&
+			this.moduleLoad.count === 0;
+		if (nothingToReport) return;
+
+		const targets: Record<string, Bucket & { avgMs: number }> = {};
+		for (const [target, bucket] of this.buckets.entries()) {
+			targets[target] = {
+				count: bucket.count,
+				totalMs: round(bucket.totalMs),
+				maxMs: round(bucket.maxMs),
+				avgMs: round(bucket.totalMs / bucket.count),
+			};
+		}
+		const io: Record<string, IoBucket & { avgWriteMs: number; avgBytes: number }> = {};
+		for (const [stream, bucket] of this.stdoutByStream.entries()) {
+			io[stream] = {
+				writes: bucket.writes,
+				bytes: bucket.bytes,
+				writeMs: round(bucket.writeMs),
+				maxWriteMs: round(bucket.maxWriteMs),
+				maxBytes: bucket.maxBytes,
+				avgWriteMs: round(bucket.writeMs / bucket.writes),
+				avgBytes: Math.round(bucket.bytes / bucket.writes),
+			};
+		}
+		const keystrokeStats = this.keystrokeLatency.count > 0
+			? {
+				count: this.keystrokeLatency.count,
+				totalMs: round(this.keystrokeLatency.totalMs),
+				maxMs: round(this.keystrokeLatency.maxMs),
+				avgMs: round(this.keystrokeLatency.totalMs / this.keystrokeLatency.count),
+			}
+			: undefined;
+		const stdinHandlerStats = this.stdinHandlerLatency.count > 0
+			? {
+				count: this.stdinHandlerLatency.count,
+				totalMs: round(this.stdinHandlerLatency.totalMs),
+				maxMs: round(this.stdinHandlerLatency.maxMs),
+				avgMs: round(this.stdinHandlerLatency.totalMs / this.stdinHandlerLatency.count),
+			}
+			: undefined;
+		const loopLagStats = this.eventLoopLag.count > 0
+			? {
+				count: this.eventLoopLag.count,
+				totalMs: round(this.eventLoopLag.totalMs),
+				maxMs: round(this.eventLoopLag.maxMs),
+				avgMs: round(this.eventLoopLag.totalMs / this.eventLoopLag.count),
+			}
+			: undefined;
+		const moduleLoadStats = this.moduleLoad.count > 0
+			? {
+				count: this.moduleLoad.count,
+				totalMs: round(this.moduleLoad.totalMs),
+				maxMs: round(this.moduleLoad.maxMs),
+				avgMs: round(this.moduleLoad.totalMs / this.moduleLoad.count),
+				slowestSpec: this.moduleLoad.slowestSpec,
+			}
+			: undefined;
+		logDiagnostic("render_stats", {
+			windowMs: STATS_FLUSH_MS,
+			targets,
+			io,
+			getBranchCalls: this.getBranchCalls,
+			sessionCacheHits: this.cacheUsageHits,
+			sessionCacheMisses: this.cacheUsageMisses,
+			branchCacheHits: this.cacheBranchHits,
+			branchCacheMisses: this.cacheBranchMisses,
+			piEvents: this.piEvents,
+			keystrokes: this.keystrokes,
+			keystrokeBytes: this.keystrokeBytes,
+			keystrokeLatency: keystrokeStats,
+			stdinHandler: stdinHandlerStats,
+			eventLoopLag: loopLagStats,
+			moduleLoad: moduleLoadStats,
+		});
+		this.buckets.clear();
+		this.getBranchCalls = 0;
+		this.cacheUsageHits = 0;
+		this.cacheUsageMisses = 0;
+		this.cacheBranchHits = 0;
+		this.cacheBranchMisses = 0;
+		this.piEvents = 0;
+		this.keystrokes = 0;
+		this.keystrokeBytes = 0;
+		this.stdoutByStream.clear();
+		this.keystrokeLatency.count = 0;
+		this.keystrokeLatency.totalMs = 0;
+		this.keystrokeLatency.maxMs = 0;
+		this.stdinHandlerLatency.count = 0;
+		this.stdinHandlerLatency.totalMs = 0;
+		this.stdinHandlerLatency.maxMs = 0;
+		this.eventLoopLag.count = 0;
+		this.eventLoopLag.totalMs = 0;
+		this.eventLoopLag.maxMs = 0;
+		this.moduleLoad.count = 0;
+		this.moduleLoad.totalMs = 0;
+		this.moduleLoad.maxMs = 0;
+		this.moduleLoad.slowestSpec = undefined;
+	}
+}
+
+function round(n: number): number {
+	return Math.round(n * 100) / 100;
+}
+
+const stats = new RenderStats();
+
+/** Counters that other modules can poke into. No-op when diagnostics are disabled. */
+export const renderDiagnosticsCounters = {
+	noteCacheHit(): void {
+		if (isDiagnosticsEnabled()) stats.recordCacheUsageHit();
+	},
+	noteCacheMiss(): void {
+		if (isDiagnosticsEnabled()) stats.recordCacheUsageMiss();
+	},
+	noteBranchCacheHit(): void {
+		if (isDiagnosticsEnabled()) stats.recordCacheBranchHit();
+	},
+	noteBranchCacheMiss(): void {
+		if (isDiagnosticsEnabled()) stats.recordCacheBranchMiss();
+	},
+} as const;
+
+type RenderableComponent = { render(width: number): string[] };
+
+function patchRender(target: RenderTarget, component: RenderableComponent): void {
+	const original = component.render.bind(component);
+	component.render = (width: number): string[] => {
+		const start = performance.now();
+		const result = original(width);
+		const duration = performance.now() - start;
+		stats.recordRender(target, duration, width, Array.isArray(result) ? result.length : 0);
+		return result;
+	};
+}
+
+type UiLike = {
+	setFooter?: (factory: unknown) => void;
+	setHeader?: (factory: unknown) => void;
+	setEditorComponent?: (factory: unknown) => void;
+	setWidget?: (key: string, contentOrFactory: unknown, options?: unknown) => void;
+};
+
+function instrumentUi(ctx: ExtensionContext): void {
+	const ui = ctx.ui as unknown as UiLike;
+	if (!ui) return;
+
+	if (typeof ui.setFooter === "function") {
+		const original = ui.setFooter.bind(ui) as (factory: unknown) => void;
+		ui.setFooter = (factory: unknown): void => {
+			if (typeof factory !== "function") return original(factory);
+			const wrapped = (...args: unknown[]): unknown => {
+				const result = (factory as (...a: unknown[]) => unknown)(...args);
+				if (result && typeof (result as RenderableComponent).render === "function") {
+					patchRender("footer", result as RenderableComponent);
+				}
+				return result;
+			};
+			return original(wrapped);
+		};
+	}
+
+	if (typeof ui.setHeader === "function") {
+		const original = ui.setHeader.bind(ui) as (factory: unknown) => void;
+		ui.setHeader = (factory: unknown): void => {
+			if (typeof factory !== "function") return original(factory);
+			const wrapped = (...args: unknown[]): unknown => {
+				const result = (factory as (...a: unknown[]) => unknown)(...args);
+				if (result && typeof (result as RenderableComponent).render === "function") {
+					patchRender("header", result as RenderableComponent);
+				}
+				return result;
+			};
+			return original(wrapped);
+		};
+	}
+
+	if (typeof ui.setEditorComponent === "function") {
+		const original = ui.setEditorComponent.bind(ui) as (factory: unknown) => void;
+		ui.setEditorComponent = (factory: unknown): void => {
+			if (typeof factory !== "function") return original(factory);
+			const wrapped = (...args: unknown[]): unknown => {
+				const result = (factory as (...a: unknown[]) => unknown)(...args);
+				if (result && typeof (result as RenderableComponent).render === "function") {
+					patchRender("editor", result as RenderableComponent);
+				}
+				return result;
+			};
+			return original(wrapped);
+		};
+	}
+
+	if (typeof ui.setWidget === "function") {
+		const original = ui.setWidget.bind(ui) as (key: string, content: unknown, options?: unknown) => void;
+		ui.setWidget = (key: string, content: unknown, options?: unknown): void => {
+			if (typeof content !== "function") return original(key, content, options);
+			const wrapped = (...args: unknown[]): unknown => {
+				const result = (content as (...a: unknown[]) => unknown)(...args);
+				if (result && typeof (result as RenderableComponent).render === "function") {
+					patchRender(`widget:${key}`, result as RenderableComponent);
+				}
+				return result;
+			};
+			return original(key, wrapped, options);
+		};
+	}
+}
+
+function instrumentSessionManager(ctx: ExtensionContext): void {
+	const sm = ctx.sessionManager as unknown as { getBranch?: (...args: unknown[]) => unknown };
+	if (!sm || typeof sm.getBranch !== "function") return;
+	const original = sm.getBranch.bind(sm);
+	sm.getBranch = (...args: unknown[]): unknown => {
+		stats.recordGetBranch();
+		return original(...args);
+	};
+}
+
+/**
+ * Patch a writable stream's `write` so we can track per-second byte volume +
+ * per-call wall time. The underlying tty write is what actually paints the
+ * frame on screen — if it's slow, no amount of upstream optimization helps.
+ */
+function instrumentWritable(stream: NodeJS.WriteStream, label: "stdout" | "stderr"): void {
+	const marker = `__sumoTuiDiagnosticsWritePatched_${label}` as const;
+	const target = stream as unknown as { [key: string]: unknown; write: NodeJS.WriteStream["write"] };
+	if (target[marker]) return;
+	const original = target.write.bind(stream) as NodeJS.WriteStream["write"];
+	target.write = ((chunk: string | Uint8Array, ...rest: unknown[]): boolean => {
+		const bytes = typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.byteLength;
+		const start = performance.now();
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const result = (original as unknown as (...args: any[]) => boolean)(chunk, ...(rest as unknown[]));
+		const duration = performance.now() - start;
+		stats.recordWrite(label, bytes, duration);
+		return result;
+	}) as NodeJS.WriteStream["write"];
+	target[marker] = true;
+}
+
+/**
+ * Wrap `process.stdin` `data` events to (a) count keystrokes / bytes, (b)
+ * derive keystroke→paint latency by hooking the next stdout write, and (c)
+ * time the *synchronous* portion of the listener chain that runs in response
+ * to each chunk. (c) is what we need to find the cold-path freeze on `/`
+ * — the difference between (a)+(b) and (c) tells us whether the freeze is
+ * inside the listener chain or downstream (next-tick / setImmediate).
+ */
+function instrumentStdin(): void {
+	const stdin = process.stdin as NodeJS.ReadStream & { __sumoTuiDiagnosticsStdinPatched?: true };
+	if (stdin.__sumoTuiDiagnosticsStdinPatched) return;
+	stdin.__sumoTuiDiagnosticsStdinPatched = true;
+
+	let pendingSince: number | undefined;
+	let pendingBytes = 0;
+
+	// Patch stdin.emit so we can wrap the entire listener chain for "data".
+	// Listeners attached BEFORE this patch as well as AFTER all run inside the
+	// timed window when the emit happens. This catches Pi's input handler.
+	type StdinWithEmit = NodeJS.ReadStream & {
+		emit(eventName: string | symbol, ...args: unknown[]): boolean;
+	};
+	const stdinTyped = stdin as StdinWithEmit;
+	const originalEmit = stdinTyped.emit.bind(stdinTyped);
+	stdinTyped.emit = ((eventName: string | symbol, ...args: unknown[]): boolean => {
+		if (eventName !== "data") return originalEmit(eventName, ...args);
+		const chunk = args[0] as Buffer | string | undefined;
+		const bytes = chunk === undefined ? 0 : typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.byteLength;
+		stats.recordKeystroke(bytes);
+		if (pendingSince === undefined) {
+			pendingSince = performance.now();
+			pendingBytes = bytes;
+		} else {
+			pendingBytes += bytes;
+		}
+		const start = performance.now();
+		const result = originalEmit(eventName, ...args);
+		const duration = performance.now() - start;
+		stats.recordStdinHandler(duration, bytes);
+		return result;
+	}) as StdinWithEmit["emit"];
+
+	// Hook the next stdout write after a keystroke; close the loop and reset.
+	// This is intentionally approximate — we capture latency to the first paint
+	// that follows a stdin event, which is what the user feels.
+	// NOTE: pendingSince/pendingBytes are shared with the emit wrapper above.
+	//
+	const stdoutPatchedKey = "__sumoTuiDiagnosticsKeystrokeLatencyHooked";
+	const stdoutTarget = process.stdout as unknown as { [k: string]: unknown; write: NodeJS.WriteStream["write"] };
+	if (stdoutTarget[stdoutPatchedKey]) return;
+	stdoutTarget[stdoutPatchedKey] = true;
+	const originalWrite = stdoutTarget.write.bind(process.stdout) as NodeJS.WriteStream["write"];
+	stdoutTarget.write = ((chunk: string | Uint8Array, ...rest: unknown[]): boolean => {
+		if (pendingSince !== undefined) {
+			const duration = performance.now() - pendingSince;
+			stats.recordKeystrokeLatency(duration, pendingBytes);
+			pendingSince = undefined;
+			pendingBytes = 0;
+		}
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		return (originalWrite as unknown as (...args: any[]) => boolean)(chunk, ...(rest as unknown[]));
+	}) as NodeJS.WriteStream["write"];
+}
+
+/**
+ * Patch `Module.prototype.require` (CJS) to time every load synchronously.
+ * Catches lazy-loaded modules: jiti compiles a TS file the first time it is
+ * required, which can block the event loop. ESM dynamic imports are not
+ * captured here — they're async and don't block the input handler.
+ *
+ * No-op if anything goes wrong (tests, ESM-only environments, custom loaders).
+ */
+function instrumentModuleLoad(): void {
+	type RequireRecord = {
+		prototype?: { require?: (id: string) => unknown };
+		__sumoTuiDiagnosticsModuleLoadPatched?: true;
+	};
+	try {
+		const require = createRequire(import.meta.url);
+		const Module = require("module") as RequireRecord;
+		if (Module.__sumoTuiDiagnosticsModuleLoadPatched) return;
+		const proto = Module.prototype;
+		if (!proto || typeof proto.require !== "function") return;
+		const original = proto.require;
+		proto.require = function patchedRequire(this: unknown, id: string) {
+			const start = performance.now();
+			try {
+				return original.call(this, id);
+			} finally {
+				const duration = performance.now() - start;
+				stats.recordModuleLoad(id, duration);
+			}
+		};
+		Module.__sumoTuiDiagnosticsModuleLoadPatched = true;
+	} catch {
+		// Ignore — diagnostics must never crash the session.
+	}
+}
+
+/**
+ * Periodically schedules `setImmediate` and measures actual delay vs target.
+ * Any work that blocks the event loop — sync IO, jiti compile, GC pause,
+ * heavy synchronous handlers — inflates the delay. This is the canonical
+ * way to detect "something is blocking the event loop" without knowing what.
+ */
+function startEventLoopLagProbe(): void {
+	let lastTick = performance.now();
+	const probe = (): void => {
+		const now = performance.now();
+		const elapsed = now - lastTick;
+		stats.recordEventLoopLag(elapsed, EVENT_LOOP_PROBE_MS);
+		lastTick = now;
+		const t = setTimeout(probe, EVENT_LOOP_PROBE_MS);
+		t.unref?.();
+	};
+	const t = setTimeout(probe, EVENT_LOOP_PROBE_MS);
+	t.unref?.();
+}
+
+function instrumentPiEvents(pi: ExtensionAPI): void {
+	const marker = "__sumoTuiDiagnosticsRenderPiInstrumented" as const;
+	const target = pi as unknown as { [k: string]: unknown; on: ExtensionAPI["on"] };
+	if (target[marker]) return;
+	const originalOn = target.on.bind(pi) as ExtensionAPI["on"];
+	target.on = ((eventName: string, handler: (...args: unknown[]) => unknown) => {
+		if (typeof handler !== "function") return originalOn(eventName as never, handler as never);
+		const wrapped = (...args: unknown[]): unknown => {
+			stats.recordPiEvent();
+			return handler(...args);
+		};
+		return originalOn(eventName as never, wrapped as never);
+	}) as ExtensionAPI["on"];
+	target[marker] = true;
+}
+
+/**
+ * Install render-time instrumentation. No-op unless diagnostics are enabled.
+ *
+ * Call this BEFORE installing footer/sidebar/top-chrome/editor — otherwise
+ * those modules will have already wired their components through unwrapped
+ * `setFooter` / `setHeader` / `setEditorComponent` / `setWidget` calls.
+ */
+export function installRenderDiagnostics(pi: ExtensionAPI): void {
+	if (!isDiagnosticsEnabled()) return;
+
+	stats.start();
+	logDiagnostic("render_diagnostics_install", {
+		renderThresholdMs: SLOW_RENDER_THRESHOLD_MS,
+		stdoutThresholdMs: SLOW_STDOUT_THRESHOLD_MS,
+		keystrokeThresholdMs: SLOW_KEYSTROKE_THRESHOLD_MS,
+		flushMs: STATS_FLUSH_MS,
+	});
+
+	instrumentWritable(process.stdout, "stdout");
+	instrumentWritable(process.stderr, "stderr");
+	instrumentStdin();
+	instrumentPiEvents(pi);
+	instrumentModuleLoad();
+	startEventLoopLagProbe();
+
+	pi.on("session_start", (_event, ctx) => {
+		if (!ctx.hasUI) return;
+		instrumentUi(ctx);
+		instrumentSessionManager(ctx);
+		logDiagnostic("render_diagnostics_session", { cwd: ctx.cwd });
+	});
+}

--- a/src/session-cache.test.ts
+++ b/src/session-cache.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	getGitBranch,
+	getSessionUsage,
+	invalidateGitBranch,
+	invalidateSessionUsage,
+	refreshGitBranchAsync,
+	refreshGitBranchSync,
+	sessionHasMessages,
+} from "./session-cache.js";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+type Branch = ReturnType<ExtensionContext["sessionManager"]["getBranch"]>;
+
+function makeCtx(branch: ReadonlyArray<unknown> = [], cwd = "/tmp"): ExtensionContext {
+	return {
+		cwd,
+		sessionManager: {
+			getBranch: vi.fn(() => branch as Branch),
+		} as unknown as ExtensionContext["sessionManager"],
+	} as unknown as ExtensionContext;
+}
+
+function assistantEntry(input: number, output: number, costTotal: number) {
+	return {
+		type: "message",
+		message: {
+			role: "assistant",
+			usage: { input, output, cost: { total: costTotal } },
+		},
+	};
+}
+
+describe("session-cache.getSessionUsage", () => {
+	it("sums tokens across assistant entries and reports hasMessages", () => {
+		const ctx = makeCtx([
+			assistantEntry(100, 50, 0.01),
+			{ type: "message", message: { role: "user" } },
+			assistantEntry(200, 25, 0.02),
+		]);
+
+		expect(getSessionUsage(ctx)).toEqual({ input: 300, output: 75, cost: 0.03, hasMessages: true });
+	});
+
+	it("returns zeros and hasMessages=false on empty branches", () => {
+		const ctx = makeCtx([]);
+		expect(getSessionUsage(ctx)).toEqual({ input: 0, output: 0, cost: 0, hasMessages: false });
+		expect(sessionHasMessages(ctx)).toBe(false);
+	});
+
+	it("does not re-walk the branch on subsequent calls within the same context", () => {
+		const branch = [assistantEntry(10, 5, 0.001)];
+		const ctx = makeCtx(branch);
+		const spy = ctx.sessionManager.getBranch as unknown as ReturnType<typeof vi.fn>;
+
+		getSessionUsage(ctx);
+		getSessionUsage(ctx);
+		getSessionUsage(ctx);
+		sessionHasMessages(ctx);
+
+		expect(spy).toHaveBeenCalledTimes(1);
+	});
+
+	it("re-walks after invalidateSessionUsage", () => {
+		const ctx = makeCtx([assistantEntry(10, 5, 0.001)]);
+		const spy = ctx.sessionManager.getBranch as unknown as ReturnType<typeof vi.fn>;
+
+		getSessionUsage(ctx);
+		invalidateSessionUsage(ctx);
+		getSessionUsage(ctx);
+
+		expect(spy).toHaveBeenCalledTimes(2);
+	});
+});
+
+describe("session-cache git branch", () => {
+	it("getGitBranch returns null until refreshed", () => {
+		const ctx = makeCtx([], "/tmp/proj");
+		expect(getGitBranch(ctx)).toBeNull();
+	});
+
+	it("refreshGitBranchSync writes the value into the cache", () => {
+		const ctx = makeCtx([], "/tmp/proj");
+		const runner = vi.fn(() => "main\n");
+
+		expect(refreshGitBranchSync(ctx, runner)).toBe("main");
+		expect(getGitBranch(ctx)).toBe("main");
+		expect(runner).toHaveBeenCalledTimes(1);
+		expect(runner).toHaveBeenCalledWith(["symbolic-ref", "--quiet", "--short", "HEAD"], "/tmp/proj");
+	});
+
+	it("falls back to detached on symbolic-ref failure (sync)", () => {
+		const ctx = makeCtx([], "/tmp/proj");
+		const runner = vi.fn((args: string[]) => {
+			if (args[0] === "symbolic-ref") throw new Error("not on a branch");
+			return "abc1234\n";
+		});
+
+		expect(refreshGitBranchSync(ctx, runner)).toBe("detached");
+	});
+
+	it("returns null when both git invocations fail (sync)", () => {
+		const ctx = makeCtx([], "/tmp/proj");
+		const runner = vi.fn(() => {
+			throw new Error("not a git repo");
+		});
+
+		expect(refreshGitBranchSync(ctx, runner)).toBeNull();
+	});
+
+	it("invalidateGitBranch clears the cached value", () => {
+		const ctx = makeCtx([], "/tmp/proj");
+		const runner = vi.fn(() => "feat/x\n");
+
+		refreshGitBranchSync(ctx, runner);
+		expect(getGitBranch(ctx)).toBe("feat/x");
+
+		invalidateGitBranch(ctx);
+		expect(getGitBranch(ctx)).toBeNull();
+	});
+
+	it("refreshGitBranchAsync updates the cache without blocking the read path", async () => {
+		const ctx = makeCtx([], "/tmp/proj");
+		refreshGitBranchSync(ctx, () => "main\n");
+		expect(getGitBranch(ctx)).toBe("main");
+
+		let resolveAsync: ((value: string) => void) | undefined;
+		const asyncRunner = vi.fn(() => new Promise<string>((res) => {
+			resolveAsync = res;
+		}));
+
+		const pending = refreshGitBranchAsync(ctx, asyncRunner);
+
+		// While the async runner is still pending, getGitBranch must return the
+		// previously cached value — not block, not return null.
+		expect(getGitBranch(ctx)).toBe("main");
+		expect(asyncRunner).toHaveBeenCalledTimes(1);
+
+		resolveAsync?.("feat/y\n");
+		await pending;
+
+		expect(getGitBranch(ctx)).toBe("feat/y");
+	});
+
+	it("refreshGitBranchAsync coalesces concurrent calls", async () => {
+		const ctx = makeCtx([], "/tmp/proj");
+		const asyncRunner = vi.fn(() => Promise.resolve("main\n"));
+
+		const a = refreshGitBranchAsync(ctx, asyncRunner);
+		const b = refreshGitBranchAsync(ctx, asyncRunner);
+		await Promise.all([a, b]);
+
+		expect(asyncRunner).toHaveBeenCalledTimes(1);
+	});
+});

--- a/src/session-cache.ts
+++ b/src/session-cache.ts
@@ -1,0 +1,223 @@
+/**
+ * Per-session memo for values that footer/sidebar/top-chrome would otherwise
+ * recompute on every keystroke.
+ *
+ * Pi triggers a re-render for every input event. Without caching:
+ *   - footer + sidebar each iterate `sessionManager.getBranch()` to sum tokens
+ *     (O(N) on every keystroke)
+ *   - sidebar runs `git symbolic-ref` via `execFileSync` (a fork+exec —
+ *     measured 0–60 ms each on macOS) on every keystroke
+ *   - footer/sidebar/top-chrome each call `getBranch().some(...)` for
+ *     `sessionHasMessages` (another O(N))
+ *
+ * That's 4–5 full branch walks plus a synchronous `git` exec per keypress
+ * on long sessions — visible typing lag.
+ *
+ * This module caches those results behind a WeakMap keyed on the
+ * ExtensionContext, and `installSessionCache(pi)` invalidates entries on
+ * lifecycle events that can change them.
+ */
+
+import { execFile, execFileSync } from "node:child_process";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { renderDiagnosticsCounters } from "./render-diagnostics.js";
+
+export type SessionUsage = {
+	readonly input: number;
+	readonly output: number;
+	readonly cost: number;
+	readonly hasMessages: boolean;
+};
+
+export type GitRunner = (args: string[], cwd: string) => string;
+export type AsyncGitRunner = (args: string[], cwd: string) => Promise<string>;
+
+type Entry = {
+	usage: SessionUsage | undefined;
+	branch: string | null | undefined;
+	asyncRefreshInFlight: boolean;
+};
+
+const cache = new WeakMap<ExtensionContext, Entry>();
+
+function entryFor(ctx: ExtensionContext): Entry {
+	let entry = cache.get(ctx);
+	if (!entry) {
+		entry = { usage: undefined, branch: undefined, asyncRefreshInFlight: false };
+		cache.set(ctx, entry);
+	}
+	return entry;
+}
+
+export function invalidateSessionUsage(ctx: ExtensionContext): void {
+	const e = cache.get(ctx);
+	if (e) e.usage = undefined;
+}
+
+export function invalidateGitBranch(ctx: ExtensionContext): void {
+	const e = cache.get(ctx);
+	if (e) e.branch = undefined;
+}
+
+/**
+ * Compute or return the cached session usage tally. Includes a `hasMessages`
+ * flag so callers don't have to walk the branch a second time just to ask
+ * "is there any message yet?".
+ */
+export function getSessionUsage(ctx: ExtensionContext): SessionUsage {
+	const entry = entryFor(ctx);
+	if (entry.usage) {
+		renderDiagnosticsCounters.noteCacheHit();
+		return entry.usage;
+	}
+	renderDiagnosticsCounters.noteCacheMiss();
+
+	let input = 0;
+	let output = 0;
+	let cost = 0;
+	let hasMessages = false;
+	for (const e of ctx.sessionManager.getBranch()) {
+		if (e.type !== "message") continue;
+		hasMessages = true;
+		// Defensive: tests and edge sessions may carry partial message shapes.
+		// Skip usage tally when fields are missing rather than throwing — the
+		// `hasMessages` flag is the only thing several call sites depend on.
+		const message = e.message as { role?: string; usage?: { input?: number; output?: number; cost?: { total?: number } } } | undefined;
+		if (!message || message.role !== "assistant" || !message.usage) continue;
+		input += message.usage.input ?? 0;
+		output += message.usage.output ?? 0;
+		cost += message.usage.cost?.total ?? 0;
+	}
+	entry.usage = { input, output, cost, hasMessages };
+	return entry.usage;
+}
+
+export function sessionHasMessages(ctx: ExtensionContext): boolean {
+	return getSessionUsage(ctx).hasMessages;
+}
+
+/**
+ * Read-only cached git branch lookup. NEVER invokes `git` — always returns the
+ * value most recently resolved by `refreshGitBranchSync` (called once on
+ * `session_start`) or `refreshGitBranchAsync` (called on `agent_end`).
+ *
+ * Render-path callers (footer, sidebar, input-hints) use this so a `git`
+ * fork+exec can never block a keystroke. Worst case while a refresh is in
+ * flight: callers see the previous value, or `null` if the cache hasn't been
+ * primed yet.
+ */
+export function getGitBranch(ctx: ExtensionContext): string | null {
+	const entry = entryFor(ctx);
+	if (entry.branch === undefined) {
+		renderDiagnosticsCounters.noteBranchCacheMiss();
+		return null;
+	}
+	renderDiagnosticsCounters.noteBranchCacheHit();
+	return entry.branch;
+}
+
+function resolveBranchSync(cwd: string, runGit: GitRunner): string | null {
+	try {
+		return runGit(["symbolic-ref", "--quiet", "--short", "HEAD"], cwd).trim() || null;
+	} catch {
+		try {
+			const detached = runGit(["rev-parse", "--short", "HEAD"], cwd).trim();
+			return detached ? "detached" : null;
+		} catch {
+			return null;
+		}
+	}
+}
+
+async function resolveBranchAsync(cwd: string, runGit: AsyncGitRunner): Promise<string | null> {
+	try {
+		const out = await runGit(["symbolic-ref", "--quiet", "--short", "HEAD"], cwd);
+		return out.trim() || null;
+	} catch {
+		try {
+			const out = await runGit(["rev-parse", "--short", "HEAD"], cwd);
+			const detached = out.trim();
+			return detached ? "detached" : null;
+		} catch {
+			return null;
+		}
+	}
+}
+
+/**
+ * Resolve the git branch synchronously and cache it. Called once on
+ * `session_start` so the first render already sees a value. Acceptable to
+ * block here — we are NOT on the input/render path.
+ */
+export function refreshGitBranchSync(ctx: ExtensionContext, runGit: GitRunner = defaultSyncGitRunner): string | null {
+	const entry = entryFor(ctx);
+	const result = resolveBranchSync(ctx.cwd, runGit);
+	entry.branch = result;
+	return result;
+}
+
+/**
+ * Resolve the git branch off the render thread and update the cache when it
+ * lands. Multiple concurrent calls are coalesced via `asyncRefreshInFlight`.
+ * Called on `agent_end` so any tool-driven `git checkout` is reflected
+ * shortly after the turn completes.
+ */
+export function refreshGitBranchAsync(ctx: ExtensionContext, runGit: AsyncGitRunner = defaultAsyncGitRunner): Promise<string | null> {
+	const entry = entryFor(ctx);
+	if (entry.asyncRefreshInFlight) return Promise.resolve(entry.branch ?? null);
+	entry.asyncRefreshInFlight = true;
+	return resolveBranchAsync(ctx.cwd, runGit)
+		.then((result) => {
+			entry.branch = result;
+			return result;
+		})
+		.finally(() => {
+			entry.asyncRefreshInFlight = false;
+		});
+}
+
+function defaultSyncGitRunner(args: string[], cwd: string): string {
+	return execFileSync("git", args, {
+		cwd,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "ignore"],
+	});
+}
+
+function defaultAsyncGitRunner(args: string[], cwd: string): Promise<string> {
+	return new Promise((resolve, reject) => {
+		execFile("git", args, { cwd, encoding: "utf8" }, (error, stdout) => {
+			if (error) reject(error);
+			else resolve(stdout);
+		});
+	});
+}
+
+/**
+ * Subscribe the cache to lifecycle events that mutate token usage or
+ * `hasMessages`. Mount this once from `extension.ts`, ideally before any
+ * consumer (footer/sidebar/top-chrome) installs.
+ */
+export function installSessionCache(pi: ExtensionAPI): void {
+	const drop = (_event: unknown, ctx: ExtensionContext): void => {
+		invalidateSessionUsage(ctx);
+	};
+	pi.on("session_start", (_event, ctx) => {
+		invalidateSessionUsage(ctx);
+		// Pre-warm the branch synchronously here — we're outside the render path
+		// so the fork+exec is fine, and it means the first keystroke already sees
+		// a real value instead of `null` while the async resolver kicks in.
+		refreshGitBranchSync(ctx);
+	});
+	pi.on("message_start", drop);
+	pi.on("message_end", drop);
+	pi.on("agent_end", (_event, ctx) => {
+		invalidateSessionUsage(ctx);
+		// Refresh the branch off-thread — a turn may have included `git checkout`
+		// via the bash tool. Errors are swallowed; the previous cached value
+		// stays in place if `git` is absent or the cwd is no longer a repo.
+		void refreshGitBranchAsync(ctx).catch(() => undefined);
+	});
+	pi.on("tool_result", drop);
+	pi.on("session_compact", drop);
+}

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,7 +1,11 @@
 import { basename } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import type { Component } from "@mariozechner/pi-tui";
-import { resolveGitBranch } from "./footer.js";
+import {
+	getGitBranch as getCachedGitBranch,
+	getSessionUsage as getCachedSessionUsage,
+	sessionHasMessages as cachedSessionHasMessages,
+} from "./session-cache.js";
 import { createRemnicMemoryClient, type RemnicMemoryClient } from "./memory.js";
 import { MetricsHud } from "./sumo-tui/cathedral/metrics-hud.js";
 import { CancellableWorkerRuntime } from "./sumo-tui/runtime/worker-runtime.js";
@@ -14,6 +18,7 @@ import {
 	type SidebarSubTab,
 } from "./sumo-tui/cathedral/sidebar-rendering.js";
 import { surfaceLine } from "./sumo-tui/cathedral/ansi.js";
+import { logDiagnostic } from "./sumo-tui/runtime/diagnostics.js";
 import { installNonCapturingSidebarOverlay, sidebarOverlayTargetRows } from "./sidebar-placement.js";
 export {
 	SIDEBAR_MIN_TERMINAL_WIDTH,
@@ -150,7 +155,7 @@ function messageText(message: unknown): string {
 }
 
 function sessionHasMessages(ctx: ExtensionContext): boolean {
-	return ctx.sessionManager.getBranch().some((entry) => entry.type === "message");
+	return cachedSessionHasMessages(ctx);
 }
 
 function snapshotFromContext(
@@ -159,18 +164,10 @@ function snapshotFromContext(
 	activeSubTab: SidebarSubTab,
 	metrics: SidebarSnapshot["metrics"],
 ): SidebarSnapshot {
-	let input = 0;
-	let output = 0;
-	let cost = 0;
-	for (const entry of ctx.sessionManager.getBranch()) {
-		if (entry.type !== "message" || entry.message.role !== "assistant") continue;
-		input += entry.message.usage.input;
-		output += entry.message.usage.output;
-		cost += entry.message.usage.cost.total;
-	}
+	const { input, output, cost } = getCachedSessionUsage(ctx);
 
 	const contextWindow = ctx.getContextUsage()?.contextWindow ?? ctx.model?.contextWindow ?? 0;
-	const branch = resolveGitBranch(ctx.cwd) ?? undefined;
+	const branch = getCachedGitBranch(ctx) ?? undefined;
 
 	return {
 		projectName: basename(ctx.cwd) || ctx.cwd,
@@ -222,13 +219,24 @@ export function installSidebar(pi: ExtensionAPI): void {
 		memoryCache = createSidebarMemoryCache(createRemnicMemoryClient());
 
 		ctx.ui.setWidget("sumocode-sidebar-dock", (tui): Component & { dispose(): void } => {
-			requestRender = () => tui.requestRender(true);
+			// `requestRender(false)` lets Pi's differential renderer diff the sidebar
+			// region and emit only changed cells. The hot driver of this trigger is
+			// MetricsHud ticking every 1s — with `force = true`, each tick forces a
+			// full-screen repaint (~25 KB of ANSI/sec idle drain measured in -d).
+			// Sidebar updates do NOT scroll chat, so there are no seam fragments to
+			// mask. Chat-scroll force-redraws stay in chat-viewport-controller.ts
+			// (see #161 Slice B for the proper owned-shell rework).
+			requestRender = () => tui.requestRender();
 			activeMetricsHud?.stop();
 			const metricsHud = new MetricsHud();
 			activeMetricsHud = metricsHud;
-			metricsHud.start(() => {
-				if (sessionHasMessages(ctx)) requestRender?.();
-			});
+			const metricsHudDisabled = process.env.SUMOCODE_DISABLE_METRICS_HUD === "1";
+			logDiagnostic("sidebar_metrics_hud", { disabled: metricsHudDisabled });
+			if (!metricsHudDisabled) {
+				metricsHud.start(() => {
+					if (sessionHasMessages(ctx)) requestRender?.();
+				});
+			}
 			const sidebarComponent: Component = {
 				invalidate(): void {},
 				render(width: number): string[] {

--- a/src/splash.ts
+++ b/src/splash.ts
@@ -21,6 +21,7 @@ import { fileURLToPath } from "node:url";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth } from "@mariozechner/pi-tui";
 import type { Component } from "@mariozechner/pi-tui";
+import { sessionHasMessages as cachedSessionHasMessages } from "./session-cache.js";
 import { CATHEDRAL_TOKENS } from "./tokens.js";
 
 const RESET = "\u001b[0m";
@@ -159,7 +160,7 @@ export function renderSplash(snapshot: SplashSnapshot, width: number, terminalHe
 
 function sessionHasMessages(ctx: ExtensionContext): boolean {
 	try {
-		return ctx.sessionManager.getBranch().some((entry) => entry.type === "message");
+		return cachedSessionHasMessages(ctx);
 	} catch {
 		return false;
 	}

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
@@ -99,6 +99,20 @@ describe("ChatViewportController", () => {
 		portraitWide.root.dispose();
 	});
 
+	it("caches repeated same-geometry viewport renders until chat content changes", async () => {
+		const { root, runtime, controller } = await makeController({ terminalRows: 12, terminalColumns: 80 });
+
+		expect(controller.render(80)).toHaveLength(8);
+		expect(controller.render(80)).toHaveLength(8);
+		expect(runtime.renderCalls).toHaveLength(1);
+
+		controller.handleAgentEvent({ type: "message_start", message: { role: "user", content: "hello" } });
+		controller.render(80);
+		controller.render(80);
+		expect(runtime.renderCalls).toHaveLength(2);
+		root.dispose();
+	});
+
 	it("translates wheel and jump-to-bottom input into local viewport repaint", async () => {
 		const { root, chat, runtime, controller } = await makeController({ terminalRows: 12, terminalColumns: 80 });
 		for (let index = 0; index < 50; index += 1) chat.addMessage("user", `message ${index}`);
@@ -188,6 +202,44 @@ describe("ChatViewportController", () => {
 		expect(message?.role).toBe("sumo");
 		expect(message?.blocks?.[0]).toMatchObject({ type: "tool", tool: { id: "tc1", name: "bash", status: "pending" } });
 		root.dispose();
+	});
+
+	it("coalesces bridge streaming render requests", async () => {
+		vi.useFakeTimers();
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const chat = ChatPager.create(yoga, root);
+		const requestRender = vi.fn();
+		const host = {
+			ui: { terminal: { rows: 24, columns: 120 }, requestRender },
+			chatContainer: { render: vi.fn(() => []), clear: vi.fn(), invalidate: vi.fn() },
+		};
+		let controls: { scheduleRender(): void; setStreamingMode(enabled: boolean): void } | undefined;
+		const runtime = {
+			getSnapshot: () => ({ chat }),
+			setExternalRenderControls: vi.fn((next) => { controls = next; }),
+			renderChatLines: vi.fn(() => []),
+			writeChatViewport: vi.fn(() => true),
+			requestRender: vi.fn(),
+			setEmptyChatQuoteState: vi.fn(),
+			noteUserMessage: vi.fn(),
+		};
+
+		const cleanup = installChatViewportBridge(host, runtime);
+		controls?.setStreamingMode(true);
+		controls?.scheduleRender();
+		controls?.scheduleRender();
+		controls?.scheduleRender();
+
+		expect(requestRender).toHaveBeenCalledTimes(1);
+		vi.advanceTimersByTime(100);
+		expect(requestRender).toHaveBeenCalledTimes(2);
+		controls?.setStreamingMode(false);
+		expect(requestRender).toHaveBeenCalledTimes(3);
+
+		cleanup?.();
+		root.dispose();
+		vi.useRealTimers();
 	});
 
 	it("mirrors Pi tool expansion state into retained chat tool blocks", async () => {

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -18,6 +18,8 @@ import { sidebarGutterWidth } from "../../sidebar-placement.js";
 const CHAT_VIEWPORT_BRIDGE_INSTALLED = Symbol("sumo-tui.chat-viewport-bridge-installed");
 const PORTRAIT_STATUS_MIN_WIDTH = 80;
 const PORTRAIT_CHAT_GUTTER_MIN_WIDTH = 80;
+const STREAMING_CHAT_RENDER_COALESCE_MS = 100;
+const MOUSE_CHAT_RENDER_COALESCE_MS = 50;
 
 interface PiRenderableComponent {
 	render(width: number): string[];
@@ -197,6 +199,11 @@ export class ChatViewportController {
 	private lastChatWidth = 1;
 	private lastChatHeight = 1;
 	private pendingMouseInput = "";
+	private pendingMouseRender: ReturnType<typeof setTimeout> | undefined;
+	private lastMouseRenderAt = 0;
+	private lastMouseInputAt = 0;
+	private renderRevision = 0;
+	private cachedRender: { revision: number; requestedWidth: number; chatTop: number; chatWidth: number; chatHeight: number; terminalRows: number; lines: string[] } | undefined;
 
 	public constructor(
 		private readonly runtime: ChatViewportRuntime,
@@ -224,13 +231,31 @@ export class ChatViewportController {
 			: portraitGutterVisible
 				? Math.max(1, terminalWidth - 1)
 				: terminalWidth;
+		const chatTop = this.computeChatTop(effectiveWidth);
+		const chatHeight = this.computeChatHeight(effectiveWidth);
 		this.lastChatWidth = effectiveWidth;
-		this.lastChatTop = this.computeChatTop(this.lastChatWidth);
-		this.lastChatHeight = this.computeChatHeight(this.lastChatWidth);
-		return this.runtime.renderChatLines(this.lastChatWidth, this.lastChatHeight);
+		this.lastChatTop = chatTop;
+		this.lastChatHeight = chatHeight;
+		const cached = this.cachedRender;
+		if (
+			cached &&
+			cached.revision === this.renderRevision &&
+			cached.requestedWidth === terminalWidth &&
+			cached.chatTop === chatTop &&
+			cached.chatWidth === effectiveWidth &&
+			cached.chatHeight === chatHeight &&
+			cached.terminalRows === terminalHeight
+		) {
+			logDiagnostic("chat_viewport_render_cache_hit", { width: effectiveWidth, height: chatHeight, revision: this.renderRevision });
+			return [...cached.lines];
+		}
+		const lines = this.runtime.renderChatLines(this.lastChatWidth, this.lastChatHeight);
+		this.cachedRender = { revision: this.renderRevision, requestedWidth: terminalWidth, chatTop, chatWidth: effectiveWidth, chatHeight, terminalRows: terminalHeight, lines: [...lines] };
+		return lines;
 	}
 
 	public clear(): void {
+		this.markRenderDirty();
 		this.chat.clearMessages();
 		this.lastAssistantText = "";
 		this.liveAssistant = undefined;
@@ -256,7 +281,7 @@ export class ChatViewportController {
 			for (const event of parsed.events) {
 				mouseViewportDirty = this.handleMouse(event, { deferRender: true }) || mouseViewportDirty;
 			}
-			if (mouseViewportDirty) this.renderChatViewportOrRequest();
+			if (mouseViewportDirty) this.scheduleMouseChatViewportRender();
 
 			// Strip every complete SGR mouse sequence — including wheel-left/right
 			// (button codes 66/67) and any other variants the parser may not
@@ -298,12 +323,14 @@ export class ChatViewportController {
 
 		const keyEvent = chatScrollCommandFromInput(nextData);
 		if (keyEvent && this.chat.handleKey(keyEvent)) {
+			this.markRenderDirty();
 			this.renderChatViewportOrRequest();
 			return { consume: true };
 		}
 
 		const selectionKey = selectionCopyKeyFromInput(nextData);
 		if (selectionKey && this.runtime.handleSelectionKey?.(selectionKey, this.lastChatWidth, this.lastChatHeight) === true) {
+			this.markRenderDirty();
 			this.renderChatViewportOrRequest();
 			return { consume: true };
 		}
@@ -342,6 +369,7 @@ export class ChatViewportController {
 		// replay; `replaceViewModels()` resets the chat-side scroll/banner state.
 		const profile = this.runtime.startResumeProfile?.();
 		const messages = measureMaybe(profile, "session_scan", () => sessionMessages(sessionContext));
+		this.markRenderDirty();
 		this.runtime.setEmptyChatQuoteState({ active: messages.length === 0, userMessageCount: countUserMessages(messages) });
 		const transcript = measureMaybe(profile, "transcript_model", () => transcriptFromSessionContext(sessionContext));
 		const stats = measureMaybe(profile, "transcript_hydrate", () => this.chat.replaceViewModels(transcript.messages));
@@ -356,6 +384,7 @@ export class ChatViewportController {
 	}
 
 	private handleMessageStart(message: unknown): void {
+		this.markRenderDirty();
 		const role = asRecord(message)?.role;
 		if (role === "user") {
 			this.liveAssistant = undefined;
@@ -377,14 +406,17 @@ export class ChatViewportController {
 
 	private handleMessageUpdate(message: unknown, assistantMessageEvent: unknown): void {
 		if (asRecord(message)?.role !== "assistant") return;
+		this.markRenderDirty();
 		const streamEvent = asRecord(assistantMessageEvent);
 		if (streamEvent?.type === "text_delta" && typeof streamEvent.delta === "string") {
+			this.chat.beginStreaming();
 			this.appendAssistantTextDelta(streamEvent.delta);
 			return;
 		}
 		const viewModel = chatMessageViewModelFromPiMessage(message);
 		const text = viewModel ? chatMessageViewModelToPlainText(viewModel) : textFromAgentMessage(message);
 		if (text.length === 0 || text === this.lastAssistantText) return;
+		this.chat.beginStreaming();
 		if (viewModel) {
 			this.liveAssistant = { ...viewModel, role: "sumo", displayName: "SUMO" };
 			this.liveAssistantBlocks = [...viewModel.blocks];
@@ -397,6 +429,7 @@ export class ChatViewportController {
 	}
 
 	private handleMessageEnd(message: unknown): void {
+		this.markRenderDirty();
 		if (asRecord(message)?.role === "assistant") {
 			const viewModel = chatMessageViewModelFromPiMessage(message);
 			const text = viewModel ? chatMessageViewModelToPlainText(viewModel) : textFromAgentMessage(message);
@@ -469,6 +502,7 @@ export class ChatViewportController {
 			return false;
 		}
 		const beforeOffset = this.chat.scrollBox.scrollOffset;
+		this.lastMouseInputAt = Date.now();
 		const handled = this.chat.handleMouseEvent(localEvent);
 		const handledSelection = this.runtime.handleSelectionMouse?.(localEvent, this.lastChatWidth, this.lastChatHeight) === true;
 		logDiagnostic("mouse_dispatch", {
@@ -483,14 +517,49 @@ export class ChatViewportController {
 			scrollOffsetBefore: beforeOffset,
 			scrollOffsetAfter: this.chat.scrollBox.scrollOffset,
 		});
+		if (handled || handledSelection) this.markRenderDirty();
 		if ((handled || handledSelection) && options.deferRender !== true) this.renderChatViewportOrRequest();
 		return handled || handledSelection;
+	}
+
+	public markRenderDirty(): void {
+		this.renderRevision += 1;
+		this.cachedRender = undefined;
 	}
 
 	private renderChatViewportOrRequest(): void {
 		if (!this.runtime.writeChatViewport(this.lastChatTop, 0, this.lastChatWidth, this.lastChatHeight)) {
 			this.runtime.requestRender();
 		}
+	}
+
+	public shouldCoalesceChatRenderAsMouse(): boolean {
+		return Date.now() - this.lastMouseInputAt <= MOUSE_CHAT_RENDER_COALESCE_MS;
+	}
+
+	public scheduleMouseChatViewportRender(): void {
+		const now = Date.now();
+		const elapsed = now - this.lastMouseRenderAt;
+		if (elapsed >= MOUSE_CHAT_RENDER_COALESCE_MS && !this.pendingMouseRender) {
+			this.lastMouseRenderAt = now;
+			logDiagnostic("chat_viewport_mouse_render_request", { source: "mouse", coalesceMs: MOUSE_CHAT_RENDER_COALESCE_MS });
+			this.renderChatViewportOrRequest();
+			return;
+		}
+		if (this.pendingMouseRender) return;
+		const delay = Math.max(0, MOUSE_CHAT_RENDER_COALESCE_MS - elapsed);
+		this.pendingMouseRender = setTimeout(() => {
+			this.pendingMouseRender = undefined;
+			this.lastMouseRenderAt = Date.now();
+			logDiagnostic("chat_viewport_mouse_render_request", { source: "mouse", coalesceMs: MOUSE_CHAT_RENDER_COALESCE_MS });
+			this.renderChatViewportOrRequest();
+		}, delay);
+		this.pendingMouseRender.unref?.();
+	}
+
+	public dispose(): void {
+		if (this.pendingMouseRender) clearTimeout(this.pendingMouseRender);
+		this.pendingMouseRender = undefined;
 	}
 
 	private computeChatTop(width: number): number {
@@ -543,6 +612,36 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 	const originalRenderSessionContext = target.renderSessionContext?.bind(target);
 	const originalSetToolsExpanded = target.setToolsExpanded?.bind(target);
 	const removeInputListener = target.ui?.addInputListener?.((data) => controller.handleInput(data));
+	let streaming = false;
+	let pendingStreamingRender: ReturnType<typeof setTimeout> | undefined;
+	let lastStreamingRenderAt = 0;
+	const requestForcedRender = (source: "immediate" | "streaming" | "stream-end"): void => {
+		lastStreamingRenderAt = Date.now();
+		logDiagnostic("chat_viewport_render_request", { source, force: true });
+		target.ui?.requestRender?.(true);
+	};
+	const flushPendingStreamingRender = (): void => {
+		if (pendingStreamingRender) {
+			clearTimeout(pendingStreamingRender);
+			pendingStreamingRender = undefined;
+		}
+		requestForcedRender("stream-end");
+	};
+	const scheduleStreamingRender = (): void => {
+		const now = Date.now();
+		const elapsed = now - lastStreamingRenderAt;
+		if (elapsed >= STREAMING_CHAT_RENDER_COALESCE_MS && !pendingStreamingRender) {
+			requestForcedRender("streaming");
+			return;
+		}
+		if (pendingStreamingRender) return;
+		const delay = Math.max(0, STREAMING_CHAT_RENDER_COALESCE_MS - elapsed);
+		pendingStreamingRender = setTimeout(() => {
+			pendingStreamingRender = undefined;
+			requestForcedRender("streaming");
+		}, delay);
+		pendingStreamingRender.unref?.();
+	};
 
 	runtime.setExternalRenderControls({
 		// Pi's normal differential renderer optimizes line shifts with terminal
@@ -550,9 +649,25 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 		// the left content while the sidebar/footer remain fixed; terminal scroll
 		// sequences move the whole screen and leave stale sidebar/chat fragments.
 		// Force Pi's full redraw path for retained chat updates until Sumo owns the
-		// entire root renderer.
-		scheduleRender: () => target.ui?.requestRender?.(true),
-		setStreamingMode: () => target.ui?.requestRender?.(true),
+		// entire root renderer, but coalesce token-stream bursts so input remains
+		// responsive while the assistant is streaming.
+		scheduleRender: () => {
+			if (streaming) {
+				scheduleStreamingRender();
+				return;
+			}
+			if (controller.shouldCoalesceChatRenderAsMouse()) {
+				controller.scheduleMouseChatViewportRender();
+				return;
+			}
+			requestForcedRender("immediate");
+		},
+		setStreamingMode: (enabled) => {
+			if (streaming === enabled) return;
+			streaming = enabled;
+			logDiagnostic("chat_viewport_streaming_mode", { enabled, coalesceMs: STREAMING_CHAT_RENDER_COALESCE_MS });
+			if (!enabled) flushPendingStreamingRender();
+		},
 	});
 	chatContainer.render = (width: number): string[] => controller.render(width);
 	chatContainer.clear = (): void => {
@@ -560,6 +675,7 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 		originalClear?.();
 	};
 	chatContainer.invalidate = (): void => {
+		controller.markRenderDirty();
 		originalInvalidate?.();
 		runtime.requestRender();
 	};
@@ -575,6 +691,7 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 	}
 	if (originalSetToolsExpanded) {
 		target.setToolsExpanded = (expanded: boolean): void => {
+			controller.markRenderDirty();
 			snapshot.chat.setToolExpansion(expanded);
 			originalSetToolsExpanded(expanded);
 		};
@@ -593,6 +710,9 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 	}
 
 	const cleanup = (): void => {
+		if (pendingStreamingRender) clearTimeout(pendingStreamingRender);
+		pendingStreamingRender = undefined;
+		controller.dispose();
 		removeInputListener?.();
 		runtime.setExternalRenderControls(undefined);
 		if (originalRender) chatContainer.render = originalRender;

--- a/src/sumo-tui/widgets/chat-pager.ts
+++ b/src/sumo-tui/widgets/chat-pager.ts
@@ -142,6 +142,10 @@ export class ChatPager extends SumoNode {
 		};
 	}
 
+	public beginStreaming(): void {
+		this.renderControls.setStreamingMode(true);
+	}
+
 	public appendToLast(chunk: string): void {
 		if (chunk.length === 0) return;
 		const last = this.getLastMessage();
@@ -154,7 +158,7 @@ export class ChatPager extends SumoNode {
 		last.appendText(chunk);
 		const afterHeight = last.getEstimatedHeight(width);
 		this.scrollBox.notifyContentChanged(Math.max(0, afterHeight - beforeHeight), Math.max(0, beforeHeight - afterHeight));
-		this.renderControls.setStreamingMode(true);
+		this.beginStreaming();
 		this.scheduleRender();
 	}
 

--- a/src/top-chrome.ts
+++ b/src/top-chrome.ts
@@ -19,8 +19,9 @@
  * Pure render only. Pi-glue is in `installTopChrome` below.
  */
 
-import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { isTopChromeHidden } from "./commands/tabs.js";
+import { sessionHasMessages as cachedSessionHasMessages } from "./session-cache.js";
 import { CATHEDRAL_TOKENS, type SumoCodeState } from "./tokens.js";
 
 const RESET = "\u001b[0m";
@@ -276,6 +277,17 @@ export function installTopChrome(pi: ExtensionAPI, loader?: TopChromeLoader): vo
 
 function sessionHasMessages(ctx: { sessionManager?: { getBranch?: () => unknown[] } }): boolean {
 	try {
+		// Route through the shared session cache when ctx looks like a real
+		// ExtensionContext so we don't re-walk the branch on every header render.
+		// Falls back to the inline traversal for the test mock shape that only
+		// supplies `{ sessionManager: { getBranch } }`.
+		if (
+			typeof (ctx as { cwd?: unknown }).cwd === "string" &&
+			ctx.sessionManager &&
+			typeof ctx.sessionManager.getBranch === "function"
+		) {
+			return cachedSessionHasMessages(ctx as ExtensionContext);
+		}
 		return ctx.sessionManager?.getBranch?.().some((entry) => (entry as { type?: string }).type === "message") ?? false;
 	} catch {
 		return false;


### PR DESCRIPTION
## Summary

- add diagnostics for render/input latency, stdout volume, event-loop lag, module loads, and cache hit rates
- cache session usage / branch / has-messages reads so chrome render paths avoid repeated branch walks and sync git lookups
- coalesce SumoTUI chat viewport redraws during assistant streaming and mouse/scroll bursts
- cache repeated same-geometry chat viewport renders within Pi render passes
- add targeted tests for session cache, render diagnostics, chat viewport render caching, and streaming coalescing

## Measured impact from local diagnostics

Before coalescing, a random burst trace showed:

- `2446` `chat_viewport` frames over ~142s (~17.2fps)
- ~66MB stdout (~456KB/s)
- ~198KB stdout per key overall
- event-loop lag up to ~18s

After streaming coalescing, normal typing trace showed:

- ~2.8 `chat_viewport` fps
- ~26KB/s stdout
- ~6KB stdout per key
- key-to-paint avg ~6.7ms

Follow-up traces showed remaining repeated same-geometry render calls (~3-4 frames/request), so this PR adds a controller-level render cache to dedupe those composites.

## Validation

Passed:

```bash
pnpm exec tsc --noEmit
pnpm test
pnpm build
pnpm visual:ci
```

`pnpm test` result: 91 files / 603 tests passed.

Known local integration status:

```bash
pnpm test:integration
```

failed 3 tests locally:

- `test/integration/mouse-scroll.test.ts` — SGR mouse bytes were echoed before the Pi session loop/bridge was fully installed in the PTY capture
- `test/integration/narrow-width.test.ts` ×2 — debug/resume-budget log lines exceeded narrow-width expectations

These failures look like existing PTY/logging harness issues on this branch rather than TypeScript/unit regressions, but they should be reviewed before merge.