### PR TITLE
Fix terminal write guard after restore

### DIFF
--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -116,6 +116,21 @@ describe("TerminalSessionOwner", () => {
 		expect(output.writes).toEqual(["\x1b[?2026h\x1b[2;1H\x1b[Khello\x1b[3;5H\x1b[?25h\x1b[?2026l"]);
 	});
 
+	it("drops writes after exitTerminal so post-cleanup renders cannot leak into main screen", () => {
+		const output = outputStub();
+		const terminal = new TerminalSessionOwner({ output });
+
+		terminal.startRetainedSession();
+		terminal.exitTerminal();
+		output.writes.length = 0;
+
+		terminal.writeFramePatches([{ row: 0, ansi: "splash bytes" }], { row: 0, col: 0 });
+		expect(terminal.writeChatViewport(0, 0, ["chat line"])).toBe(false);
+		expect(terminal.writeClipboardSequence("\x1b]52;c;abc\x1b\\")).toBe(false);
+
+		expect(output.writes).toEqual([]);
+	});
+
 	it("clears full-row patches before drawing so the final column is not erased", () => {
 		const output = outputStub();
 		const terminal = new TerminalSessionOwner({ output });

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -181,7 +181,7 @@ export class TerminalSessionOwner {
 	}
 
 	public writeChatViewport(top: number, left: number, lines: readonly string[]): boolean {
-		if (!this.isTTY() || lines.length === 0) return false;
+		if (!this.isTTY() || this.restored || lines.length === 0) return false;
 		const safeTop = Math.max(0, Math.floor(top));
 		const safeLeft = Math.max(0, Math.floor(left));
 		let output = "\x1b[?2026h\x1b7";
@@ -194,13 +194,13 @@ export class TerminalSessionOwner {
 	}
 
 	public writeClipboardSequence(sequence: string): boolean {
-		if (!this.isTTY() || sequence.length === 0) return false;
+		if (!this.isTTY() || this.restored || sequence.length === 0) return false;
 		this.write(sequence);
 		return true;
 	}
 
 	public writeFramePatches(patches: readonly TerminalPatch[], cursor: TerminalCursor | null): void {
-		if (!this.isTTY()) return;
+		if (!this.isTTY() || this.restored) return;
 		// Lazy frame-start (OpenTUI port, see `lastEmittedCursor` comment): if no
 		// cells changed AND the cursor would land where it already is, emit zero
 		// bytes. Otherwise wrap the patches in `\x1b[?2026h … \x1b[?2026l` for a


### PR DESCRIPTION
## Summary

Fixes #199.

- Guard all retained terminal write seams with `this.restored` after `exitTerminal()` runs.
- Prevent late owned-shell/scheduler renders from painting absolute-positioned SumoCode bytes into the main shell screen after altscreen restore.
- Add regression coverage for post-cleanup frame/chat/clipboard writes.

## Verification

- `pnpm exec tsc --noEmit && pnpm build`
- `pnpm test` — 639 tests
- `pnpm test:integration` — 21 tests
- `pnpm visual:ci`

## Notes

This intentionally ships the Tier 1 defensive backstop from #199. Tier 2 scheduler-drain cleanup can remain a separate follow-up if exit glitches recur.