### PR TITLE
fix(tui): pin defaultTerminalSessionOwner to globalThis (#199 follow-up)

### DIFF
--- a/src/sumo-tui/runtime/terminal-controller.test.ts
+++ b/src/sumo-tui/runtime/terminal-controller.test.ts
@@ -3,6 +3,7 @@ import {
 	ALTSCREEN_ENTER_SEQUENCE,
 	CURSOR_COLOR_RESET,
 	CURSOR_COLOR_SET,
+	defaultTerminalSessionOwner,
 	MOUSE_SGR_DISABLE_SEQUENCE,
 	MOUSE_SGR_ENABLE_SEQUENCE,
 	TERMINAL_BG_RESET,
@@ -93,6 +94,24 @@ describe("TerminalSessionOwner", () => {
 		expect(TERMINAL_CLEANUP_SEQUENCE).toContain("\x1b[>4;0m");
 		expect(ALTSCREEN_ENTER_SEQUENCE).toContain("\x1b[?2004h");
 		expect(TERMINAL_CLEANUP_SEQUENCE).toContain("\x1b[?2004l");
+	});
+
+	it("defaultTerminalSessionOwner is a globalThis-pinned singleton (#199)", () => {
+		// Regression guard: jiti can evaluate this module multiple times per
+		// process, and a plain module-level `const` would give each evaluation
+		// its own `defaultTerminalSessionOwner` with its own `restored` flag.
+		// The lifecycle would call `exitTerminal` on instance A while the
+		// OwnedShellRenderer rendered through instance B, and PR #200's guard
+		// would silently miss the leak.
+		//
+		// The contract is "the value is stored on globalThis under a stable
+		// key, so any future module evaluation finds and reuses it". Verify
+		// directly: the export must be the same object globalThis holds, and
+		// re-evaluating the export expression must yield that same object.
+		const pinned = (globalThis as { __sumoDefaultTerminalSessionOwner?: TerminalSessionOwner })
+			.__sumoDefaultTerminalSessionOwner;
+		expect(pinned).toBeDefined();
+		expect(pinned).toBe(defaultTerminalSessionOwner);
 	});
 
 	it("setCursorColor is idempotent for the active accent and resets on cleanup", () => {

--- a/src/sumo-tui/runtime/terminal-controller.ts
+++ b/src/sumo-tui/runtime/terminal-controller.ts
@@ -319,4 +319,24 @@ export class TerminalSessionOwner {
  */
 export class TerminalController extends TerminalSessionOwner {}
 
-export const defaultTerminalSessionOwner = new TerminalSessionOwner();
+/**
+ * Singleton across module loads.
+ *
+ * Why a `globalThis` pin instead of a plain module-level `const`: jiti's TS
+ * loader (used by SumoCode's launcher) evaluates this source file multiple
+ * times per process — once per importer when path normalization or extension
+ * resolution differ. Each evaluation would otherwise construct its own
+ * `defaultTerminalSessionOwner` with its own `restored` flag. The lifecycle
+ * shim then calls `exitTerminal()` on instance A while the OwnedShellRenderer
+ * paints through instance B — and PR #200's `restored` guard silently misses
+ * the leak, repainting the splash onto the user's main shell scrollback after
+ * altscreen exit (#199 / "splash residue" repro).
+ *
+ * Pinning to `globalThis` makes every importer see the same object regardless
+ * of how many times the source is evaluated.
+ */
+const GLOBAL_OWNER_KEY = "__sumoDefaultTerminalSessionOwner";
+type GlobalWithOwner = typeof globalThis & { [GLOBAL_OWNER_KEY]?: TerminalSessionOwner };
+const globalForOwner = globalThis as GlobalWithOwner;
+if (!globalForOwner[GLOBAL_OWNER_KEY]) globalForOwner[GLOBAL_OWNER_KEY] = new TerminalSessionOwner();
+export const defaultTerminalSessionOwner: TerminalSessionOwner = globalForOwner[GLOBAL_OWNER_KEY] as TerminalSessionOwner;


### PR DESCRIPTION
## Summary

PR #200 added a `restored` guard to `TerminalSessionOwner.writeFramePatches` to drop late renders after altscreen exit. The user reported the splash residue still appeared after `/resume → /exit`. node-pty diagnostics revealed why: jiti was evaluating `terminal-controller.ts` more than once per process, producing **multiple `defaultTerminalSessionOwner` instances** with separate `restored` flags. The lifecycle called `exitTerminal()` on instance A; the OwnedShellRenderer painted through instance B; PR #200's guard silently missed the leak.

This pins the singleton to `globalThis` so every importer reuses the same object regardless of how many times the source is evaluated.

## Root cause (captured live with node-pty + temp diagnostics)

```
exit_terminal_called           moduleLoadId 444915 (LifecycleRuntime.restoreTerminal)
write_frame_patches_after_exit moduleLoadId 886468 (OwnedShellRenderer.render)
                               restored: false ← different module instance,
                                                 different `restored` flag
```

Three `terminal-controller.ts` evaluations were observed in a single process; the last one even appeared mid-resume.

## End-to-end verification

A node-pty driver runs the exact failing repro (`/resume → /exit`), captures every byte that would have hit the user's terminal, finds every `\x1b[?1049l` (altscreen-off) and `\x1b[?1049h` (altscreen-on), and asserts no splash markers (`SUMOCODE`, `DIVINE INVOCATION`, cat-row) appear in any window between an altscreen-off and the next altscreen-on:

```
altscreen-off positions: 2, altscreen-on positions: 2
OK: no splash bytes found between altscreen-off and the next altscreen-on
```

## Tests

- [x] `pnpm test` — 643 unit tests pass, including a new `defaultTerminalSessionOwner is a globalThis-pinned singleton (#199)` regression test.
- [x] `pnpm test:integration` — 21 integration tests pass.
- [x] `pnpm exec tsc --noEmit && pnpm build` — clean.
- [x] node-pty end-to-end leak verification: 0 splash bytes between altscreen-off and altscreen-on.
- [ ] Manual smoke: `./bin/sumocode.sh`, `/resume`, pick session, `/exit` — shell scrollback should be clean.
- [ ] Repeat for splash → exit, Ctrl+C, Ctrl+D paths.

## Why globalThis instead of fixing jiti's loader

jiti caches by resolved file path. Different importers in this codebase reach `terminal-controller.ts` through different relative paths (`./terminal-controller.js`, `../runtime/terminal-controller.js`, `../../runtime/terminal-controller.js`, `./sumo-tui/runtime/terminal-controller.js`). Normalizing those to a single canonical path is fragile (every new importer is a hazard). A `globalThis` pin is portable, intent-explicit (the comment names the bug it prevents), and only applies to the small set of values that genuinely need to be process-singletons (the terminal-state machine being one of them).

## Related

- Fixes #199.
- Builds on PR #200 (which added the `restored` guard — the guard is correct, the singleton is what was missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
