### PR TITLE
Fix approval modal Bible drift

### DIFF
--- a/src/approval-modal.test.ts
+++ b/src/approval-modal.test.ts
@@ -22,20 +22,24 @@ function snapshot(overrides: Partial<ApprovalModalSnapshot> = {}): ApprovalModal
 }
 
 describe("renderApprovalModal", () => {
-	it("renders 'APPROVAL REQUIRED' title in accent", () => {
+	it("renders 'APPROVAL REQUIRED' title in approval red with scriptorium marks", () => {
 		const lines = renderApprovalModal(snapshot(), 80);
-		const titleLine = lines.find((l) => stripAnsi(l).includes("APPROVAL REQUIRED"));
+		const titleLine = lines.find((line) => stripAnsi(line).includes("APPROVAL REQUIRED"));
 		expect(titleLine).toBeDefined();
-		// accent #D97706 -> 217;119;6
-		expect(titleLine).toContain("\u001b[38;2;217;119;6m");
+		expect(stripAnsi(titleLine!)).toContain("✾  APPROVAL REQUIRED  ✾");
+		// approval #C1443E -> 193;68;62
+		expect(titleLine).toContain("\u001b[38;2;193;68;62m");
 	});
 
-	it("renders the command in a carved code block frame", () => {
-		const lines = renderApprovalModal(snapshot(), 80).map(stripAnsi);
-		const text = lines.join("\n");
+	it("renders the command in a recessed carved code block frame", () => {
+		const lines = renderApprovalModal(snapshot(), 80);
+		const text = lines.map(stripAnsi).join("\n");
 		expect(text).toContain("┌");
 		expect(text).toContain("└");
 		expect(text).toContain("rm -rf node_modules/");
+		const commandFrameRows = lines.filter((line) => stripAnsi(line).includes("│") || stripAnsi(line).includes("┌") || stripAnsi(line).includes("└"));
+		expect(commandFrameRows).toHaveLength(3);
+		for (const row of commandFrameRows) expect(row).toContain("\u001b[48;2;18;13;10m"); // surfaceRecess
 	});
 
 	it("renders em-dash explanation in dim", () => {
@@ -54,31 +58,46 @@ describe("renderApprovalModal", () => {
 		expect(sysLine).toContain("\u001b[38;2;193;68;62m");
 	});
 
-	it("renders all three buttons: [Y]ES [N]O [A]LWAYS", () => {
+	it("renders all three buttons with NO focused by default", () => {
 		const lines = renderApprovalModal(snapshot(), 80).map(stripAnsi);
 		const text = lines.join("\n");
 		expect(text).toContain("[Y]ES");
-		expect(text).toContain("[N]O");
+		expect(text).toContain("  NO  ");
 		expect(text).toContain("[A]LWAYS");
 	});
 
-	it("highlights the active button with accent fill (default [N]O)", () => {
+	it("highlights the active button with approval fill (default NO)", () => {
 		const lines = renderApprovalModal(snapshot({ activeButton: "no" }), 80);
-		const buttonLine = lines.find((l) => stripAnsi(l).includes("[N]O"));
-		// accent bg 217;119;6
-		expect(buttonLine).toContain("\u001b[48;2;217;119;6m");
+		const buttonLine = lines.find((line) => stripAnsi(line).includes("NO"));
+		// approval bg 193;68;62
+		expect(buttonLine).toContain("\u001b[48;2;193;68;62m");
+		expect(stripAnsi(buttonLine!)).toContain("  NO  ");
 	});
 
-	it("when activeButton=yes, [Y]ES is filled", () => {
+	it("when activeButton=yes, YES is filled with approval red", () => {
 		const lines = renderApprovalModal(snapshot({ activeButton: "yes" }), 80);
-		const text = lines.join("\n");
-		// Find the [Y]ES button section after the bg escape
-		expect(text).toContain("\u001b[48;2;217;119;6m");
-		// And the accent bg should be associated with [Y]ES — by checking there's
-		// only ONE accent bg in the line containing buttons
-		const buttonLine = lines.find((l) => l.includes("[Y]ES"));
-		const matches = buttonLine!.match(/\u001b\[48;2;217;119;6m/g) ?? [];
+		const buttonLine = lines.find((line) => stripAnsi(line).includes("YES"));
+		expect(buttonLine).toContain("\u001b[48;2;193;68;62m");
+		const matches = buttonLine!.match(/\u001b\[48;2;193;68;62m/g) ?? [];
 		expect(matches.length).toBe(1);
+	});
+
+	it("paints every modal row with surfaceLifted background", () => {
+		const lines = renderApprovalModal(snapshot(), 80);
+		expect(lines.length).toBeGreaterThan(0);
+		for (const line of lines) expect(line).toContain("\u001b[48;2;61;48;36m");
+	});
+
+	it("wraps long commands and descriptions inside the modal width", () => {
+		const longCommand = `cd \"/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode\" && gh issue create --title \"Approval modal leaks long commands across the terminal\" --body \"long quoted body with spaces\"`;
+		const lines = renderApprovalModal(snapshot({
+			command: longCommand,
+			descriptionLines: ["This command mutates GitHub state and has a very long quoted body that should wrap inside the lifted modal without leaking past the terminal edge."],
+		}), 80);
+		const plain = lines.map(stripAnsi);
+		for (const row of plain) expect(row.length).toBeLessThanOrEqual(80);
+		expect(plain.filter((row) => row.includes("│")).length).toBeGreaterThan(1);
+		expect(plain.join("\n")).toContain("Approval modal leaks long commands");
 	});
 });
 

--- a/src/approval-modal.ts
+++ b/src/approval-modal.ts
@@ -30,27 +30,63 @@
 
 import type { Component } from "@mariozechner/pi-tui";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { matchesKey } from "@mariozechner/pi-tui";
-import { colorHex } from "./footer.js";
+import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import { CATHEDRAL_TOKENS } from "./tokens.js";
 
 const RESET = "\u001b[0m";
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+const PANEL_INDENT = "   ";
+const BIBLE_COMMAND_BOX_WIDTH_AT_80 = 68;
 
 function visibleLength(text: string): number {
-	return text.replace(ANSI_PATTERN, "").length;
+	return visibleWidth(text.replace(ANSI_PATTERN, ""));
+}
+
+function sgr(hex: string, mode: 38 | 48): string {
+	const normalized = hex.replace("#", "");
+	const red = Number.parseInt(normalized.slice(0, 2), 16);
+	const green = Number.parseInt(normalized.slice(2, 4), 16);
+	const blue = Number.parseInt(normalized.slice(4, 6), 16);
+	return `\u001b[${mode};2;${red};${green};${blue}m`;
+}
+
+function fg(text: string, hex: string): string {
+	return `${sgr(hex, 38)}${text}${RESET}`;
+}
+
+function persistentBg(text: string, fgHex: string, bgHex: string): string {
+	const styleCode = `${sgr(fgHex, 38)}${sgr(bgHex, 48)}`;
+	return `${styleCode}${text.replace(/\u001b\[0m/g, `${RESET}${styleCode}`)}${RESET}`;
+}
+
+function fitLine(line: string, width: number): string {
+	if (width <= 0) return "";
+	return visibleLength(line) > width ? truncateToWidth(line, width, "…") : line;
+}
+
+function padRight(line: string, width: number): string {
+	const fitted = fitLine(line, width);
+	const length = visibleLength(fitted);
+	if (length >= width) return fitted;
+	return `${fitted}${" ".repeat(width - length)}`;
 }
 
 function center(line: string, width: number): string {
-	const len = visibleLength(line);
-	if (len >= width) return line;
-	const pad = Math.floor((width - len) / 2);
-	return `${" ".repeat(pad)}${line}`;
+	const fitted = fitLine(line, width);
+	const length = visibleLength(fitted);
+	if (length >= width) return fitted;
+	const left = Math.floor((width - length) / 2);
+	return `${" ".repeat(left)}${fitted}${" ".repeat(width - length - left)}`;
 }
 
-function divider(width: number): string {
-	const inner = Math.max(0, width - 6);
-	return `   ${colorHex("─".repeat(inner), CATHEDRAL_TOKENS.colors.divider)}`;
+function panelRow(inner: string, width: number): string {
+	return persistentBg(padRight(inner, width), CATHEDRAL_TOKENS.colors.foreground, CATHEDRAL_TOKENS.colors.surfaceLifted);
+}
+
+function splitRule(width: number): string {
+	const ruleLength = Math.max(1, Math.min(22, Math.floor((width - 5) / 2)));
+	const divider = CATHEDRAL_TOKENS.colors.divider;
+	return center(`${fg("─".repeat(ruleLength), divider)}  ${fg("·", divider)}  ${fg("─".repeat(ruleLength), divider)}`, width);
 }
 
 export type ApprovalChoice = "yes" | "no" | "always";
@@ -64,62 +100,83 @@ export type ApprovalModalSnapshot = {
 const DEFAULT_BUTTON_ORDER: readonly ApprovalChoice[] = ["yes", "no", "always"];
 
 function renderButton(choice: ApprovalChoice, isActive: boolean): string {
-	const label = choice === "yes" ? "[Y]ES" : choice === "no" ? "[N]O" : "[A]LWAYS";
+	const key = choice === "yes" ? "Y" : choice === "no" ? "N" : "A";
+	const rest = choice === "yes" ? "ES" : choice === "no" ? "O" : "LWAYS";
 	if (isActive) {
-		// Active button is filled in accent (burnt orange) per Q6.4 lock
-		const bg = `\u001b[48;2;217;119;6m`;
-		const fg = `\u001b[38;2;26;21;17m`; // background hex 1A1511 inverted on accent
-		return `${bg}${fg} ${label} ${RESET}`;
+		const label = choice === "yes" ? " YES " : choice === "no" ? "  NO  " : " ALWAYS ";
+		return `${sgr(CATHEDRAL_TOKENS.colors.states.approval, 48)}${sgr(CATHEDRAL_TOKENS.colors.background, 38)}${label}${RESET}`;
 	}
-	return ` ${colorHex(label, CATHEDRAL_TOKENS.colors.foreground)} `;
+	return `${fg("[", CATHEDRAL_TOKENS.colors.divider)}${fg(key, CATHEDRAL_TOKENS.colors.foreground)}${fg("]", CATHEDRAL_TOKENS.colors.divider)}${fg(rest, CATHEDRAL_TOKENS.colors.foreground)}`;
+}
+
+function commandBoxWidth(width: number): number {
+	const maxBoxWidth = Math.max(2, width - visibleLength(PANEL_INDENT));
+	const target = Math.max(20, width - (80 - BIBLE_COMMAND_BOX_WIDTH_AT_80));
+	return Math.min(maxBoxWidth, target);
+}
+
+function renderCommandFrame(command: string, width: number): string[] {
+	const boxWidth = commandBoxWidth(width);
+	const innerWidth = Math.max(0, boxWidth - 2);
+	const commandWidth = Math.max(1, innerWidth - 2);
+	const border = CATHEDRAL_TOKENS.colors.divider;
+	const commandRows = wrapTextWithAnsi(command, commandWidth);
+	const safeRows = commandRows.length > 0 ? commandRows : [""];
+	const boxRows = [
+		fg(`┌${"─".repeat(innerWidth)}┐`, border),
+		...safeRows.map((row) => `${fg("│", border)} ${fg(fitLine(row, commandWidth), CATHEDRAL_TOKENS.colors.foreground)}${" ".repeat(Math.max(0, commandWidth - visibleLength(row)))} ${fg("│", border)}`),
+		fg(`└${"─".repeat(innerWidth)}┘`, border),
+	];
+	return boxRows.map((row) => `${PANEL_INDENT}${persistentBg(padRight(row, boxWidth), CATHEDRAL_TOKENS.colors.foreground, CATHEDRAL_TOKENS.colors.surfaceRecess)}`);
+}
+
+function renderDescriptionRows(descriptionLines: readonly string[], width: number): string[] {
+	const rows: string[] = [];
+	const contentWidth = Math.max(1, width - visibleLength(PANEL_INDENT));
+	for (let index = 0; index < descriptionLines.length; index += 1) {
+		const prefix = index === 0 ? "— " : "  ";
+		const wrapped = wrapTextWithAnsi(descriptionLines[index] ?? "", Math.max(1, contentWidth - visibleLength(prefix)));
+		const lines = wrapped.length > 0 ? wrapped : [""];
+		for (let rowIndex = 0; rowIndex < lines.length; rowIndex += 1) {
+			const rowPrefix = rowIndex === 0 ? prefix : "  ";
+			rows.push(`${PANEL_INDENT}${fg(`${rowPrefix}${lines[rowIndex]}`, CATHEDRAL_TOKENS.colors.foregroundDim)}`);
+		}
+	}
+	return rows;
 }
 
 /**
  * Pure render of the modal content (lines that go inside the overlay).
  */
 export function renderApprovalModal(snapshot: ApprovalModalSnapshot, width: number): string[] {
+	const safeWidth = Math.max(1, Math.floor(width));
 	const lines: string[] = [];
 
-	lines.push("");
-	lines.push(center(colorHex("APPROVAL REQUIRED", CATHEDRAL_TOKENS.colors.accent), width));
-	lines.push(divider(width));
-	lines.push("");
+	lines.push(panelRow("", safeWidth));
+	lines.push(panelRow(center(`${fg("✾", CATHEDRAL_TOKENS.colors.states.approval)}  ${fg("APPROVAL REQUIRED", CATHEDRAL_TOKENS.colors.states.approval)}  ${fg("✾", CATHEDRAL_TOKENS.colors.states.approval)}`, safeWidth), safeWidth));
+	lines.push(panelRow("", safeWidth));
+	lines.push(panelRow(splitRule(safeWidth), safeWidth));
+	lines.push(panelRow("", safeWidth));
 
-	// "You are about to execute:"
-	lines.push(`   ${colorHex("You are about to execute:", CATHEDRAL_TOKENS.colors.foreground)}`);
-	lines.push("");
+	lines.push(panelRow(`${PANEL_INDENT}${fg("You are about to execute:", CATHEDRAL_TOKENS.colors.foreground)}`, safeWidth));
+	lines.push(panelRow("", safeWidth));
 
-	// Code block frame around the command
-	const innerWidth = Math.max(20, width - 6);
-	const top = colorHex(`┌${"─".repeat(innerWidth - 2)}┐`, CATHEDRAL_TOKENS.colors.divider);
-	const bottom = colorHex(`└${"─".repeat(innerWidth - 2)}┘`, CATHEDRAL_TOKENS.colors.divider);
-	const sideOpen = colorHex("│", CATHEDRAL_TOKENS.colors.divider);
-	const sideClose = colorHex("│", CATHEDRAL_TOKENS.colors.divider);
-	const cmdText = colorHex(snapshot.command, CATHEDRAL_TOKENS.colors.accent);
-	const cmdLine = `${sideOpen} ${cmdText}`;
-	const cmdLinePad = Math.max(1, innerWidth - 1 - 1 - visibleLength(snapshot.command) - 1);
-	const cmdLineFull = `${cmdLine}${" ".repeat(cmdLinePad)}${sideClose}`;
-	lines.push(`   ${top}`);
-	lines.push(`   ${cmdLineFull}`);
-	lines.push(`   ${bottom}`);
-	lines.push("");
+	for (const row of renderCommandFrame(snapshot.command, safeWidth)) lines.push(panelRow(row, safeWidth));
+	lines.push(panelRow("", safeWidth));
 
-	// Description lines (em-dash leader on first)
-	for (let i = 0; i < snapshot.descriptionLines.length; i++) {
-		const prefix = i === 0 ? "— " : "  ";
-		lines.push(`   ${colorHex(`${prefix}${snapshot.descriptionLines[i]}`, CATHEDRAL_TOKENS.colors.foregroundDim)}`);
-	}
+	for (const row of renderDescriptionRows(snapshot.descriptionLines, safeWidth)) lines.push(panelRow(row, safeWidth));
 
-	lines.push("");
-	lines.push(divider(width));
+	lines.push(panelRow("", safeWidth));
+	lines.push(panelRow(splitRule(safeWidth), safeWidth));
+	lines.push(panelRow("", safeWidth));
 
-	// Bottom row: ■ SYSTEM NOTICE   [Y]ES  [N]O  [A]LWAYS (right-aligned)
-	const systemNotice = `${colorHex("■", CATHEDRAL_TOKENS.colors.states.approval)} ${colorHex("SYSTEM NOTICE", CATHEDRAL_TOKENS.colors.foregroundDim)}`;
-	const buttons = DEFAULT_BUTTON_ORDER.map((c) => renderButton(c, c === snapshot.activeButton)).join(" ");
-	const left = `   ${systemNotice}`;
-	const right = `${buttons}   `;
-	const gap = Math.max(2, width - visibleLength(left) - visibleLength(right));
-	lines.push(`${left}${" ".repeat(gap)}${right}`);
+	const systemNotice = `${fg("■", CATHEDRAL_TOKENS.colors.states.approval)} ${fg("SYSTEM NOTICE", CATHEDRAL_TOKENS.colors.foregroundDim)}`;
+	const buttons = DEFAULT_BUTTON_ORDER.map((choice) => renderButton(choice, choice === snapshot.activeButton)).join("  ");
+	const left = `${PANEL_INDENT}${systemNotice}`;
+	const right = `${buttons}${PANEL_INDENT}`;
+	const gap = Math.max(1, safeWidth - visibleLength(left) - visibleLength(right));
+	lines.push(panelRow(`${left}${" ".repeat(gap)}${right}`, safeWidth));
+	lines.push(panelRow("", safeWidth));
 
 	return lines;
 }

--- a/src/commands/approval.test.ts
+++ b/src/commands/approval.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerApprovalCommand } from "./approval.js";
+
+describe("/sumo:approval slash command", () => {
+	it("registers /sumo:approval on the pi API", () => {
+		const registerCommand = vi.fn();
+		registerApprovalCommand({ registerCommand } as never);
+
+		expect(registerCommand).toHaveBeenCalledWith(
+			"sumo:approval",
+			expect.objectContaining({ description: "Open a test Cathedral approval modal" }),
+		);
+	});
+
+	it("opens the approval modal and reports the selected choice", async () => {
+		let handler: ((args: string[], ctx: unknown) => Promise<void>) | undefined;
+		const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
+			handler = options.handler;
+		});
+		const custom = vi.fn(async () => "yes");
+		const notify = vi.fn();
+		registerApprovalCommand({ registerCommand } as never);
+
+		await handler?.([], { hasUI: true, ui: { custom, notify } });
+
+		expect(custom).toHaveBeenCalledTimes(1);
+		const [, options] = custom.mock.calls[0] as unknown[];
+		expect(options).toMatchObject({ overlay: true });
+		expect(notify).toHaveBeenCalledWith("Approval selected: yes", "info");
+	});
+
+	it("prints a message in non-interactive mode", async () => {
+		let handler: ((args: string[], ctx: unknown) => Promise<void>) | undefined;
+		const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
+			handler = options.handler;
+		});
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		registerApprovalCommand({ registerCommand } as never);
+
+		try {
+			await handler?.([], { hasUI: false });
+			expect(stdout).toHaveBeenCalledWith("sumo:approval requires interactive UI\n");
+		} finally {
+			stdout.mockRestore();
+		}
+	});
+});

--- a/src/commands/approval.ts
+++ b/src/commands/approval.ts
@@ -1,0 +1,29 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { showApprovalModal } from "../approval-modal.js";
+
+const TEST_COMMAND = `cd "/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode" && gh issue create --title "Approval modal leaks long commands across the terminal" --body "long quoted body with spaces"`;
+
+/**
+ * `/sumo:approval` — manual QA helper for the Cathedral approval modal.
+ * Opens the same runtime overlay used by the approval gate, without requiring
+ * a dangerous tool call to trigger it.
+ */
+export function registerApprovalCommand(pi: ExtensionAPI): void {
+	pi.registerCommand("sumo:approval", {
+		description: "Open a test Cathedral approval modal",
+		handler: async (_args, ctx: ExtensionContext) => {
+			if (!ctx.hasUI) {
+				process.stdout.write("sumo:approval requires interactive UI\n");
+				return;
+			}
+
+			const choice = await showApprovalModal(ctx, {
+				command: TEST_COMMAND,
+				descriptionLines: [
+					"This command mutates GitHub state and has a very long quoted body that should wrap inside the lifted modal without leaking past the terminal edge.",
+				],
+			});
+			ctx.ui.notify(`Approval selected: ${choice}`, choice === "no" ? "warning" : "info");
+		},
+	});
+}

--- a/src/interaction-registry.test.ts
+++ b/src/interaction-registry.test.ts
@@ -72,6 +72,7 @@ describe("InteractionRegistry", () => {
 		expect(snapshot.diagnostics).toEqual([]);
 		expect(snapshot.commands.map(([id]) => id).sort()).toEqual([
 			"exit",
+			"sumo:approval",
 			"sumo:cursor",
 			"sumo:memory",
 			"sumo:persona",
@@ -82,7 +83,7 @@ describe("InteractionRegistry", () => {
 			"sumo:theme-check",
 		]);
 		expect(snapshot.shortcuts.map(([id]) => id).sort()).toEqual(["ctrl+/", "ctrl+1", "ctrl+2"]);
-		expect(pi.registerCommand).toHaveBeenCalledTimes(9);
+		expect(pi.registerCommand).toHaveBeenCalledTimes(10);
 		expect(pi.registerShortcut).toHaveBeenCalledTimes(3);
 	});
 });

--- a/src/interaction-registry.ts
+++ b/src/interaction-registry.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { installCommandPalette } from "./command-palette.js";
+import { registerApprovalCommand } from "./commands/approval.js";
 import { registerCursorCommand } from "./commands/cursor.js";
 import { registerDivineQueryCommand } from "./commands/divine-query.js";
 import { registerExitCommand } from "./commands/exit.js";
@@ -124,6 +125,7 @@ export function installSumoInteractions(pi: ExtensionAPI, options: InstallSumoIn
 	const registry = createInteractionRegistry(pi, options.reporter);
 	registry.install("command-palette", installCommandPalette);
 	registry.install("sidebar", installSidebar);
+	registry.install("commands.approval", registerApprovalCommand);
 	registry.install("commands.cursor", registerCursorCommand);
 	registry.install("commands.divine-query", registerDivineQueryCommand);
 	registry.install("commands.exit", registerExitCommand);


### PR DESCRIPTION
## Summary

Fixes #189.

- Rebuild approval modal rows around the Element 6 Bible contract.
- Paint every modal row with `surfaceLifted` and command-frame rows with `surfaceRecess`.
- Use approval red for the title, system notice marker, and focused safety button.
- Center the split divider rule and title with the `✾ APPROVAL REQUIRED ✾` marks.
- Wrap long commands and descriptions inside the modal width so `gh issue create ...` commands cannot leak past the frame.

## Self-review

- Checked the rendered 80-column plaintext against `docs/ui/bible/06-approval-rm.html`: title/rules/command frame/system notice/footer now match the row structure.
- Reviewed nested ANSI reset behavior: recessed command rows are wrapped inside persistent lifted panel rows, so background returns to `surfaceLifted` after inner resets.
- Added regression coverage for long quoted commands and full-row modal background painting.

## Verification

- `pnpm vitest run src/approval-modal.test.ts` ✅
- `pnpm exec tsc --noEmit && pnpm build` ✅
- `pnpm test` ✅ `93 passed / 645 tests`
- `pnpm test:integration` ✅ `15 passed / 21 tests`
- `pnpm visual:ci` ✅

## Notes

A pre-existing local change to `bin/sumocode.sh` was stashed before branching and is not included in this PR.