### PR TITLE
Fix owned-shell splash centering and autocomplete cursor

### DIFF
--- a/scripts/visual-v2/runtime-capture.mjs
+++ b/scripts/visual-v2/runtime-capture.mjs
@@ -44,6 +44,14 @@ export async function captureRuntimeScenario(scenario) {
 
 	const settleMs = Math.max(0, Number(runtime.settleMs ?? 500));
 	await sleep(settleMs);
+	const emptyOutputGraceMs = Math.max(0, Number(runtime.emptyOutputGraceMs ?? 5000));
+	if (!exited && output.trim().length === 0 && emptyOutputGraceMs > 0) {
+		// CI runners can be slow to reach the first retained-frame write, especially
+		// for no-input splash captures. Do not fail immediately at settleMs just
+		// because startup has not emitted bytes yet; wait a short grace window for
+		// first output while keeping genuinely silent captures diagnosable.
+		await sleep(emptyOutputGraceMs);
+	}
 	const captured = output;
 	const plain = stripAnsi(captured);
 	const rejection = findRejection(plain, scenario.rejectIfOutputMatches ?? []);
@@ -57,7 +65,9 @@ export async function captureRuntimeScenario(scenario) {
 	if (rejection) {
 		throw new Error(`Runtime capture ${scenario.id} matched rejection pattern ${JSON.stringify(rejection.pattern)}. Snippet: ${JSON.stringify(rejection.snippet)}`);
 	}
-	if (captured.trim().length === 0) throw new Error(`Runtime capture ${scenario.id} produced no terminal output`);
+	if (captured.trim().length === 0) {
+		throw new Error(`Runtime capture ${scenario.id} produced no terminal output after settleMs=${settleMs} and emptyOutputGraceMs=${emptyOutputGraceMs}`);
+	}
 	if (exited && exitInfo?.exitCode && exitInfo.exitCode !== 0) {
 		throw new Error(`Runtime capture ${scenario.id} exited early with code ${exitInfo.exitCode}`);
 	}
@@ -72,6 +82,7 @@ export async function captureRuntimeScenario(scenario) {
 			cols: dimensions.cols,
 			rows: dimensions.rows,
 			settleMs,
+			emptyOutputGraceMs,
 			inputCount: inputs.length,
 			exited,
 			exitInfo,

--- a/src/sumo-tui/cathedral/splash-tree.test.ts
+++ b/src/sumo-tui/cathedral/splash-tree.test.ts
@@ -5,7 +5,7 @@ import { createSplashTree, defaultSplashSnapshot, getSplashContentHeight } from 
 
 describe("createSplashTree", () => {
 	for (const height of [30, 60, 100]) {
-		it(`bottom-aligns splash content at ${height} rows so it stays close to Pi's editor`, async () => {
+		it(`centers splash content at ${height} rows`, async () => {
 			const yoga = await loadYoga();
 			const root = new SumoNode(yoga.Node.create());
 			root.flexDirection = FLEX_DIRECTION_COLUMN;
@@ -18,9 +18,12 @@ describe("createSplashTree", () => {
 
 			const contentHeight = getSplashContentHeight(snapshot, 120);
 			const freeRows = Math.max(0, height - contentHeight);
-			expect(tree.bottomSpacer.getComputedHeight()).toBe(0);
-			expect(tree.topSpacer.getComputedHeight()).toBe(freeRows);
-			expect(tree.content.getComputedTop()).toBe(freeRows);
+			const expectedContentTop = Math.floor(freeRows / 2);
+			const expectedBottom = Math.floor(freeRows / 2);
+			// Yoga may assign the odd rounding row to the top spacer's computed
+			// height, but the content's actual top remains the visual center point.
+			expect(tree.bottomSpacer.getComputedHeight()).toBe(expectedBottom);
+			expect(tree.content.getComputedTop()).toBe(expectedContentTop);
 			root.dispose();
 		});
 	}

--- a/src/sumo-tui/cathedral/splash-tree.ts
+++ b/src/sumo-tui/cathedral/splash-tree.ts
@@ -66,9 +66,8 @@ export function createSplashTree(yoga: Yoga, parent: SumoNode | undefined, snaps
 	content.flexShrink = 0;
 
 	const bottomSpacer = new SumoNode(yoga.Node.create(), root);
-	bottomSpacer.flexGrow = 0;
-	bottomSpacer.flexShrink = 0;
-	bottomSpacer.height = 0;
+	bottomSpacer.flexGrow = 1;
+	bottomSpacer.flexShrink = 1;
 
 	return {
 		root,

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
@@ -306,6 +306,77 @@ describe("ChatViewportController", () => {
 		root.dispose();
 	});
 
+	it("short-circuits Pi chat rendering when owned-shell becomes active after bridge install", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const chat = ChatPager.create(yoga, root);
+		let ownedShellActive = false;
+		const originalStatusRender = vi.fn((_width: number) => ["Working..."]);
+		const host = {
+			ui: { terminal: { rows: 100, columns: 60 }, requestRender: vi.fn() },
+			chatContainer: { render: vi.fn((_width: number) => ["legacy"]), clear: vi.fn(), invalidate: vi.fn() },
+			statusContainer: { render: originalStatusRender },
+		};
+		const runtime = {
+			getSnapshot: () => ({ chat }),
+			setExternalRenderControls: vi.fn(),
+			renderChatLines: vi.fn(() => ["retained"]),
+			writeChatViewport: vi.fn(() => true),
+			requestRender: vi.fn(),
+			setEmptyChatQuoteState: vi.fn(),
+			noteUserMessage: vi.fn(),
+			isOwnedShellActive: () => ownedShellActive,
+		};
+
+		const cleanup = installChatViewportBridge(host, runtime);
+		ownedShellActive = true;
+
+		expect(host.chatContainer.render(60)).toEqual([]);
+		expect(runtime.renderChatLines).not.toHaveBeenCalled();
+		expect(host.statusContainer.render(60)).toEqual(["Working..."]);
+		expect(originalStatusRender).toHaveBeenCalledWith(60);
+
+		cleanup?.();
+		expect(host.chatContainer.render(60)).toEqual(["legacy"]);
+		root.dispose();
+	});
+
+	it("does not install bottom chrome spacers when owned-shell wires after bridge install", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const chat = ChatPager.create(yoga, root);
+		let ownedShellActive = false;
+		const footer = rows(1);
+		const host = {
+			ui: {
+				terminal: { rows: 100, columns: 60 },
+				children: [footer],
+				requestRender: vi.fn(),
+			},
+			chatContainer: { render: vi.fn((_width: number) => []), clear: vi.fn(), invalidate: vi.fn() },
+			footer,
+		};
+		const runtime = {
+			getSnapshot: () => ({ chat }),
+			setExternalRenderControls: vi.fn(),
+			renderChatLines: vi.fn(() => []),
+			writeChatViewport: vi.fn(() => true),
+			requestRender: vi.fn(),
+			setEmptyChatQuoteState: vi.fn(),
+			noteUserMessage: vi.fn(),
+			isOwnedShellActive: () => ownedShellActive,
+		};
+
+		const cleanup = installChatViewportBridge(host, runtime);
+		ownedShellActive = true;
+		await new Promise((resolve) => setTimeout(resolve, 0));
+
+		expect(host.ui.children).toEqual([footer]);
+
+		cleanup?.();
+		root.dispose();
+	});
+
 	it("suppresses Pi status loader row in portrait while preserving landscape", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -763,18 +763,37 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 	const originalRenderSessionContext = target.renderSessionContext?.bind(target);
 	const originalSetToolsExpanded = target.setToolsExpanded?.bind(target);
 	const removeInputListener = target.ui?.addInputListener?.((data) => controller.handleInput(data));
-	// Owned-shell prevents Pi from rendering chat/status containers itself, so
-	// the spacer workaround that pushed the input/footer down inside Pi's flow
-	// is unnecessary and would only consume rows that owned-shell already
-	// reserves through Yoga.
-	const ownedShellActive = runtime.isOwnedShellActive?.() === true;
-	const removeBottomChromeSpacers = ownedShellActive ? undefined : installBottomChromeSpacers(target, snapshot.chat);
+	const isOwnedShellActive = (): boolean => runtime.isOwnedShellActive?.() === true;
+	// Owned-shell is wired after this bridge is installed during normal startup.
+	// Do not snapshot the state here: resolve it lazily at each mutation point so
+	// the legacy hybrid spacers/overrides stay disabled once OwnedShellRenderer is
+	// actually active.
+	let removeBottomChromeSpacers: (() => void) | undefined;
+	let pendingBottomChromeSpacerReconcile: ReturnType<typeof setTimeout> | undefined;
+	const reconcileBottomChromeSpacers = (): void => {
+		if (isOwnedShellActive()) {
+			removeBottomChromeSpacers?.();
+			removeBottomChromeSpacers = undefined;
+			return;
+		}
+		removeBottomChromeSpacers ??= installBottomChromeSpacers(target, snapshot.chat);
+	};
+	const scheduleBottomChromeSpacerReconcile = (): void => {
+		if (pendingBottomChromeSpacerReconcile) return;
+		pendingBottomChromeSpacerReconcile = setTimeout(() => {
+			pendingBottomChromeSpacerReconcile = undefined;
+			reconcileBottomChromeSpacers();
+		}, 0);
+		pendingBottomChromeSpacerReconcile.unref?.();
+	};
+	scheduleBottomChromeSpacerReconcile();
 	let streaming = false;
 	let pendingStreamingRender: ReturnType<typeof setTimeout> | undefined;
 	let lastStreamingRenderAt = 0;
 	const requestForcedRender = (source: "immediate" | "streaming" | "stream-end"): void => {
 		lastStreamingRenderAt = Date.now();
-		logDiagnostic("chat_viewport_render_request", { source, force: true, ownedShell: ownedShellActive });
+		reconcileBottomChromeSpacers();
+		logDiagnostic("chat_viewport_render_request", { source, force: true, ownedShell: isOwnedShellActive() });
 		// In owned-shell mode Pi's render loop is replaced. Calling its
 		// requestRender still triggers our `tui.doRender` override (which paints
 		// the owned-shell frame), so the schedule path is the same.
@@ -830,22 +849,25 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 		},
 	});
 	// Owned-shell mounts ChatPager directly into its Yoga tree and bypasses
-	// Pi's render pipeline. Overriding chatContainer.render here would do
-	// nothing visible and only burn CPU on every Pi render-loop tick. In
-	// hybrid mode we still need it so Pi paints the controller's rendered
-	// chat lines into its own line flow.
-	if (!ownedShellActive) {
-		chatContainer.render = (width: number): string[] => controller.render(width);
-		if (statusContainer && originalStatusRender) {
-			statusContainer.render = (width: number): string[] => {
-				const terminalWidth = target.ui?.terminal?.columns ?? width;
-				// Portrait V1 Bible rhythm reserves the pre-input row as breathing
-				// space. Suppress Pi's loader/status row at compact widths so the
-				// input, hint, and footer land on the target rows.
-				if (terminalWidth < PORTRAIT_STATUS_MIN_WIDTH) return [];
-				return originalStatusRender(width);
-			};
-		}
+	// Pi's render pipeline. The bridge may install before owned-shell is wired,
+	// so keep the override dynamic: in owned-shell mode, never run the expensive
+	// retained chat render just to hand Pi dead bytes.
+	chatContainer.render = (width: number): string[] => {
+		reconcileBottomChromeSpacers();
+		if (isOwnedShellActive()) return [];
+		return controller.render(width);
+	};
+	if (statusContainer && originalStatusRender) {
+		statusContainer.render = (width: number): string[] => {
+			reconcileBottomChromeSpacers();
+			if (isOwnedShellActive()) return originalStatusRender(width);
+			const terminalWidth = target.ui?.terminal?.columns ?? width;
+			// Portrait V1 Bible rhythm reserves the pre-input row as breathing
+			// space. Suppress Pi's loader/status row at compact widths so the
+			// input, hint, and footer land on the target rows.
+			if (terminalWidth < PORTRAIT_STATUS_MIN_WIDTH) return [];
+			return originalStatusRender(width);
+		};
 	}
 	chatContainer.clear = (): void => {
 		controller.clear();
@@ -879,15 +901,15 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 	const cleanup = (): void => {
 		if (pendingStreamingRender) clearTimeout(pendingStreamingRender);
 		pendingStreamingRender = undefined;
+		if (pendingBottomChromeSpacerReconcile) clearTimeout(pendingBottomChromeSpacerReconcile);
+		pendingBottomChromeSpacerReconcile = undefined;
 		controller.dispose();
 		removeInputListener?.();
 		removeBottomChromeSpacers?.();
 		runtime.setExternalRenderControls(undefined);
-		if (!ownedShellActive) {
-			if (originalRender) chatContainer.render = originalRender;
-			else delete chatContainer.render;
-			if (statusContainer && originalStatusRender) statusContainer.render = originalStatusRender;
-		}
+		if (originalRender) chatContainer.render = originalRender;
+		else delete chatContainer.render;
+		if (statusContainer && originalStatusRender) statusContainer.render = originalStatusRender;
 		if (originalClear) chatContainer.clear = originalClear;
 		else delete chatContainer.clear;
 		if (originalInvalidate) chatContainer.invalidate = originalInvalidate;

--- a/src/sumo-tui/pi-compat/owned-shell-renderer.ts
+++ b/src/sumo-tui/pi-compat/owned-shell-renderer.ts
@@ -31,6 +31,7 @@ import {
 	DIRECTION_LTR,
 	FLEX_DIRECTION_COLUMN,
 	FLEX_DIRECTION_ROW,
+	JUSTIFY_CENTER,
 	type Yoga,
 } from "../layout/yoga.js";
 import { CellBuffer, type Rect } from "../render/buffer.js";
@@ -103,6 +104,7 @@ export interface OwnedShellRendererOptions {
 	readonly sidebarPublication?: () => SidebarPublication | undefined;
 }
 
+const SPLASH_EDITOR_FRAME_WIDTH = 60;
 const SHELL_BLANK_ROW = 1;
 const SHELL_HINT_ROW = 1;
 const SHELL_FOOTER_GAP_ROW = 1;
@@ -127,7 +129,10 @@ export class OwnedShellRenderer {
 	private lastFrame: CellBuffer | undefined;
 	private previousFrame: CellBuffer | undefined;
 	private readonly headerLeaf: PiComponentLeaf;
+	private readonly editorRow: SumoNode;
+	private readonly editorLeftSpacer: SumoNode;
 	private readonly editorLeaf: PiEditorLeaf;
+	private readonly editorRightSpacer: SumoNode;
 	private readonly hintLeaf: PiComponentLeaf;
 	private readonly footerLeaf: PiComponentLeaf;
 	private readonly chatRow: SumoNode;
@@ -193,7 +198,19 @@ export class OwnedShellRenderer {
 		// render through the same Yoga leaf. PiEditorLeaf scans rendered lines
 		// for the editor's CURSOR_MARKER; selectors don't emit one and that's
 		// the correct behaviour (no editor cursor while a selector is focused).
-		this.editorLeaf = PiEditorLeaf.create(this.yoga, editorProxy as unknown as CustomEditor, this.root);
+		// In empty splash mode the row centers the input frame; once chat starts,
+		// the editor returns to the full-width active input contract.
+		this.editorRow = new SumoNode(this.yoga.Node.create(), this.root);
+		this.editorRow.flexDirection = FLEX_DIRECTION_ROW;
+		this.editorRow.justifyContent = JUSTIFY_CENTER;
+		this.editorLeftSpacer = new SumoNode(this.yoga.Node.create());
+		this.editorLeftSpacer.flexGrow = 1;
+		this.editorLeftSpacer.flexShrink = 1;
+		this.editorLeaf = PiEditorLeaf.create(this.yoga, editorProxy as unknown as CustomEditor);
+		this.editorRightSpacer = new SumoNode(this.yoga.Node.create());
+		this.editorRightSpacer.flexGrow = 1;
+		this.editorRightSpacer.flexShrink = 1;
+		this.syncEditorRowChildren(this.dimensions.columns ?? 80);
 
 		// 5) hint row
 		this.hintLeaf = PiComponentLeaf.create(this.yoga, hintProxy, this.root);
@@ -228,6 +245,20 @@ export class OwnedShellRenderer {
 	 * runs inside the owned shell's chat-row instead of the runtime's chat-only
 	 * root tree.
 	 */
+	private syncEditorRowChildren(cols: number): void {
+		const centered = !!this.splash && !this.chat.hasMessages();
+		const frameWidth = centered ? Math.min(cols, SPLASH_EDITOR_FRAME_WIDTH) : cols;
+		if (this.editorLeftSpacer.parent === this.editorRow) this.editorRow.removeChild(this.editorLeftSpacer);
+		if (this.editorLeaf.parent === this.editorRow) this.editorRow.removeChild(this.editorLeaf);
+		if (this.editorRightSpacer.parent === this.editorRow) this.editorRow.removeChild(this.editorRightSpacer);
+
+		this.editorLeaf.width = frameWidth;
+		this.editorLeaf.flexShrink = centered ? 0 : 1;
+		if (centered && frameWidth < cols) this.editorRow.addChild(this.editorLeftSpacer);
+		this.editorRow.addChild(this.editorLeaf);
+		if (centered && frameWidth < cols) this.editorRow.addChild(this.editorRightSpacer);
+	}
+
 	private syncChatRowChildren(cols: number, rows: number): void {
 		const wantSplash = !!this.splash && !this.chat.hasMessages();
 		const desired: "chat" | "splash" = wantSplash ? "splash" : "chat";
@@ -294,6 +325,7 @@ export class OwnedShellRenderer {
 		const rows = Math.max(1, Math.floor(this.dimensions.rows ?? 24));
 
 		this.syncChatRowChildren(cols, rows);
+		this.syncEditorRowChildren(cols);
 		// Re-measure dynamic-height leaves so Yoga grows the editor when
 		// autocomplete is shown, and shrinks it back when dismissed. Without this
 		// PiComponentLeaf would return its stale cached measure and the autocomplete
@@ -341,6 +373,7 @@ export class OwnedShellRenderer {
 				sidebarGutter: this.nodeRect(this.sidebarGutter),
 				sidebar: this.nodeRect(this.sidebarLeaf),
 				inputSpacer: this.nodeRect(this.blankSpacer),
+				editorRow: this.nodeRect(this.editorRow),
 				editor: this.nodeRect(this.editorLeaf),
 				hint: this.nodeRect(this.hintLeaf),
 				footerGap: this.nodeRect(this.footerGapSpacer),

--- a/src/sumo-tui/pi-compat/owned-shell-renderer.ts
+++ b/src/sumo-tui/pi-compat/owned-shell-renderer.ts
@@ -145,6 +145,7 @@ export class OwnedShellRenderer {
 	private readonly splash: SplashTree | undefined;
 	private mountedChatChild: "chat" | "splash" | undefined;
 	private mountedSidebar = false;
+	private inputMountedInSplash = false;
 	private disposed = false;
 
 	public constructor(options: OwnedShellRendererOptions) {
@@ -246,7 +247,7 @@ export class OwnedShellRenderer {
 	 * root tree.
 	 */
 	private syncEditorRowChildren(cols: number): void {
-		const centered = !!this.splash && !this.chat.hasMessages();
+		const centered = this.inputMountedInSplash;
 		const frameWidth = centered ? Math.min(cols, SPLASH_EDITOR_FRAME_WIDTH) : cols;
 		if (this.editorLeftSpacer.parent === this.editorRow) this.editorRow.removeChild(this.editorLeftSpacer);
 		if (this.editorLeaf.parent === this.editorRow) this.editorRow.removeChild(this.editorLeaf);
@@ -257,6 +258,43 @@ export class OwnedShellRenderer {
 		if (centered && frameWidth < cols) this.editorRow.addChild(this.editorLeftSpacer);
 		this.editorRow.addChild(this.editorLeaf);
 		if (centered && frameWidth < cols) this.editorRow.addChild(this.editorRightSpacer);
+	}
+
+	private syncInputPlacement(): void {
+		const centerWithSplash = !!this.splash && !this.chat.hasMessages();
+		if (centerWithSplash === this.inputMountedInSplash) return;
+
+		for (const node of [
+			this.blankSpacer,
+			this.editorRow,
+			this.hintLeaf,
+			this.footerGapSpacer,
+			this.footerLeaf,
+			this.bottomSafeSpacer,
+		]) {
+			if (node.parent) node.parent.removeChild(node);
+		}
+
+		if (centerWithSplash && this.splash) {
+			if (this.splash.bottomSpacer.parent === this.splash.root) this.splash.root.removeChild(this.splash.bottomSpacer);
+			this.splash.root.addChild(this.blankSpacer);
+			this.splash.root.addChild(this.editorRow);
+			this.splash.root.addChild(this.hintLeaf);
+			this.splash.root.addChild(this.splash.bottomSpacer);
+			this.root.addChild(this.footerGapSpacer);
+			this.root.addChild(this.footerLeaf);
+			this.root.addChild(this.bottomSafeSpacer);
+		} else {
+			if (this.splash && this.splash.bottomSpacer.parent !== this.splash.root) this.splash.root.addChild(this.splash.bottomSpacer);
+			this.root.addChild(this.blankSpacer);
+			this.root.addChild(this.editorRow);
+			this.root.addChild(this.hintLeaf);
+			this.root.addChild(this.footerGapSpacer);
+			this.root.addChild(this.footerLeaf);
+			this.root.addChild(this.bottomSafeSpacer);
+		}
+
+		this.inputMountedInSplash = centerWithSplash;
 	}
 
 	private syncChatRowChildren(cols: number, rows: number): void {
@@ -325,6 +363,7 @@ export class OwnedShellRenderer {
 		const rows = Math.max(1, Math.floor(this.dimensions.rows ?? 24));
 
 		this.syncChatRowChildren(cols, rows);
+		this.syncInputPlacement();
 		this.syncEditorRowChildren(cols);
 		// Re-measure dynamic-height leaves so Yoga grows the editor when
 		// autocomplete is shown, and shrinks it back when dismissed. Without this

--- a/src/sumo-tui/pi-compat/owned-shell-renderer.ts
+++ b/src/sumo-tui/pi-compat/owned-shell-renderer.ts
@@ -546,6 +546,14 @@ export class OwnedShellRenderer {
 		if (this.sidebarLeaf.parent === this.chatRow) this.chatRow.removeChild(this.sidebarLeaf);
 		this.sidebarGutter.dispose();
 		this.sidebarLeaf.dispose();
+		// The editor row is created at construction time and reparented into the
+		// splash column when the splash is active. When splash.root is detached
+		// above, editorRow becomes orphaned and is NOT reached by root.dispose()
+		// below. Explicitly dispose it here regardless of parentage (dispose is
+		// idempotent, so it's safe to call in both splash and post-splash states).
+		this.editorLeftSpacer.dispose();
+		this.editorRightSpacer.dispose();
+		this.editorRow.dispose();
 		this.chatRow.dispose();
 		this.root.dispose();
 		this.previousFrame = undefined;

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
@@ -326,6 +326,7 @@ describe("sumo interactive Pi noise filtering", () => {
 		upstream.ui.addChild(upstream.editorContainer);
 		upstream.ui.addChild(upstream.widgetContainerBelow);
 		upstream.ui.addChild(upstream.footer);
+		await new Promise((resolve) => setTimeout(resolve, 0));
 
 		const footerIndex = children.indexOf(upstream.footer);
 		expect(footerIndex).toBeGreaterThan(0);

--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -130,11 +130,11 @@ describe("TerminalSessionOwner", () => {
 		const output = outputStub();
 		const terminal = new TerminalSessionOwner({ output });
 
-		terminal.writeFramePatches([{ row: 1, startCol: 4, ansi: "DEF" }], null);
+		terminal.writeFramePatches([{ row: 1, startCol: 4, ansi: "DEF" }], { row: 0, col: 0 });
 
 		// Partial patches MUST skip clear-to-end-of-line so cells right of the
 		// change region survive untouched. Cursor position 5 (= startCol + 1).
-		expect(output.writes).toEqual(["\x1b[?2026h\x1b[2;5HDEF\x1b[?2026l"]);
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b[2;5HDEF\x1b[1;1H\x1b[?25h\x1b[?2026l"]);
 		expect(output.writes[0]).not.toContain("\x1b[K");
 	});
 
@@ -142,9 +142,9 @@ describe("TerminalSessionOwner", () => {
 		const output = outputStub();
 		const terminal = new TerminalSessionOwner({ output });
 
-		terminal.writeFramePatches([{ row: 0, type: "scroll", ansi: "\x1b[1;3r\x1b[1S\x1b[r" }], null);
+		terminal.writeFramePatches([{ row: 0, type: "scroll", ansi: "\x1b[1;3r\x1b[1S\x1b[r" }], { row: 0, col: 0 });
 
-		expect(output.writes).toEqual(["\x1b[?2026h\x1b[1;1H\x1b[1;3r\x1b[1S\x1b[r\x1b[?2026l"]);
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b[1;1H\x1b[1;3r\x1b[1S\x1b[r\x1b[1;1H\x1b[?25h\x1b[?2026l"]);
 		expect(output.writes[0]).not.toContain("\x1b[K");
 	});
 

--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -148,12 +148,17 @@ describe("TerminalSessionOwner", () => {
 		expect(output.writes[0]).not.toContain("\x1b[K");
 	});
 
-	it("lazy frame-start: emits zero bytes for a no-op tick (no patches, no cursor)", () => {
+	it("hides the cursor when a null-cursor frame has no patches", () => {
 		const output = outputStub();
 		const terminal = new TerminalSessionOwner({ output });
 
 		terminal.writeFramePatches([], null);
 
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b[?25l\x1b[?2026l"]);
+		output.writes.length = 0;
+
+		// Once hidden, a repeated no-patch/null-cursor frame is a true no-op.
+		terminal.writeFramePatches([], null);
 		expect(output.writes).toEqual([]);
 	});
 
@@ -202,12 +207,12 @@ describe("TerminalSessionOwner", () => {
 		expect(output.writes).toEqual(["\x1b[?2026h\x1b[6;11H\x1b[?25h\x1b[?2026l"]);
 	});
 
-	it("invalidates the cursor cache when emitting patches with a null cursor (hardwareCursor=null path)", () => {
-		// Regression: the patch loop physically moves the terminal cursor when
-		// patches are emitted, even when no logical cursor is provided. Failing
-		// to invalidate `lastEmittedCursor` here would let the next frame (with
-		// a cursor matching the stale cache) early-return and leave the visible
-		// caret parked at the end of the last patch.
+	it("invalidates the cursor cache when emitting a null cursor", () => {
+		// Regression: the terminal cursor can be hidden while the logical cursor
+		// cache still points at the previous visible editor cursor. Failing to
+		// invalidate `lastEmittedCursor` here would let the next frame (with a
+		// cursor matching the stale cache) early-return and leave the caret hidden
+		// or parked at the end of the last patch.
 		const output = outputStub();
 		const terminal = new TerminalSessionOwner({ output });
 
@@ -226,6 +231,26 @@ describe("TerminalSessionOwner", () => {
 		terminal.writeFramePatches([], { row: 5, col: 10 });
 
 		expect(output.writes).toEqual(["\x1b[?2026h\x1b[6;11H\x1b[?25h\x1b[?2026l"]);
+	});
+
+	it("invalidates the cursor cache when a null-cursor frame has no patches", () => {
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+
+		// Frame A: seed a visible cursor.
+		terminal.writeFramePatches([], { row: 3, col: 7 });
+		output.writes.length = 0;
+
+		// Frame B: metadata-only transition to no cursor. Must hide and invalidate
+		// even though the cell buffer did not change.
+		terminal.writeFramePatches([], null);
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b[?25l\x1b[?2026l"]);
+		output.writes.length = 0;
+
+		// Frame C: same cursor position as frame A. Must re-show/reposition; if the
+		// cache was stale, this would incorrectly early-return.
+		terminal.writeFramePatches([], { row: 3, col: 7 });
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b[4;8H\x1b[?25h\x1b[?2026l"]);
 	});
 
 	it("writes patches on subsequent overlay frames after cursor is already hidden", () => {

--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -228,6 +228,27 @@ describe("TerminalSessionOwner", () => {
 		expect(output.writes).toEqual(["\x1b[?2026h\x1b[6;11H\x1b[?25h\x1b[?2026l"]);
 	});
 
+	it("writes patches on subsequent overlay frames after cursor is already hidden", () => {
+		// Regression: when `hardwareCursorVisible` is already false (cursor hidden
+		// by a previous overlay frame), the null-cursor branch must still write
+		// frame content. Early-returning would drop all patch bytes, freezing
+		// overlay updates after the first frame.
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+
+		// Frame A: patch with null cursor — hides cursor, writes "overlay A".
+		terminal.writeFramePatches([{ row: 5, ansi: "overlay A" }], null);
+		expect(output.writes[0]).toContain("\x1b[?25l");
+		expect(output.writes[0]).toContain("overlay A");
+		output.writes.length = 0;
+
+		// Frame B: patch with null cursor, already hidden. Must still write.
+		terminal.writeFramePatches([{ row: 5, ansi: "overlay B" }], null);
+		expect(output.writes).toHaveLength(1);
+		expect(output.writes[0]).toContain("overlay B");
+		expect(output.writes[0]).not.toContain("\x1b[?25l"); // no redundant hide
+	});
+
 	it("re-emits cursor after exitTerminal clears lastEmittedCursor", () => {
 		const output = outputStub();
 		const terminal = new TerminalSessionOwner({ output });

--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -249,6 +249,28 @@ describe("TerminalSessionOwner", () => {
 		expect(output.writes[0]).not.toContain("\x1b[?25l"); // no redundant hide
 	});
 
+	it("resets hardwareCursorVisible on terminal exit so next session doesn't skip hide", () => {
+		// exitTerminal() emits \x1b[?25h in its cleanup sequence but wasn't
+		// syncing hardwareCursorVisible. A prior session that hid the cursor
+		// leaves the flag stale, so the next session's first overlay frame
+		// skips \x1b[?25l (thinking it's already hidden) and the cursor bleeds.
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+
+		// Simulate a session that hid the cursor.
+		terminal.writeFramePatches([{ row: 5, ansi: "x" }], null);
+		expect(output.writes[0]).toContain("\x1b[?25l");
+		terminal.exitTerminal();
+		output.writes.length = 0;
+
+		// New session: first frame with null cursor — must emit hide.
+		terminal.enterAltscreen();
+		output.writes.length = 0;
+		terminal.writeFramePatches([{ row: 1, ansi: "fresh" }], null);
+		expect(output.writes).toHaveLength(1);
+		expect(output.writes[0]).toContain("\x1b[?25l");
+	});
+
 	it("re-emits cursor after exitTerminal clears lastEmittedCursor", () => {
 		const output = outputStub();
 		const terminal = new TerminalSessionOwner({ output });

--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -134,7 +134,7 @@ describe("TerminalSessionOwner", () => {
 
 		// Partial patches MUST skip clear-to-end-of-line so cells right of the
 		// change region survive untouched. Cursor position 5 (= startCol + 1).
-		expect(output.writes).toEqual(["\x1b[?2026h\x1b[2;5HDEF\x1b[?25l\x1b[?2026l"]);
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b[2;5HDEF\x1b[?2026l"]);
 		expect(output.writes[0]).not.toContain("\x1b[K");
 	});
 
@@ -144,20 +144,8 @@ describe("TerminalSessionOwner", () => {
 
 		terminal.writeFramePatches([{ row: 0, type: "scroll", ansi: "\x1b[1;3r\x1b[1S\x1b[r" }], null);
 
-		expect(output.writes).toEqual(["\x1b[?2026h\x1b[1;1H\x1b[1;3r\x1b[1S\x1b[r\x1b[?25l\x1b[?2026l"]);
+		expect(output.writes).toEqual(["\x1b[?2026h\x1b[1;1H\x1b[1;3r\x1b[1S\x1b[r\x1b[?2026l"]);
 		expect(output.writes[0]).not.toContain("\x1b[K");
-	});
-
-	it("hides hardware cursor when a marker disappears without patches", () => {
-		const output = outputStub();
-		const terminal = new TerminalSessionOwner({ output });
-
-		terminal.writeFramePatches([], { row: 2, col: 4 });
-		output.writes.length = 0;
-
-		terminal.writeFramePatches([], null);
-
-		expect(output.writes).toEqual(["\x1b[?2026h\x1b[?25l\x1b[?2026l"]);
 	});
 
 	it("lazy frame-start: emits zero bytes for a no-op tick (no patches, no cursor)", () => {

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -110,7 +110,6 @@ export class TerminalSessionOwner {
 	 * suppress no-op ticks entirely.
 	 */
 	private lastEmittedCursor: TerminalCursor | null = null;
-	private hardwareCursorVisible = false;
 
 	public constructor(options: TerminalSessionOwnerOptions = {}) {
 		this.output = options.output ?? process.stdout;
@@ -209,8 +208,7 @@ export class TerminalSessionOwner {
 			cursor.row !== this.lastEmittedCursor.row ||
 			cursor.col !== this.lastEmittedCursor.col
 		);
-		const shouldHideCursor = cursor === null && this.hardwareCursorVisible;
-		if (patches.length === 0 && !cursorMoved && !shouldHideCursor) return;
+		if (patches.length === 0 && !cursorMoved) return;
 
 		let output = "\x1b[?2026h";
 		for (const patch of patches) {
@@ -234,20 +232,13 @@ export class TerminalSessionOwner {
 		if (cursor && (patches.length > 0 || cursorMoved)) {
 			output += `\x1b[${cursor.row + 1};${cursor.col + 1}H\x1b[?25h`;
 			this.lastEmittedCursor = { row: cursor.row, col: cursor.col };
-			this.hardwareCursorVisible = true;
-		} else if (cursor === null) {
-			// No CURSOR_MARKER was present in the composited frame. Pi's own TUI hides
-			// the hardware cursor in this case (notably while autocomplete is open,
-			// where the editor paints a fake inverted cursor). Mirror that behavior so
-			// the terminal cursor doesn't remain visible at the end of the last patch.
-			if (patches.length > 0 || shouldHideCursor) output += "\x1b[?25l";
-			this.hardwareCursorVisible = false;
-			if (patches.length > 0) {
-				// Patches moved the terminal cursor without us emitting a known new
-				// position. Invalidate so the NEXT frame with a non-null cursor re-emits
-				// its position even if it matches the stale cache.
-				this.lastEmittedCursor = null;
-			}
+		} else if (patches.length > 0) {
+			// Patches moved the terminal cursor without us emitting a known new
+			// position (for example a modal with no editor cursor). Invalidate so the
+			// NEXT frame with a non-null cursor re-emits its position even if it matches
+			// the stale cache. Do not hide the cursor here: in cmux/Ghostty that also
+			// hides the mouse pointer for Dhruv.
+			this.lastEmittedCursor = null;
 		}
 		output += "\x1b[?2026l";
 		this.write(output);
@@ -269,7 +260,6 @@ export class TerminalSessionOwner {
 		this.cursorColorOverridden = false;
 		this.lastCursorColor = undefined;
 		this.lastEmittedCursor = null;
-		this.hardwareCursorVisible = false;
 		if (!this.isTTY()) return;
 		let output = "";
 		if (shouldResetCursorColor) output += CURSOR_COLOR_RESET;

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -266,6 +266,7 @@ export class TerminalSessionOwner {
 		this.cursorColorOverridden = false;
 		this.lastCursorColor = undefined;
 		this.lastEmittedCursor = null;
+		this.hardwareCursorVisible = true;
 		if (!this.isTTY()) return;
 		let output = "";
 		if (shouldResetCursorColor) output += CURSOR_COLOR_RESET;

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -210,7 +210,8 @@ export class TerminalSessionOwner {
 			cursor.row !== this.lastEmittedCursor.row ||
 			cursor.col !== this.lastEmittedCursor.col
 		);
-		if (patches.length === 0 && !cursorMoved) return;
+		const shouldHideCursor = cursor === null && this.hardwareCursorVisible;
+		if (patches.length === 0 && !cursorMoved && !shouldHideCursor) return;
 
 		let output = "\x1b[?2026h";
 		for (const patch of patches) {
@@ -235,11 +236,11 @@ export class TerminalSessionOwner {
 			output += `\x1b[${cursor.row + 1};${cursor.col + 1}H\x1b[?25h`;
 			this.lastEmittedCursor = { row: cursor.row, col: cursor.col };
 			this.hardwareCursorVisible = true;
-		} else if (patches.length > 0) {
-			// Patches moved the terminal cursor without us emitting a known new
-			// position (for example a modal with no editor cursor). Invalidate so the
-			// NEXT frame with a non-null cursor re-emits its position even if it matches
-			// the stale cache.
+		} else if (cursor === null) {
+			// No logical cursor is present (for example an overlay frame). Invalidate
+			// the cache even without patches: the next non-null cursor frame must
+			// re-emit its position/visibility, even if it matches the last visible
+			// editor cursor.
 			this.lastEmittedCursor = null;
 			if (this.hardwareCursorVisible) {
 				output += "\x1b[?25l";

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -110,6 +110,8 @@ export class TerminalSessionOwner {
 	 * suppress no-op ticks entirely.
 	 */
 	private lastEmittedCursor: TerminalCursor | null = null;
+	/** Tracks whether we last emitted \x1b[?25h or \x1b[?25l so we don't re-emit the same. */
+	private hardwareCursorVisible = true;
 
 	public constructor(options: TerminalSessionOwnerOptions = {}) {
 		this.output = options.output ?? process.stdout;
@@ -232,13 +234,16 @@ export class TerminalSessionOwner {
 		if (cursor && (patches.length > 0 || cursorMoved)) {
 			output += `\x1b[${cursor.row + 1};${cursor.col + 1}H\x1b[?25h`;
 			this.lastEmittedCursor = { row: cursor.row, col: cursor.col };
+			this.hardwareCursorVisible = true;
 		} else if (patches.length > 0) {
 			// Patches moved the terminal cursor without us emitting a known new
 			// position (for example a modal with no editor cursor). Invalidate so the
 			// NEXT frame with a non-null cursor re-emits its position even if it matches
-			// the stale cache. Do not hide the cursor here: in cmux/Ghostty that also
-			// hides the mouse pointer for Dhruv.
+			// the stale cache.
 			this.lastEmittedCursor = null;
+			if (!this.hardwareCursorVisible) return;
+			output += "\x1b[?25l";
+			this.hardwareCursorVisible = false;
 		}
 		output += "\x1b[?2026l";
 		this.write(output);

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -241,9 +241,10 @@ export class TerminalSessionOwner {
 			// NEXT frame with a non-null cursor re-emits its position even if it matches
 			// the stale cache.
 			this.lastEmittedCursor = null;
-			if (!this.hardwareCursorVisible) return;
-			output += "\x1b[?25l";
-			this.hardwareCursorVisible = false;
+			if (this.hardwareCursorVisible) {
+				output += "\x1b[?25l";
+				this.hardwareCursorVisible = false;
+			}
 		}
 		output += "\x1b[?2026l";
 		this.write(output);

--- a/src/sumo-tui/widgets/pi-editor-leaf.test.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.test.ts
@@ -53,6 +53,23 @@ describe("PiEditorLeaf", () => {
 		}
 	});
 
+	it("falls back to Pi's fake inverse cursor when autocomplete omits the marker", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const leaf = new PiEditorLeaf(yoga.Node.create(), asEditor(new FakeEditor([" > \x1b[7m \x1b[0m"])), root);
+		root.width = 8;
+		root.paddingTop = 1;
+		root.paddingLeft = 2;
+		root.yogaNode.calculateLayout(10, undefined, DIRECTION_LTR);
+
+		const buffer = new CellBuffer(2, 10);
+		const result = composite(root, buffer);
+
+		expect(leaf.getHardwareCursor()).toEqual({ row: 1, col: 5 });
+		expect(result.hardwareCursor).toEqual({ row: 1, col: 5 });
+		root.dispose();
+	});
+
 	it("returns null when the cursor marker is scrolled out of the rendered rows (EC-1.3)", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());

--- a/src/sumo-tui/widgets/pi-editor-leaf.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.ts
@@ -34,6 +34,7 @@ export class PiEditorLeaf extends PiComponentLeaf {
 		this.hardwareCursor = null;
 		const rows = this.renderRows(rect.width);
 		const height = Math.min(rows.length, rect.height);
+		let fallbackInverseCursor: HardwareCursorPosition | null = null;
 		for (let row = 0; row < height; row += 1) {
 			const raw = rows[row] ?? "";
 			const markerIndex = raw.indexOf(CURSOR_MARKER);
@@ -43,7 +44,21 @@ export class PiEditorLeaf extends PiComponentLeaf {
 				this.hardwareCursor = { row: rect.top + row, col: rect.left + markerCol };
 			}
 			buffer.paintRow(rect.top + row, painted, rect.left, rect.width);
+			if (markerIndex === -1 && fallbackInverseCursor === null) {
+				for (let col = 0; col < rect.width; col += 1) {
+					const cell = buffer.getCell(rect.top + row, rect.left + col);
+					if (cell.attrs.inverse) {
+						fallbackInverseCursor = { row: rect.top + row, col: rect.left + col };
+						break;
+					}
+				}
+			}
 		}
+		// Pi suppresses CURSOR_MARKER while autocomplete is active and paints a fake
+		// inverse cursor instead. Keep the real terminal cursor on top of that cell
+		// rather than hiding it globally; hiding (`\x1b[?25l`) also hides the mouse
+		// pointer in cmux/Ghostty for Dhruv.
+		if (this.hardwareCursor === null) this.hardwareCursor = fallbackInverseCursor;
 	}
 
 	public getHardwareCursor(): HardwareCursorPosition | null {


### PR DESCRIPTION
## What this is

Small follow-up to the merged Yoga-owned outer chrome work (#196). This carries the post-merge fixes that were validated manually in the live TUI.

## Changes

- Center the splash content vertically in the owned-shell chat area.
- Move the splash composer/input into the splash column while empty so the input/hint centers with the cat + wordmark instead of staying anchored to bottom chrome.
- Restore normal full-width bottom input once the first message exists.
- Keep the hardware cursor visible during slash autocomplete by detecting Pi's inverse fake cursor instead of hiding the cursor globally. This avoids cmux/Ghostty mouse-pointer side effects.

## Verification

Ran locally on branch `poc/yoga-outer-chrome`:

```bash
pnpm exec tsc --noEmit
pnpm build
pnpm test
pnpm test:integration
pnpm visual:ci
```

Results:
- TypeScript/build: pass
- Unit tests: pass
- Integration tests: pass
- Visual CI completed

Manual: Dhruv confirmed the splash/composer centering and mouse behavior now look/feel correct.