### PR TITLE
fix(input): preserve \x1b\r so Shift+Enter survives the bridge

### DIFF
--- a/src/cathedral/cathedral-editor.test.ts
+++ b/src/cathedral/cathedral-editor.test.ts
@@ -27,6 +27,18 @@ describe("normalizeRawMultilinePasteInput", () => {
 		// shift+enter nor alt+enter, silently dropping the keypress.
 		expect(normalizeRawMultilinePasteInput("\x1b\r")).toBe("\x1b\r");
 		expect(normalizeRawMultilinePasteInput("\x1b\n")).toBe("\x1b\n");
+		// Defend against a hypothetical terminal-batched chunk of two
+		// Shift+Enters arriving in one event — must still pass through.
+		expect(normalizeRawMultilinePasteInput("\x1b\r\x1b\r")).toBe("\x1b\r\x1b\r");
+	});
+
+	it("still normalizes paste even when content contains ESC sequences", () => {
+		// Pasting an ANSI-colored multi-line log: the bridge must still turn raw
+		// CR into editor newlines so the user's draft preserves all lines. The
+		// modifier-Enter bailout is a regex that matches ONLY whole-chunk
+		// modifier-Enter encodings, so paste-with-embedded-ESC stays in the
+		// rewrite path.
+		expect(normalizeRawMultilinePasteInput("\x1b[31mError\x1b[0m\rline two")).toBe("\x1b[31mError\x1b[0m\nline two");
 	});
 });
 

--- a/src/cathedral/cathedral-editor.test.ts
+++ b/src/cathedral/cathedral-editor.test.ts
@@ -18,6 +18,16 @@ describe("normalizeRawMultilinePasteInput", () => {
 		const paste = "\x1b[200~line one\rline two\x1b[201~";
 		expect(normalizeRawMultilinePasteInput(paste)).toBe(paste);
 	});
+
+	it("preserves modifier-Enter encodings so Shift+Enter / Alt+Enter survive (#201)", () => {
+		// Kitty's default Shift+Enter mapping (and the legacy Alt+Enter encoding
+		// when kitty protocol is off) is `\x1b\r`. Ghostty's Shift+Enter is
+		// `\x1b\n`. Both must pass through verbatim — rewriting the CR to LF
+		// yields `\x1b\n`, which pi-tui's editor recognizes as neither
+		// shift+enter nor alt+enter, silently dropping the keypress.
+		expect(normalizeRawMultilinePasteInput("\x1b\r")).toBe("\x1b\r");
+		expect(normalizeRawMultilinePasteInput("\x1b\n")).toBe("\x1b\n");
+	});
 });
 
 describe("alignAutocompleteRow", () => {

--- a/src/cathedral/multiline-paste.ts
+++ b/src/cathedral/multiline-paste.ts
@@ -5,5 +5,14 @@ export function normalizeRawMultilinePasteInput(data: string): string {
 	// paste-like (or terminal-batched) input; keep them in the draft by turning
 	// raw CR/CRLF line breaks into editor newlines.
 	if (data === "\r") return data;
+	// Modifier-Enter encodings: pi-tui's editor recognizes `\x1b\r` as
+	// shift+enter (kitty mapping) when kitty protocol is active, or alt+enter
+	// when not. Rewriting the CR to LF here yields `\x1b\n`, which the editor
+	// recognizes as neither — the keypress is silently dropped. Pass these
+	// through verbatim so pi-tui can interpret them. Same applies to `\x1b\n`
+	// (Ghostty's shift+enter encoding). CSI u modifier-Enter sequences such as
+	// `\x1b[13;2u` already do not contain CR, so they are unaffected by the
+	// rewrite below.
+	if (data === "\x1b\r" || data === "\x1b\n") return data;
 	return data.replace(/\r\n?/g, "\n");
 }

--- a/src/cathedral/multiline-paste.ts
+++ b/src/cathedral/multiline-paste.ts
@@ -10,9 +10,13 @@ export function normalizeRawMultilinePasteInput(data: string): string {
 	// when not. Rewriting the CR to LF here yields `\x1b\n`, which the editor
 	// recognizes as neither — the keypress is silently dropped. Pass these
 	// through verbatim so pi-tui can interpret them. Same applies to `\x1b\n`
-	// (Ghostty's shift+enter encoding). CSI u modifier-Enter sequences such as
-	// `\x1b[13;2u` already do not contain CR, so they are unaffected by the
-	// rewrite below.
-	if (data === "\x1b\r" || data === "\x1b\n") return data;
+	// (Ghostty's shift+enter encoding). The regex matches one or more
+	// modifier-Enter encodings (defending against a hypothetical batched
+	// `\x1b\r\x1b\r` chunk) and explicitly NOT a chunk that mixes
+	// modifier-Enter with paste content — that case stays in the rewrite path
+	// because the paste content is what we actually need to normalize.
+	// CSI u modifier-Enter sequences such as `\x1b[13;2u` already do not
+	// contain CR, so they are unaffected by the rewrite below.
+	if (/^(?:\x1b[\r\n])+$/.test(data)) return data;
 	return data.replace(/\r\n?/g, "\n");
 }

--- a/src/render-diagnostics.ts
+++ b/src/render-diagnostics.ts
@@ -481,6 +481,26 @@ function instrumentStdin(): void {
 		const chunk = args[0] as Buffer | string | undefined;
 		const bytes = chunk === undefined ? 0 : typeof chunk === "string" ? Buffer.byteLength(chunk) : chunk.byteLength;
 		stats.recordKeystroke(bytes);
+		// Log the raw bytes so investigators can see exactly what the terminal
+		// produced for any given keypress. Capped at 64 bytes (paste chunks can
+		// be huge). This is what we need to debug Shift+Enter and other
+		// modifier-aware keys without speculation.
+		if (chunk !== undefined && bytes > 0) {
+			const buf = typeof chunk === "string" ? Buffer.from(chunk, "utf8") : chunk;
+			const sliced = buf.subarray(0, 64);
+			let hex = "";
+			let ascii = "";
+			for (const b of sliced) {
+				hex += b.toString(16).padStart(2, "0") + " ";
+				ascii += b >= 0x20 && b < 0x7f ? String.fromCharCode(b) : ".";
+			}
+			logDiagnostic("stdin_raw", {
+				bytes,
+				truncated: bytes > 64,
+				hex: hex.trimEnd(),
+				ascii,
+			});
+		}
 		if (pendingSince === undefined) {
 			pendingSince = performance.now();
 			pendingBytes = bytes;

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -445,6 +445,20 @@ export class ChatViewportController {
 			return { consume: true };
 		}
 
+		// Diagnostic: log the bridge handleInput verdict for ESC-prefixed chunks
+		// so investigators can see whether the bridge consumed/rewrote/forwarded
+		// modifier-aware sequences like \x1b[13;2u (Shift+Enter, kitty CSI u).
+		if (data.includes("\x1b") || data !== nextData || consumed) {
+			logDiagnostic("bridge_input_verdict", {
+				inLen: data.length,
+				outLen: nextData.length,
+				consumed,
+				rewritten: nextData !== data,
+				inHex: toHex(data.slice(0, 32)),
+				outHex: toHex(nextData.slice(0, 32)),
+			});
+		}
+
 		if (nextData.length === 0 && consumed) return { consume: true };
 		if (nextData !== data) return { data: nextData };
 		return undefined;

--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -67,8 +67,32 @@ describe("TerminalSessionOwner", () => {
 		terminal.enterAltscreen();
 
 		expect(output.writes).toEqual([`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`]);
-		expect(output.writes[0]).toBe("\x1b[?1049h\x1b[?25h\x1b[H\x1b]11;#1A1511\x1b\\");
+		expect(output.writes[0]).toBe(
+			"\x1b[?1049h\x1b[?2004h\x1b[>7u\x1b[>4;2m\x1b[?25h\x1b[H\x1b]11;#1A1511\x1b\\",
+		);
+		// Bracketed paste, kitty keyboard, and modifyOtherKeys must all be pushed
+		// on altscreen entry so modified Enter keys (Shift+Enter, Alt+Enter, etc.)
+		// remain distinguishable inside altscreen. Pi-tui pushes these on the main
+		// screen at startup; without re-pushing here the altscreen stack starts
+		// at flags=0 and Shift+Enter collapses to plain `\r`.
+		expect(output.writes[0]).toContain("\x1b[>7u");
+		expect(output.writes[0]).toContain("\x1b[>4;2m");
+		expect(output.writes[0]).toContain("\x1b[?2004h");
 		expect(output.writes[0]).not.toContain("\x1b]12;");
+	});
+
+	it("altscreen enter/cleanup pair is symmetric for keyboard modes (#201)", () => {
+		// Regression guard for the Shift+Enter altscreen-entry bug. Kitty keyboard
+		// mode and xterm modifyOtherKeys are per-screen; cleanup pops them on the
+		// way out of altscreen, so the enter sequence must push them on the way
+		// in. Without this pairing, modified Enter keys collapse to plain `\r`
+		// inside altscreen and Shift+Enter silently submits.
+		expect(ALTSCREEN_ENTER_SEQUENCE).toContain("\x1b[>7u");
+		expect(TERMINAL_CLEANUP_SEQUENCE).toContain("\x1b[<u");
+		expect(ALTSCREEN_ENTER_SEQUENCE).toContain("\x1b[>4;2m");
+		expect(TERMINAL_CLEANUP_SEQUENCE).toContain("\x1b[>4;0m");
+		expect(ALTSCREEN_ENTER_SEQUENCE).toContain("\x1b[?2004h");
+		expect(TERMINAL_CLEANUP_SEQUENCE).toContain("\x1b[?2004l");
 	});
 
 	it("setCursorColor is idempotent for the active accent and resets on cleanup", () => {

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -8,6 +8,8 @@
  * `docs/research/sumo-tui-spike/01-opencode.md` section 2).
  */
 
+import { logDiagnostic } from "./diagnostics.js";
+
 // Kitty keyboard mode and xterm modifyOtherKeys are per-screen. pi-tui pushes
 // `\x1b[>7u` (or falls back to `\x1b[>4;2m`) on the main screen at startup; the
 // altscreen stack starts at flags=0, so without re-pushing here Shift+Enter,
@@ -166,6 +168,12 @@ export class TerminalSessionOwner {
 		// V2 contract: do not emit OSC 12 cursor color during normal startup.
 		this.write(output);
 		this.altscreenActive = true;
+		logDiagnostic("altscreen_enter_written", {
+			containsKittyPush: output.includes("\x1b[>7u"),
+			containsModifyOtherKeys: output.includes("\x1b[>4;2m"),
+			containsBracketedPaste: output.includes("\x1b[?2004h"),
+			bytes: output.length,
+		});
 	}
 
 	public enableMouseSGR(): void {

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -8,7 +8,20 @@
  * `docs/research/sumo-tui-spike/01-opencode.md` section 2).
  */
 
-export const ALTSCREEN_ENTER_SEQUENCE = "\x1b[?1049h\x1b[?25h\x1b[H";
+// Kitty keyboard mode and xterm modifyOtherKeys are per-screen. pi-tui pushes
+// `\x1b[>7u` (or falls back to `\x1b[>4;2m`) on the main screen at startup; the
+// altscreen stack starts at flags=0, so without re-pushing here Shift+Enter,
+// Alt+Enter etc. all collapse to plain `\r` once we enter altscreen. Bracketed
+// paste is per-screen on enough terminals (kitty) to be worth re-asserting too.
+// The cleanup pops every one of these on exit (TERMINAL_CLEANUP_SEQUENCE), so
+// the enter sequence has to push them or the pair is asymmetric. Pushing on a
+// terminal that doesn't support a given mode is a no-op.
+export const ALTSCREEN_ENTER_SEQUENCE =
+	"\x1b[?1049h" + // altscreen on
+	"\x1b[?2004h" + // bracketed paste on
+	"\x1b[>7u" + // kitty keyboard push (flags 1+2+4, matches pi-tui terminal.js)
+	"\x1b[>4;2m" + // xterm modifyOtherKeys mode 2 (kitty-less fallback)
+	"\x1b[?25h\x1b[H";
 export const CURSOR_COLOR_SET = "\x1b]12;#D97706\x1b\\";
 export const CURSOR_COLOR_RESET = "\x1b]112\x1b\\";
 // OSC 11 sets the terminal's default background color. Without this, cells


### PR DESCRIPTION
## Summary

The actual fix is in `src/cathedral/multiline-paste.ts`: bail out for the 2-byte modifier-Enter encodings (`\x1b\r`, `\x1b\n`) so the raw-multiline-paste helper doesn't corrupt them.

The branch also includes a defensive structural fix to `ALTSCREEN_ENTER_SEQUENCE` (push kitty keyboard / modifyOtherKeys / bracketed paste on altscreen entry, symmetric with cleanup) and three new diagnostic events that captured the bug.

## Root cause (captured live with `sumocode -d`)

Pressing Shift+Enter in iTerm2:

```
stdin_raw            hex="1b 0d"     (terminal sent ESC + CR — kitty's default Shift+Enter mapping)
bridge_input_verdict consumed:true rewritten:true
                     inHex="1b0d"  outHex="1b0a"   ← bridge corrupted it
```

`normalizeRawMultilinePasteInput` saw `\x1b\r`, decided it was a CR-line-ending paste, and rewrote the CR to LF, producing `\x1b\n`. Pi-tui's editor recognizes:

- `\x1b\r` → "shift+enter" (kitty mapping) or "alt+enter" (legacy)
- `\x1b\n` → **nothing** — silently dropped

The trigger condition in the helper was `includes("\r") && data !== "\r"` — too loose. A 2-byte ESC+CR chunk is overwhelmingly a modifier-Enter encoding, not paste. Bail out for `\x1b\r` and `\x1b\n` (Ghostty's Shift+Enter encoding) and let pi-tui's editor handle them.

## Why the altscreen-symmetry change is still useful

It's a defensive structural fix even though it was not the proximate cause:
- Kitty keyboard mode and modifyOtherKeys are per-screen; pi-tui pushes them on the main screen at startup, and our cleanup pops them on exit, so the enter side should match.
- It guarantees `\x1b[13;2u` would survive in altscreen on terminals that only emit CSI u (where the kitty handshake response arrived after our altscreen entry).
- The new symmetric-pair regression test prevents the inverse asymmetry from recurring.

## Diagnostics added

Three new events, only when `SUMO_TUI_DIAG_FILE` is set:
- `stdin_raw` — hex + ASCII of every stdin chunk (cap 64 bytes).
- `altscreen_enter_written` — confirms the kitty/modifyOtherKeys/bracketed-paste pushes hit stdout.
- `bridge_input_verdict` — chat-viewport-controller's verdict on every ESC-prefixed input chunk.

These were the tools that turned this from speculation into a definitive root cause.

Fixes #201.

## Test plan

- [x] `pnpm test` — 640 unit tests pass, including the new `preserves modifier-Enter encodings` and `altscreen enter/cleanup pair is symmetric for keyboard modes` regression guards.
- [x] `pnpm test:integration` — 21 integration tests pass.
- [x] `pnpm exec tsc --noEmit && pnpm build` — clean.
- [ ] Manual on iTerm2: type `abc<Shift+Enter>def`, verify two-line draft, plain Enter still submits. (Captured `1b 0d` → `1b 0d` in `bridge_input_verdict` after this fix.)
- [ ] Manual on Ghostty / kitty / Apple Terminal.app — repeat smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
