### PR TITLE
feat(task): add native scribe task tool

### DIFF
--- a/bin/sumocode.sh
+++ b/bin/sumocode.sh
@@ -1,7 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "${SOURCE}" ]]; do
+	SOURCE_DIR="$(cd "$(dirname "${SOURCE}")" && pwd)"
+	TARGET="$(readlink "${SOURCE}")"
+	if [[ "${TARGET}" == /* ]]; then
+		SOURCE="${TARGET}"
+	else
+		SOURCE="${SOURCE_DIR}/${TARGET}"
+	fi
+done
+SCRIPT_DIR="$(cd "$(dirname "${SOURCE}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 export SUMO_TUI="${SUMO_TUI:-1}"

--- a/docs/PI_TOOL_ARCHITECTURE.md
+++ b/docs/PI_TOOL_ARCHITECTURE.md
@@ -20,8 +20,6 @@ These ship with Pi and are always available:
 | `write` | Create/overwrite files                           | Tool pill renderer (E9)      |
 | `edit`  | Precise text replacement                         | Tool pill renderer (E9)      |
 | `mcp`   | Call MCP server tools                            | Tool pill renderer (E9)      |
-| `task`  | Dispatch sub-agent work                          | Scroll/scribe renderer (E12) |
-
 SumoCode **does not re-register** these. It intercepts them via `pi.on("tool_call")`
 for approval gating and renders them via the transcript view-model pipeline.
 
@@ -46,7 +44,7 @@ vanilla Pi.
 
 | Tool         | Source                         | Purpose                      |
 |--------------|--------------------------------|------------------------------|
-| *(none yet)* | —                              | —                            |
+| `task`       | `src/native-task-tool.ts`       | Run isolated Pi subprocess tasks and stream structured scroll/scribe state |
 
 ### 4. SumoCode Extension Hooks
 

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import sumocode, {
 	findActiveSumoDevTree,
 	isInstalledPiAgentGitModule,
+	shouldInstallNativeTaskTool,
 	shouldNoopDuplicateInstalledExtension,
 } from "./extension.js";
 
@@ -88,6 +89,28 @@ describe("duplicate installed extension guard", () => {
 });
 
 describe("sumocode extension", () => {
+	it("detects whether native task can install without conflicting with the legacy task extension", () => {
+		expect(shouldInstallNativeTaskTool({ homeDir: "/home/dhruv", exists: () => false })).toBe(true);
+		expect(shouldInstallNativeTaskTool({ homeDir: "/home/dhruv", exists: () => true })).toBe(false);
+		expect(shouldInstallNativeTaskTool({ homeDir: "/home/dhruv", exists: () => true, force: "1" })).toBe(true);
+	});
+
+	it("registers a native task tool when forced", () => {
+		const previous = process.env.SUMOCODE_NATIVE_TASK;
+		process.env.SUMOCODE_NATIVE_TASK = "1";
+		try {
+			const { pi } = buildPiStub();
+
+			sumocode(pi as never);
+
+			const toolNames = pi.registerTool.mock.calls.map((call) => (call[0] as { name: string }).name);
+			expect(toolNames).toContain("task");
+		} finally {
+			if (previous === undefined) delete process.env.SUMOCODE_NATIVE_TASK;
+			else process.env.SUMOCODE_NATIVE_TASK = previous;
+		}
+	});
+
 	it("does not push a 'SumoCode loaded' notification on session_start", () => {
 		const { pi, handlers } = buildPiStub();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { installInputHints } from "./cathedral/input-hints.js";
 import { installAnswerTool } from "./answer-tool.js";
 import { installApprovalGate } from "./approval-modal.js";
 import { installQuestionTool } from "./question-tool.js";
+import { taskTool } from "./native-task-tool.js";
 
 import { installAltscreen } from "./cathedral/altscreen.js";
 import { installCathedralEditor } from "./cathedral/cathedral-editor.js";
@@ -19,6 +20,7 @@ import { installTopChrome } from "./top-chrome.js";
 import { installWorkingIndicator } from "./working-indicator.js";
 
 const SUMOCODE_PACKAGE_NAME = "@dhruvkelawala/sumocode";
+const LEGACY_TASK_TOOL_EXTENSION_PATH = join(".pi", "agent", "extensions", "task-tool", "index.ts");
 
 type ExistsFn = (path: string) => boolean;
 type ReadFileFn = (path: string, encoding: BufferEncoding) => string;
@@ -77,6 +79,16 @@ export function shouldNoopDuplicateInstalledExtension(options: DuplicateInstalle
 	return findActiveSumoDevTree(options.cwd ?? process.cwd(), options) !== undefined;
 }
 
+export function hasLegacyTaskToolExtension(options: Pick<DuplicateInstalledExtensionOptions, "homeDir" | "exists"> = {}): boolean {
+	const exists = options.exists ?? existsSync;
+	return exists(join(options.homeDir ?? homedir(), LEGACY_TASK_TOOL_EXTENSION_PATH));
+}
+
+export function shouldInstallNativeTaskTool(options: Pick<DuplicateInstalledExtensionOptions, "homeDir" | "exists"> & { force?: string } = {}): boolean {
+	if (options.force === "1" || options.force === "true") return true;
+	return !hasLegacyTaskToolExtension(options);
+}
+
 /**
  * SumoCode — cathedral-themed Pi extension entry point.
  *
@@ -107,6 +119,31 @@ export default function sumocode(pi: ExtensionAPI): void {
 	installCathedralEditor(pi);
 	installInputHints(pi);
 	installApprovalGate(pi);
+	// The old global `~/.pi/agent/extensions/task-tool` extension registers the
+	// same `task` tool name and Pi treats duplicate tools as fatal. Until the
+	// user removes/disables that legacy extension, defer to it instead of
+	// crashing SumoCode startup. Native task takes over automatically once the
+	// legacy wrapper is gone.
+	if (shouldInstallNativeTaskTool({ force: process.env.SUMOCODE_NATIVE_TASK })) {
+		taskTool({
+			name: "task",
+			label: "Task",
+			description: [
+				"Run isolated pi subprocess tasks (single, chain, or parallel).",
+				"Optional model override (provider/modelId).",
+			].join(" "),
+			maxParallelTasks: 8,
+			maxConcurrency: 4,
+			collapsedItemCount: 10,
+			skillListLimit: 30,
+			systemPromptPatches: [
+				{
+					match: /\n\s*\n\s*in addition to the tools above, you may have access to other custom tools depending on the project\./i,
+					replace: "\n- task: never run this tool unless it's a skill run or I explictly ask you to",
+				},
+			],
+		})(pi);
+	}
 	installQuestionTool(pi);
 	installAnswerTool(pi);
 

--- a/src/native-task-config.ts
+++ b/src/native-task-config.ts
@@ -1,0 +1,65 @@
+import type { ProviderModel, TaskThinking, TaskWorkItem, ThinkingLevel } from "./native-task-params.js";
+import { resolveModel } from "./native-task-params.js";
+
+const BUILT_IN_TOOLS = ["read", "bash", "edit", "write", "grep", "find", "ls"] as const;
+
+export type BuiltInToolName = (typeof BUILT_IN_TOOLS)[number];
+
+const isBuiltInToolName = (toolName: string): toolName is BuiltInToolName => {
+	return (BUILT_IN_TOOLS as readonly string[]).includes(toolName);
+};
+
+export const getBuiltInToolsFromActiveTools = (activeTools: string[]): BuiltInToolName[] => {
+	return activeTools.filter(isBuiltInToolName);
+};
+
+const resolveThinkingLevel = (thinking: TaskThinking, inherited: ThinkingLevel): ThinkingLevel => {
+	return thinking === "inherit" ? inherited : thinking;
+};
+
+const buildSubprocessArgs = (options: {
+	model: ProviderModel | undefined;
+	thinkingLevel: ThinkingLevel;
+	builtInTools: BuiltInToolName[];
+}): string[] => {
+	const args: string[] = ["--mode", "json", "-p", "--no-session", "--no-extensions"];
+
+	if (options.model) {
+		args.push("--provider", options.model.provider);
+		args.push("--model", options.model.modelId);
+	}
+
+	args.push("--thinking", options.thinkingLevel);
+
+	if (options.builtInTools.length === 0) {
+		args.push("--no-tools");
+	} else {
+		args.push("--tools", options.builtInTools.join(","));
+	}
+
+	return args;
+};
+
+export const resolveTaskConfig = (options: {
+	item: TaskWorkItem;
+	defaultModel: string | undefined;
+	defaultThinking: TaskThinking;
+	inheritedThinking: ThinkingLevel;
+	ctxModel: { provider: string; id: string } | undefined;
+	builtInTools: BuiltInToolName[];
+}):
+	| { ok: true; thinkingLevel: ThinkingLevel; subprocessArgs: string[]; modelLabel: string | undefined }
+	| { ok: false; error: string } => {
+	const modelOverride = options.item.model ?? options.defaultModel;
+	const modelResolution = resolveModel(modelOverride, options.ctxModel);
+	if (!modelResolution.ok) return modelResolution;
+
+	const thinking = resolveThinkingLevel(options.item.thinking ?? options.defaultThinking, options.inheritedThinking);
+	const subprocessArgs = buildSubprocessArgs({
+		model: modelResolution.model,
+		thinkingLevel: thinking,
+		builtInTools: options.builtInTools,
+	});
+
+	return { ok: true, thinkingLevel: thinking, subprocessArgs, modelLabel: modelResolution.model?.label };
+};

--- a/src/native-task-params.test.ts
+++ b/src/native-task-params.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { normalizeTaskParams } from "./native-task-params.js";
+
+describe("native task params", () => {
+	it("normalizes single task defaults", () => {
+		const result = normalizeTaskParams({ type: "single", tasks: [{ prompt: "Audit auth" }] });
+
+		expect(result).toEqual({
+			ok: true,
+			value: {
+				mode: "single",
+				model: undefined,
+				thinking: "inherit",
+				items: [{ prompt: "Audit auth", skill: undefined, model: undefined, thinking: undefined, fork: true }],
+			},
+		});
+	});
+
+	it("rejects invalid thinking levels", () => {
+		const result = normalizeTaskParams({ type: "single", tasks: [{ prompt: "Audit auth", thinking: "maximum" }] });
+
+		expect(result).toMatchObject({ ok: false });
+		if (!result.ok) expect(result.error).toContain("thinking");
+	});
+});

--- a/src/native-task-params.ts
+++ b/src/native-task-params.ts
@@ -1,0 +1,188 @@
+export const MAX_PARALLEL_TASKS = 8;
+export const VALID_THINKING_LEVELS = ["off", "minimal", "low", "medium", "high", "xhigh"] as const;
+export const VALID_THINKING_OPTIONS = ["inherit", ...VALID_THINKING_LEVELS] as const;
+
+export type ThinkingLevel = (typeof VALID_THINKING_LEVELS)[number];
+export type TaskThinking = (typeof VALID_THINKING_OPTIONS)[number];
+
+export type TaskWorkItem = {
+	prompt: string;
+	skill?: string;
+	model?: string;
+	thinking?: TaskThinking;
+	fork: boolean;
+};
+
+export type ProviderModel = {
+	provider: string;
+	modelId: string;
+	label: string;
+};
+
+export type NormalizedParams =
+	| { mode: "single"; model?: string; thinking: TaskThinking; items: [TaskWorkItem] }
+	| { mode: "parallel"; model?: string; thinking: TaskThinking; items: TaskWorkItem[] }
+	| { mode: "chain"; model?: string; thinking: TaskThinking; items: TaskWorkItem[] };
+
+export const isRecord = (value: unknown): value is Record<string, unknown> => {
+	return value !== null && typeof value === "object";
+};
+
+const isTaskThinking = (value: string): value is TaskThinking => {
+	return (VALID_THINKING_OPTIONS as readonly string[]).includes(value);
+};
+
+const parseProviderModel = (value: string): { ok: true; model: ProviderModel } | { ok: false; error: string } => {
+	const trimmed = value.trim();
+	const slashIndex = trimmed.indexOf("/");
+	if (slashIndex <= 0 || slashIndex === trimmed.length - 1) {
+		return { ok: false, error: `Invalid model format: "${value}". Expected provider/modelId.` };
+	}
+	const provider = trimmed.slice(0, slashIndex);
+	const modelId = trimmed.slice(slashIndex + 1);
+	return { ok: true, model: { provider, modelId, label: `${provider}/${modelId}` } };
+};
+
+export const resolveModel = (
+	modelOverride: string | undefined,
+	ctxModel: { provider: string; id: string } | undefined,
+): { ok: true; model: ProviderModel | undefined } | { ok: false; error: string } => {
+	if (modelOverride) {
+		const parsed = parseProviderModel(modelOverride);
+		if (!parsed.ok) return parsed;
+		return { ok: true, model: parsed.model };
+	}
+
+	if (!ctxModel) return { ok: true, model: undefined };
+	return {
+		ok: true,
+		model: { provider: ctxModel.provider, modelId: ctxModel.id, label: `${ctxModel.provider}/${ctxModel.id}` },
+	};
+};
+
+const normalizeModelInput = (
+	value: unknown,
+	label: string,
+): { ok: true; value?: string } | { ok: false; error: string } => {
+	if (value === undefined) return { ok: true, value: undefined };
+	if (typeof value !== "string") return { ok: false, error: `Invalid parameters: ${label} must be a string.` };
+	const trimmed = value.trim();
+	return { ok: true, value: trimmed ? trimmed : undefined };
+};
+
+const normalizeThinkingInput = (
+	value: unknown,
+	label: string,
+): { ok: true; value?: TaskThinking } | { ok: false; error: string } => {
+	if (value === undefined) return { ok: true, value: undefined };
+	if (typeof value !== "string") return { ok: false, error: `Invalid parameters: ${label} must be a string.` };
+	const trimmed = value.trim();
+	if (!trimmed) return { ok: true, value: undefined };
+	if (!isTaskThinking(trimmed)) {
+		return {
+			ok: false,
+			error: `Invalid parameters: ${label} must be one of ${VALID_THINKING_OPTIONS.join(", ")}.`,
+		};
+	}
+	return { ok: true, value: trimmed };
+};
+
+const normalizeForkInput = (
+	value: unknown,
+	label: string,
+): { ok: true; value: boolean } | { ok: false; error: string } => {
+	if (value === undefined) return { ok: true, value: true };
+	if (typeof value !== "boolean") return { ok: false, error: `Invalid parameters: ${label} must be a boolean.` };
+	return { ok: true, value };
+};
+
+const parseTaskItems = (rawTasks: unknown[]): { ok: true; items: TaskWorkItem[] } | { ok: false; error: string } => {
+	const items: TaskWorkItem[] = [];
+	for (const [index, taskEntry] of rawTasks.entries()) {
+		if (!isRecord(taskEntry)) return { ok: false, error: "Invalid task item: expected an object." };
+		const prompt = typeof taskEntry.prompt === "string" ? taskEntry.prompt.trim() : "";
+		const skill = typeof taskEntry.skill === "string" ? taskEntry.skill.trim() : undefined;
+		if (!prompt && !skill) {
+			return { ok: false, error: 'Invalid task item: provide a non-empty "prompt" or "skill".' };
+		}
+
+		const modelResult = normalizeModelInput(taskEntry.model, `"tasks[${index}].model"`);
+		if (!modelResult.ok) return modelResult;
+
+		const thinkingResult = normalizeThinkingInput(taskEntry.thinking, `"tasks[${index}].thinking"`);
+		if (!thinkingResult.ok) return thinkingResult;
+
+		const forkResult = normalizeForkInput(taskEntry.fork, `"tasks[${index}].fork"`);
+		if (!forkResult.ok) return forkResult;
+
+		items.push({
+			prompt,
+			skill,
+			model: modelResult.value,
+			thinking: thinkingResult.value,
+			fork: forkResult.value,
+		});
+	}
+	return { ok: true, items };
+};
+
+export const normalizeTaskParams = (
+	params: unknown,
+	options: { maxParallelTasks: number } = { maxParallelTasks: MAX_PARALLEL_TASKS },
+): { ok: true; value: NormalizedParams } | { ok: false; error: string } => {
+	if (!isRecord(params)) return { ok: false, error: "Invalid parameters: expected an object." };
+
+	const mode = params.type;
+	if (typeof mode !== "string") return { ok: false, error: 'Invalid parameters: "type" must be a string.' };
+
+	const modelResult = normalizeModelInput(params.model, '"model"');
+	if (!modelResult.ok) return modelResult;
+	const model = modelResult.value;
+
+	const thinkingResult = normalizeThinkingInput(params.thinking, '"thinking"');
+	if (!thinkingResult.ok) return thinkingResult;
+	const thinking = thinkingResult.value ?? "inherit";
+
+	const rawTasks = Array.isArray(params.tasks) ? params.tasks : [];
+
+	if (mode === "single") {
+		if (rawTasks.length !== 1) {
+			return { ok: false, error: 'Invalid parameters: type="single" requires exactly one task in "tasks".' };
+		}
+		const parsed = parseTaskItems(rawTasks);
+		if (!parsed.ok) return parsed;
+		return { ok: true, value: { mode: "single", model, thinking, items: [parsed.items[0]] } };
+	}
+
+	if (mode === "parallel") {
+		if (rawTasks.length === 0) {
+			return { ok: false, error: 'Invalid parameters: type="parallel" requires a non-empty "tasks" array.' };
+		}
+		if (rawTasks.length > options.maxParallelTasks) {
+			return {
+				ok: false,
+				error: `Too many parallel tasks (${rawTasks.length}). Max is ${options.maxParallelTasks}.`,
+			};
+		}
+		const parsed = parseTaskItems(rawTasks);
+		if (!parsed.ok) return parsed;
+		return { ok: true, value: { mode: "parallel", model, thinking, items: parsed.items } };
+	}
+
+	if (mode === "chain") {
+		if (rawTasks.length === 0) {
+			return { ok: false, error: 'Invalid parameters: type="chain" requires a non-empty "tasks" array.' };
+		}
+		if (rawTasks.length > options.maxParallelTasks) {
+			return {
+				ok: false,
+				error: `Too many chain tasks (${rawTasks.length}). Max is ${options.maxParallelTasks}.`,
+			};
+		}
+		const parsed = parseTaskItems(rawTasks);
+		if (!parsed.ok) return parsed;
+		return { ok: true, value: { mode: "chain", model, thinking, items: parsed.items } };
+	}
+
+	return { ok: false, error: 'Invalid parameters: "type" must be "single", "chain", or "parallel".' };
+};

--- a/src/native-task-tool.test.ts
+++ b/src/native-task-tool.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+import { taskTool } from "./native-task-tool.js";
+
+describe("native task tool", () => {
+	it("marks single-task setup failures as tool errors", async () => {
+		let definition: { execute: (...args: unknown[]) => Promise<{ isError?: boolean; content: Array<{ type: string; text: string }> }> } | undefined;
+		const pi = {
+			registerTool: vi.fn((toolDefinition) => {
+				definition = toolDefinition as typeof definition;
+			}),
+			on: vi.fn(),
+			getThinkingLevel: vi.fn(() => "low"),
+			getActiveTools: vi.fn(() => ["read"]),
+		};
+
+		taskTool()(pi as never);
+
+		const result = await definition?.execute(
+			"tc-task",
+			{ type: "single", tasks: [{ prompt: "## Needs fork", fork: true }] },
+			undefined,
+			undefined,
+			{
+				cwd: process.cwd(),
+				model: undefined,
+				sessionManager: { getSessionFile: () => undefined },
+			} as never,
+		);
+
+		expect(result?.isError).toBe(true);
+		expect(result?.content[0]?.text).toContain("Forked tasks require a persisted session file");
+	});
+});

--- a/src/native-task-tool.ts
+++ b/src/native-task-tool.ts
@@ -1,0 +1,1233 @@
+import { type ChildProcessWithoutNullStreams, spawn } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AssistantMessage, Message } from "@mariozechner/pi-ai";
+import {
+	type ExtensionAPI,
+	getAgentDir,
+	loadSkills,
+	SettingsManager,
+	type Skill,
+	type Theme,
+	type ThemeColor,
+} from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { Type } from "typebox";
+import { type BuiltInToolName, getBuiltInToolsFromActiveTools, resolveTaskConfig } from "./native-task-config.js";
+import {
+	isRecord,
+	MAX_PARALLEL_TASKS,
+	normalizeTaskParams,
+	type TaskThinking,
+	type TaskWorkItem,
+	VALID_THINKING_OPTIONS,
+	type ThinkingLevel,
+} from "./native-task-params.js";
+
+export type PromptPatch = { match: RegExp; replace: string };
+
+export type TaskToolOptions = {
+	name: string;
+	label: string;
+	description: string;
+	maxParallelTasks: number;
+	maxConcurrency: number;
+	collapsedItemCount: number;
+	skillListLimit: number;
+	systemPromptPatches: PromptPatch[];
+};
+
+const DEFAULT_OPTIONS: TaskToolOptions = {
+	name: "task",
+	label: "Task",
+	description: [
+		"Run isolated pi subprocess tasks (single, chain, or parallel).",
+		"Supports optional skill wrapper (matches /skill: behavior) and optional model override (provider/modelId).",
+	].join(" "),
+	maxParallelTasks: MAX_PARALLEL_TASKS,
+	maxConcurrency: 4,
+	collapsedItemCount: 10,
+	skillListLimit: 30,
+	systemPromptPatches: [
+		{
+			match: /\n\s*\n\s*in addition to the tools above, you may have access to other custom tools depending on the project\./i,
+			replace: "\n- task: Run isolated pi subprocess tasks (single, chain, or parallel).",
+		},
+		{
+			match: /Use the read tool to load a skill's file when the task matches its description\./i,
+			replace:
+				"Use skill directly: Use the read tool to load a skill's file when the task matches its description. Use skill in task: Pass the skill to the task tool and the task context will load it.",
+		},
+	],
+};
+
+const loadSkillDiscovery = (cwd: string) => {
+	const settingsManager = SettingsManager.create(cwd);
+	const agentDir = getAgentDir();
+	const skillPaths = settingsManager.getSkillPaths();
+	return loadSkills({ cwd, agentDir, skillPaths, includeDefaults: true });
+};
+
+const applyPromptPatches = (prompt: string, patches: PromptPatch[]): string => {
+	return patches.reduce((value, patch) => value.replace(patch.match, patch.replace), prompt);
+};
+
+type UsageStats = {
+	input: number;
+	output: number;
+	cacheRead: number;
+	cacheWrite: number;
+	cost: number;
+	contextTokens: number;
+	turns: number;
+};
+
+type SingleResult = {
+	prompt: string;
+	skill?: string;
+	exitCode: number;
+	messages: Message[];
+	toolEvents: ToolCallItem[];
+	streamingText?: string;
+	stderr: string;
+	usage: UsageStats;
+	model?: string;
+	thinking?: ThinkingLevel;
+	fork?: boolean;
+	stopReason?: string;
+	errorMessage?: string;
+	index?: number;
+};
+
+type TaskToolDetails = {
+	mode: "single" | "parallel" | "chain";
+	modelOverride?: string;
+	results: SingleResult[];
+};
+
+type TaskStatus = "Running" | "Done" | "Failed" | "Pending";
+type OverallStatus = "Running" | "Done" | "Failed";
+
+type ToolCallItem = {
+	id?: string;
+	name: string;
+	args: Record<string, unknown>;
+	status: "pending" | "running" | "success" | "error" | "cancelled";
+	output?: string;
+};
+
+type PreparedTask = {
+	item: TaskWorkItem;
+	subprocessPrompt: string;
+};
+
+type PreparedExecution = {
+	task: PreparedTask;
+	config: { thinkingLevel: ThinkingLevel; subprocessArgs: string[]; modelLabel: string | undefined };
+};
+
+type ForkSession = { dir: string; seedPath: string };
+
+const createForkSession = async (sessionFile: string): Promise<ForkSession> => {
+	const tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "pi-task-tool-"));
+	const seedPath = path.join(tmpDir, "seed.jsonl");
+	try {
+		await fs.promises.copyFile(sessionFile, seedPath);
+		return { dir: tmpDir, seedPath };
+	} catch (error) {
+		try {
+			await fs.promises.rm(tmpDir, { recursive: true, force: true });
+		} catch {}
+		throw error;
+	}
+};
+
+const cleanupForkSession = async (session?: ForkSession): Promise<void> => {
+	if (!session) return;
+	try {
+		await fs.promises.rm(session.dir, { recursive: true, force: true });
+	} catch {}
+};
+
+const applyForkSessionArgs = (baseArgs: string[], session?: ForkSession): string[] => {
+	if (!session) return baseArgs;
+	const filtered = baseArgs.filter((arg) => arg !== "--no-session");
+	return [...filtered, "--session", session.seedPath, "--session-dir", session.dir];
+};
+
+const shortenPath = (filePath: string): string => {
+	const home = os.homedir();
+	return filePath.startsWith(home) ? `~${filePath.slice(home.length)}` : filePath;
+};
+
+const formatTokens = (count: number): string => {
+	if (count < 1000) return count.toString();
+	if (count < 10000) return `${(count / 1000).toFixed(1)}k`;
+	if (count < 1000000) return `${Math.round(count / 1000)}k`;
+	return `${(count / 1000000).toFixed(1)}M`;
+};
+
+const formatUsageStats = (
+	usage: {
+		input: number;
+		output: number;
+		cacheRead: number;
+		cacheWrite: number;
+		cost: number;
+		contextTokens?: number;
+		turns?: number;
+	},
+	model?: string,
+	thinking?: ThinkingLevel,
+): string => {
+	const parts: string[] = [];
+	if (usage.turns) parts.push(`${usage.turns} turn${usage.turns > 1 ? "s" : ""}`);
+	if (usage.input) parts.push(`↑${formatTokens(usage.input)}`);
+	if (usage.output) parts.push(`↓${formatTokens(usage.output)}`);
+	if (usage.cost) parts.push(`$${usage.cost.toFixed(4)}`);
+	if (usage.contextTokens && usage.contextTokens > 0) parts.push(`ctx:${formatTokens(usage.contextTokens)}`);
+	if (model) parts.push(model);
+	if (thinking) parts.push(`thinking:${thinking}`);
+	return parts.join(" ");
+};
+
+const formatTaskConfig = (result: SingleResult): string | undefined => {
+	const parts: string[] = [];
+	if (result.model) parts.push(result.model);
+	if (result.thinking) parts.push(`thinking:${result.thinking}`);
+	const contextLabel = getTaskContextLabel(result);
+	if (contextLabel) parts.push(`context:${contextLabel}`);
+	return parts.length > 0 ? parts.join(" ") : undefined;
+};
+
+const stripYamlFrontmatter = (content: string): string => {
+	const normalized = content.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+	return normalized.replace(/^---\n[\s\S]*?\n---\n/, "").trim();
+};
+
+const formatToolCall = (
+	toolName: string,
+	args: Record<string, unknown>,
+	themeFg: (color: ThemeColor, text: string) => string,
+): string => {
+	if (toolName === "bash") {
+		const command = typeof args.command === "string" ? args.command : "...";
+		const preview = command.length > 60 ? `${command.slice(0, 60)}...` : command;
+		return themeFg("muted", "$ ") + themeFg("toolOutput", preview);
+	}
+
+	if (toolName === "read") {
+		const rawPath =
+			typeof args.file_path === "string" ? args.file_path : typeof args.path === "string" ? args.path : "...";
+		const offset = typeof args.offset === "number" ? args.offset : undefined;
+		const limit = typeof args.limit === "number" ? args.limit : undefined;
+		let text = themeFg("accent", shortenPath(rawPath));
+		if (offset !== undefined || limit !== undefined) {
+			const startLine = offset ?? 1;
+			const endLine = limit !== undefined ? startLine + limit - 1 : "";
+			text += themeFg("warning", `:${startLine}${endLine ? `-${endLine}` : ""}`);
+		}
+		return themeFg("muted", "read ") + text;
+	}
+
+	if (toolName === "write") {
+		const rawPath =
+			typeof args.file_path === "string" ? args.file_path : typeof args.path === "string" ? args.path : "...";
+		const content = typeof args.content === "string" ? args.content : "";
+		const lines = content.split("\n").length;
+		let text = themeFg("muted", "write ") + themeFg("accent", shortenPath(rawPath));
+		if (lines > 1) text += themeFg("dim", ` (${lines} lines)`);
+		return text;
+	}
+
+	if (toolName === "edit") {
+		const rawPath =
+			typeof args.file_path === "string" ? args.file_path : typeof args.path === "string" ? args.path : "...";
+		return themeFg("muted", "edit ") + themeFg("accent", shortenPath(rawPath));
+	}
+
+	if (toolName === "ls") {
+		const rawPath = typeof args.path === "string" ? args.path : ".";
+		return themeFg("muted", "ls ") + themeFg("accent", shortenPath(rawPath));
+	}
+
+	if (toolName === "find") {
+		const pattern = typeof args.pattern === "string" ? args.pattern : "*";
+		const rawPath = typeof args.path === "string" ? args.path : ".";
+		return themeFg("muted", "find ") + themeFg("accent", pattern) + themeFg("dim", ` in ${shortenPath(rawPath)}`);
+	}
+
+	if (toolName === "grep") {
+		const pattern = typeof args.pattern === "string" ? args.pattern : "";
+		const rawPath = typeof args.path === "string" ? args.path : ".";
+		return (
+			themeFg("muted", "grep ") + themeFg("accent", `/${pattern}/`) + themeFg("dim", ` in ${shortenPath(rawPath)}`)
+		);
+	}
+
+	const argsStr = JSON.stringify(args);
+	const preview = argsStr.length > 50 ? `${argsStr.slice(0, 50)}...` : argsStr;
+	return themeFg("accent", toolName) + themeFg("dim", ` ${preview}`);
+};
+
+const getFinalOutput = (messages: Message[]): string => {
+	for (let index = messages.length - 1; index >= 0; index--) {
+		const message = messages[index];
+		if (message.role === "assistant") {
+			for (const part of message.content) {
+				if (part.type === "text") return part.text;
+			}
+		}
+	}
+	return "";
+};
+
+const indentLine = (text: string, indent: number): string => `${" ".repeat(indent)}${text}`;
+
+const indentText = (text: string, indent: number): string => {
+	return text.split("\n").map((line) => indentLine(line, indent)).join("\n");
+};
+
+const formatLabeledLine = (label: string, value: string, indent: number): string => {
+	const lines = value.split("\n");
+	const header = indentLine(`${label}: ${lines[0] ?? ""}`, indent);
+	if (lines.length === 1) return header;
+	const rest = lines.slice(1).map((line) => indentLine(line, indent + 2));
+	return [header, ...rest].join("\n");
+};
+
+const formatSection = (label: string, body: string, indent: number): string => {
+	return `${indentLine(`${label}:`, indent)}\n${indentText(body, indent + 2)}`;
+};
+
+const isTaskRunning = (result: SingleResult): boolean => result.exitCode === -1;
+const isTaskPending = (result: SingleResult): boolean => result.exitCode === -2;
+
+const getTaskStatus = (result: SingleResult): TaskStatus => {
+	if (isTaskPending(result)) return "Pending";
+	if (isTaskRunning(result)) return "Running";
+	return isTaskError(result) ? "Failed" : "Done";
+};
+
+const getParallelStatus = (results: SingleResult[]): OverallStatus => {
+	const hasRunning = results.some((result) => isTaskRunning(result));
+	if (hasRunning) return "Running";
+	return results.some(isTaskError) ? "Failed" : "Done";
+};
+
+const getChainStatus = (results: SingleResult[]): OverallStatus => {
+	const hasError = results.some(isTaskError);
+	if (hasError) return "Failed";
+	const hasInProgress = results.some((result) => isTaskRunning(result) || isTaskPending(result));
+	return hasInProgress ? "Running" : "Done";
+};
+
+const getStatusIcon = (status: TaskStatus | OverallStatus, theme: Theme): string => {
+	if (status === "Done") return theme.fg("success", "✓");
+	if (status === "Failed") return theme.fg("error", "✗");
+	return theme.fg("warning", "⏳");
+};
+
+const getToolCallItems = (result: SingleResult): ToolCallItem[] => {
+	if (result.toolEvents.length > 0) return result.toolEvents;
+	const items: ToolCallItem[] = [];
+	for (const message of result.messages) {
+		if (message.role === "assistant") {
+			for (const part of message.content) {
+				if (part.type === "toolCall") items.push({ id: part.id, name: part.name, args: part.arguments, status: "running" });
+			}
+		}
+	}
+	return items;
+};
+
+const getToolCallLines = (result: SingleResult, theme: Theme): string[] => {
+	const items = getToolCallItems(result);
+	const themeFg = theme.fg.bind(theme);
+	return items.map((item) => {
+		const icon = item.status === "success" ? themeFg("success", "✓ ") : item.status === "error" ? themeFg("error", "✗ ") : themeFg("warning", "→ ");
+		const output = item.output ? themeFg("dim", ` — ${item.output.slice(0, 80)}`) : "";
+		return `${icon}${formatToolCall(item.name, item.args, themeFg)}${output}`;
+	});
+};
+
+const getTaskOutputText = (result: SingleResult): string => {
+	if (isTaskError(result)) return getTaskErrorText(result);
+	return getFinalOutput(result.messages);
+};
+
+const formatFinalOutputText = (result: SingleResult): string => {
+	const output = getTaskOutputText(result).trim();
+	return output ? output : "(no output)";
+};
+
+const formatStatusLine = (status: TaskStatus | OverallStatus, indent: number, detail?: string): string => {
+	const base = `Status: ${status}`;
+	return indentLine(detail ? `${base} — ${detail}` : base, indent);
+};
+
+const buildTaskBlockLines = (options: { label: string; result: SingleResult; theme: Theme; indent: number }): string[] => {
+	const { label, result, theme, indent } = options;
+	const status = getTaskStatus(result);
+	const lines = [indentLine(`${theme.fg("toolTitle", label)} ${getStatusIcon(status, theme)}`, indent)];
+	lines.push(formatStatusLine(status, indent + 2));
+	const skillLabel = getTaskSkillLabel(result);
+	if (skillLabel) lines.push(formatLabeledLine("Skill", skillLabel, indent + 2));
+	const configLine = formatTaskConfig(result);
+	if (configLine) lines.push(formatLabeledLine("Subprocess", configLine, indent + 2));
+	lines.push(formatLabeledLine("Prompt", result.prompt.trim(), indent + 2));
+	const logLines = status === "Pending" ? [] : getToolCallLines(result, theme);
+	if (status !== "Pending") {
+		if (logLines.length > 0) lines.push(formatSection("Logs", logLines.join("\n"), indent + 2));
+		else lines.push(indentLine("Logs:", indent + 2));
+	}
+	if (status === "Done" || status === "Failed") {
+		lines.push(formatSection("Final output", formatFinalOutputText(result), indent + 2));
+		const usageStr = formatUsageStats(result.usage, result.model, result.thinking);
+		if (usageStr) lines.push(indentLine(`Usage: ${usageStr}`, indent + 2));
+	}
+	return lines;
+};
+
+const buildChainPrompt = (prompt: string, previousOutput: string): string => {
+	return prompt.replace(/\{previous\}/g, previousOutput);
+};
+
+const buildPendingPrompt = (prompt: string): string => {
+	return buildChainPrompt(prompt, "…");
+};
+
+const countCompletedTasks = (results: SingleResult[]): number => {
+	let count = 0;
+	for (const result of results) {
+		if (!isTaskRunning(result) && !isTaskPending(result)) count += 1;
+	}
+	return count;
+};
+
+const aggregateUsage = (results: SingleResult[]): UsageStats => {
+	const total: UsageStats = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 };
+	for (const result of results) {
+		total.input += result.usage.input;
+		total.output += result.usage.output;
+		total.cacheRead += result.usage.cacheRead;
+		total.cacheWrite += result.usage.cacheWrite;
+		total.cost += result.usage.cost;
+		total.turns += result.usage.turns;
+	}
+	return total;
+};
+
+const formatAvailableSkills = (skills: Skill[], maxItems: number): { text: string; remaining: number } => {
+	if (skills.length === 0) return { text: "none", remaining: 0 };
+	const listed = skills.slice(0, maxItems);
+	const remaining = skills.length - listed.length;
+	return {
+		text: listed.map((skill) => skill.name).join(", "),
+		remaining,
+	};
+};
+
+const buildSkillMessageBase = (skill: Skill): string => {
+	const content = fs.readFileSync(skill.filePath, "utf-8");
+	const body = stripYamlFrontmatter(content);
+	const header = `Skill location: ${skill.filePath}\nReferences are relative to ${skill.baseDir}.`;
+	return `${header}\n\n${body}`;
+};
+
+type SkillPromptState = {
+	skills: Skill[];
+	skillByName: Map<string, Skill>;
+	baseCache: Map<string, string>;
+};
+
+const createSkillPromptState = (skills: Skill[]): SkillPromptState => {
+	const skillByName = new Map<string, Skill>();
+	for (const skill of skills) skillByName.set(skill.name, skill);
+	return { skills, skillByName, baseCache: new Map<string, string>() };
+};
+
+const buildSubprocessPrompt = (
+	item: TaskWorkItem,
+	state: SkillPromptState,
+	skillListLimit: number,
+): { ok: true; prompt: string } | { ok: false; error: string } => {
+	if (!item.skill) return { ok: true, prompt: item.prompt };
+
+	const skill = state.skillByName.get(item.skill);
+	if (!skill) {
+		const available = formatAvailableSkills(state.skills, skillListLimit);
+		const suffix = available.remaining > 0 ? `, ... +${available.remaining} more` : "";
+		return {
+			ok: false,
+			error: `Unknown skill: ${item.skill}\nAvailable skills: ${available.text}${suffix}`,
+		};
+	}
+
+	let base = state.baseCache.get(skill.name);
+	if (!base) {
+		try {
+			base = buildSkillMessageBase(skill);
+			state.baseCache.set(skill.name, base);
+		} catch (err) {
+			return {
+				ok: false,
+				error: `Failed to load skill "${skill.name}": ${err instanceof Error ? err.message : String(err)}`,
+			};
+		}
+	}
+
+	return { ok: true, prompt: `${base}\n\n---\n\nUser: ${item.prompt}` };
+};
+
+const createPlaceholderResult = (
+	item: TaskWorkItem,
+	index: number | undefined,
+	thinking?: ThinkingLevel,
+	model?: string,
+	exitCode = -1,
+): SingleResult => {
+	return {
+		prompt: item.prompt,
+		skill: item.skill,
+		index,
+		exitCode,
+		messages: [],
+		toolEvents: [],
+		stderr: "",
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
+		model,
+		thinking,
+		fork: item.fork,
+	};
+};
+
+const getTaskSkillLabel = (result: { skill?: string } | undefined): string | undefined => {
+	const skill = result?.skill?.trim();
+	return skill ? skill : undefined;
+};
+
+const getTaskSummaryLabel = (result: SingleResult): string => {
+	const skillLabel = getTaskSkillLabel(result);
+	if (skillLabel) return skillLabel;
+	if (result.index) return `task ${result.index}`;
+	return "task";
+};
+
+const getTaskContextLabel = (result: SingleResult): string | undefined => {
+	if (result.fork === undefined) return undefined;
+	return result.fork ? "fork" : "fresh";
+};
+
+const isTaskError = (result: SingleResult): boolean => {
+	return result.exitCode > 0 || result.stopReason === "error" || result.stopReason === "aborted";
+};
+
+const getTaskErrorText = (result: SingleResult): string => {
+	return result.errorMessage || result.stderr || getFinalOutput(result.messages) || "(no output)";
+};
+
+const attachAbortSignal = (
+	proc: ChildProcessWithoutNullStreams,
+	signal: AbortSignal | undefined,
+): { isAborted: () => boolean } => {
+	let aborted = false;
+	if (!signal) return { isAborted: () => aborted };
+
+	const killProcess = () => {
+		aborted = true;
+		proc.kill("SIGTERM");
+		setTimeout(() => {
+			if (!proc.killed) proc.kill("SIGKILL");
+		}, 5000);
+	};
+
+	if (signal.aborted) killProcess();
+	else signal.addEventListener("abort", killProcess, { once: true });
+
+	return { isAborted: () => aborted };
+};
+
+const parseJsonLine = (line: string): Record<string, unknown> | undefined => {
+	if (!line.trim()) return undefined;
+	try {
+		const parsed = JSON.parse(line) as unknown;
+		return isRecord(parsed) ? parsed : undefined;
+	} catch {
+		return undefined;
+	}
+};
+
+const isMessage = (value: unknown): value is Message => {
+	if (!isRecord(value)) return false;
+	const role = value.role;
+	return role === "assistant" || role === "user" || role === "toolResult";
+};
+
+const applyAssistantUsage = (result: SingleResult, message: AssistantMessage): void => {
+	result.usage.turns += 1;
+	const usage = message.usage;
+
+	result.usage.input += usage.input ?? 0;
+	result.usage.output += usage.output ?? 0;
+	result.usage.cacheRead += usage.cacheRead ?? 0;
+	result.usage.cacheWrite += usage.cacheWrite ?? 0;
+	result.usage.cost += usage.cost?.total ?? 0;
+	result.usage.contextTokens = usage.totalTokens ?? 0;
+};
+
+const handleEventMessage = (result: SingleResult, message: Message): void => {
+	result.messages.push(message);
+
+	if (message.role !== "assistant") return;
+
+	applyAssistantUsage(result, message);
+	if (!result.model && message.model) result.model = message.model;
+	if (message.stopReason) result.stopReason = message.stopReason;
+	if (message.errorMessage) result.errorMessage = message.errorMessage;
+};
+
+const prepareTaskExecutions = (options: {
+	items: TaskWorkItem[];
+	state: SkillPromptState;
+	skillListLimit: number;
+	defaultModel: string | undefined;
+	defaultThinking: TaskThinking;
+	inheritedThinking: ThinkingLevel;
+	ctxModel: { provider: string; id: string } | undefined;
+	builtInTools: BuiltInToolName[];
+}): { ok: true; executions: PreparedExecution[] } | { ok: false; error: string } => {
+	const executions: PreparedExecution[] = [];
+	for (const item of options.items) {
+		const prepared = buildSubprocessPrompt(item, options.state, options.skillListLimit);
+		if (!prepared.ok) return prepared;
+		const config = resolveTaskConfig({
+			item,
+			defaultModel: options.defaultModel,
+			defaultThinking: options.defaultThinking,
+			inheritedThinking: options.inheritedThinking,
+			ctxModel: options.ctxModel,
+			builtInTools: options.builtInTools,
+		});
+		if (!config.ok) return config;
+		executions.push({
+			task: { item, subprocessPrompt: prepared.prompt },
+			config: {
+				thinkingLevel: config.thinkingLevel,
+				subprocessArgs: config.subprocessArgs,
+				modelLabel: config.modelLabel,
+			},
+		});
+	}
+	return { ok: true, executions };
+};
+
+const stringifyToolOutput = (value: unknown): string | undefined => {
+	if (value === undefined) return undefined;
+	if (typeof value === "string") return value;
+	if (isRecord(value)) {
+		const content = value.content;
+		if (Array.isArray(content)) {
+			const text = content
+				.map((part) => isRecord(part) && part.type === "text" && typeof part.text === "string" ? part.text : undefined)
+				.filter((part): part is string => part !== undefined)
+				.join("\n");
+			if (text.trim().length > 0) return text;
+		}
+	}
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+};
+
+const upsertToolEvent = (result: SingleResult, event: ToolCallItem): void => {
+	const key = event.id ?? `${event.name}:${JSON.stringify(event.args)}`;
+	const index = result.toolEvents.findIndex((item) => (item.id ?? `${item.name}:${JSON.stringify(item.args)}`) === key);
+	if (index === -1) {
+		result.toolEvents.push(event);
+		return;
+	}
+	result.toolEvents[index] = { ...result.toolEvents[index], ...event };
+};
+
+const mapWithConcurrencyLimit = async <TIn, TOut>(
+	items: TIn[],
+	concurrency: number,
+	fn: (item: TIn, index: number) => Promise<TOut>,
+): Promise<TOut[]> => {
+	if (items.length === 0) return [];
+	const limit = Math.max(1, Math.min(concurrency, items.length));
+	const results: TOut[] = new Array(items.length);
+	let nextIndex = 0;
+
+	const runWorker = async (): Promise<void> => {
+		const currentIndex = nextIndex;
+		nextIndex += 1;
+		if (currentIndex >= items.length) return;
+		results[currentIndex] = await fn(items[currentIndex], currentIndex);
+		await runWorker();
+	};
+
+	await Promise.all(new Array(limit).fill(null).map(async () => runWorker()));
+	return results;
+};
+
+const runSingleTask = async (options: {
+	defaultCwd: string;
+	item: TaskWorkItem;
+	subprocessPrompt: string;
+	index: number | undefined;
+	subprocessArgs: string[];
+	modelLabel: string | undefined;
+	thinking: ThinkingLevel;
+	fork: boolean;
+	sessionFile: string | undefined;
+	signal: AbortSignal | undefined;
+	onResultUpdate: ((result: SingleResult) => void) | undefined;
+}): Promise<SingleResult> => {
+	const currentResult: SingleResult = {
+		prompt: options.item.prompt,
+		skill: options.item.skill,
+		index: options.index,
+		exitCode: -1,
+		messages: [],
+		toolEvents: [],
+		stderr: "",
+		usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
+		model: options.modelLabel,
+		thinking: options.thinking,
+		fork: options.fork,
+	};
+
+	const emitUpdate = () => {
+		options.onResultUpdate?.(currentResult);
+	};
+
+	let forkSession: ForkSession | undefined;
+	if (options.fork) {
+		if (!options.sessionFile) {
+			currentResult.exitCode = 1;
+			currentResult.errorMessage = "Forked tasks require a persisted session file.";
+			return currentResult;
+		}
+		try {
+			forkSession = await createForkSession(options.sessionFile);
+		} catch (error) {
+			currentResult.exitCode = 1;
+			currentResult.errorMessage = error instanceof Error ? error.message : String(error);
+			return currentResult;
+		}
+	}
+
+	try {
+		const args = [...applyForkSessionArgs(options.subprocessArgs, forkSession), options.subprocessPrompt];
+
+		const exitCode = await new Promise<number>((resolve) => {
+			const proc = spawn("pi", args, {
+				cwd: options.defaultCwd,
+				shell: false,
+				stdio: ["pipe", "pipe", "pipe"],
+			});
+
+			proc.stdin.end();
+
+			const abortState = attachAbortSignal(proc, options.signal);
+
+			let buffer = "";
+			const processLine = (line: string) => {
+				const event = parseJsonLine(line);
+				if (!event) return;
+				const typeValue = event.type;
+				const typeText = typeof typeValue === "string" ? typeValue : "";
+				if (typeText === "message_update") {
+					const assistantEvent = isRecord(event.assistantMessageEvent) ? event.assistantMessageEvent : undefined;
+					if (assistantEvent?.type === "text_delta" && typeof assistantEvent.delta === "string") {
+						currentResult.streamingText = `${currentResult.streamingText ?? ""}${assistantEvent.delta}`;
+						emitUpdate();
+					}
+				}
+				if (typeText === "tool_execution_start") {
+					upsertToolEvent(currentResult, {
+						id: typeof event.toolCallId === "string" ? event.toolCallId : undefined,
+						name: typeof event.toolName === "string" ? event.toolName : "tool",
+						args: isRecord(event.args) ? event.args : {},
+						status: "running",
+					});
+					emitUpdate();
+				}
+				if (typeText === "tool_execution_update") {
+					upsertToolEvent(currentResult, {
+						id: typeof event.toolCallId === "string" ? event.toolCallId : undefined,
+						name: typeof event.toolName === "string" ? event.toolName : "tool",
+						args: isRecord(event.args) ? event.args : {},
+						status: "running",
+						output: stringifyToolOutput(event.partialResult),
+					});
+					emitUpdate();
+				}
+				if (typeText === "tool_execution_end") {
+					upsertToolEvent(currentResult, {
+						id: typeof event.toolCallId === "string" ? event.toolCallId : undefined,
+						name: typeof event.toolName === "string" ? event.toolName : "tool",
+						args: isRecord(event.args) ? event.args : {},
+						status: event.isError === true ? "error" : "success",
+						output: stringifyToolOutput(event.result),
+					});
+					emitUpdate();
+				}
+				const messageValue = event.message;
+				if ((typeText === "message_end" || typeText === "tool_result_end") && isMessage(messageValue)) {
+					handleEventMessage(currentResult, messageValue);
+					emitUpdate();
+				}
+			};
+
+			proc.stdout.on("data", (data) => {
+				buffer += data.toString();
+				const lines = buffer.split("\n");
+				buffer = lines.pop() ?? "";
+				for (const line of lines) processLine(line);
+			});
+
+			proc.stderr.on("data", (data) => {
+				currentResult.stderr += data.toString();
+			});
+
+			proc.on("close", (code) => {
+				if (buffer.trim()) processLine(buffer);
+				currentResult.exitCode = code ?? 0;
+				if (abortState.isAborted()) currentResult.stopReason = "aborted";
+				resolve(code ?? 0);
+			});
+
+			proc.on("error", () => {
+				currentResult.exitCode = 1;
+				resolve(1);
+			});
+		});
+
+		currentResult.exitCode = exitCode;
+		return currentResult;
+	} finally {
+		await cleanupForkSession(forkSession);
+	}
+};
+
+const ModelOverrideSchema = Type.Optional(Type.String({ description: "Optional model override: provider/modelId" }));
+
+const ThinkingOverrideSchema = Type.Optional(
+	Type.String({
+		enum: [...VALID_THINKING_OPTIONS],
+		description: "Thinking level override: off, minimal, low, medium, high, xhigh, or inherit",
+	}),
+);
+
+const TaskItemSchema = Type.Object({
+	prompt: Type.String({ description: "Task prompt" }),
+	skill: Type.Optional(Type.String({ description: "Optional skill name" })),
+	model: ModelOverrideSchema,
+	thinking: ThinkingOverrideSchema,
+	fork: Type.Optional(Type.Boolean({ description: "Fork context from current session (default: true)" })),
+});
+
+const TaskParams = Type.Object({
+	type: Type.String({
+		enum: ["single", "chain", "parallel"],
+		description: "Execution mode: single prompt, chain or parallel tasks",
+	}),
+	tasks: Type.Array(TaskItemSchema, {
+		minItems: 1,
+		description: "Tasks to run (single expects exactly one).",
+	}),
+	model: ModelOverrideSchema,
+	thinking: ThinkingOverrideSchema,
+});
+
+const renderSingleResult = (result: SingleResult, _expanded: boolean, theme: Theme): Text => {
+	const lines = buildTaskBlockLines({ label: "task", result, theme, indent: 0 });
+	return new Text(lines.join("\n"), 0, 0);
+};
+
+const renderParallelResult = (results: SingleResult[], _expanded: boolean, theme: Theme): Text => {
+	const status = getParallelStatus(results);
+	const doneCount = countCompletedTasks(results);
+	const lines = [
+		indentLine(`${theme.fg("toolTitle", "task (parallel)")} ${getStatusIcon(status, theme)}`, 0),
+		formatStatusLine(status, 2, status === "Running" ? `${doneCount}/${results.length} done` : undefined),
+		indentLine("Tasks:", 2),
+	];
+
+	for (let index = 0; index < results.length; index++) {
+		if (index > 0) lines.push("");
+		lines.push(...buildTaskBlockLines({ label: "task", result: results[index], theme, indent: 4 }));
+	}
+
+	const usageStr = formatUsageStats(aggregateUsage(results));
+	if (usageStr) {
+		lines.push("");
+		const totalLabel = status === "Running" ? "Total usage so far" : "Total usage";
+		lines.push(indentLine(`${totalLabel}: ${usageStr}`, 2));
+	}
+
+	return new Text(lines.join("\n"), 0, 0);
+};
+
+const renderChainResult = (results: SingleResult[], _expanded: boolean, theme: Theme): Text => {
+	const status = getChainStatus(results);
+	const doneCount = countCompletedTasks(results);
+	const lines = [
+		indentLine(`${theme.fg("toolTitle", "task (chain)")} ${getStatusIcon(status, theme)}`, 0),
+		formatStatusLine(status, 2, status === "Running" ? `${doneCount}/${results.length} done` : undefined),
+		indentLine("Steps:", 2),
+	];
+
+	for (let index = 0; index < results.length; index++) {
+		if (index > 0) lines.push("");
+		const result = results[index];
+		const stepNumber = result.index ?? index + 1;
+		lines.push(...buildTaskBlockLines({ label: `Step ${stepNumber} (task)`, result, theme, indent: 4 }));
+	}
+
+	const usageStr = formatUsageStats(aggregateUsage(results));
+	if (usageStr) {
+		lines.push("");
+		const totalLabel = status === "Running" ? "Total usage so far" : "Total usage";
+		lines.push(indentLine(`${totalLabel}: ${usageStr}`, 2));
+	}
+
+	return new Text(lines.join("\n"), 0, 0);
+};
+
+export const taskTool = (options: TaskToolOptions = DEFAULT_OPTIONS) => (pi: ExtensionAPI) => {
+	const merged = { ...DEFAULT_OPTIONS, ...options };
+
+	pi.registerTool({
+		name: merged.name,
+		label: merged.label,
+		description: merged.description,
+		parameters: TaskParams,
+
+		async execute(_toolCallId, params, signal, onUpdate, ctx) {
+			const normalized = normalizeTaskParams(params as unknown, { maxParallelTasks: merged.maxParallelTasks });
+			if (!normalized.ok) {
+				const discovery = loadSkillDiscovery(ctx.cwd);
+				const available = formatAvailableSkills(discovery.skills, merged.skillListLimit);
+				const suffix = available.remaining > 0 ? `, ... +${available.remaining} more` : "";
+				return {
+					content: [{ type: "text", text: `${normalized.error}\nAvailable skills: ${available.text}${suffix}` }],
+					details: { mode: "single", results: [] } as TaskToolDetails,
+				};
+			}
+
+			const discovery = loadSkillDiscovery(ctx.cwd);
+			const skillState = createSkillPromptState(discovery.skills);
+
+			const inheritedThinking = pi.getThinkingLevel();
+			const builtInTools = getBuiltInToolsFromActiveTools(pi.getActiveTools());
+			const ctxModel = ctx.model ? { provider: ctx.model.provider, id: ctx.model.id } : undefined;
+
+			const makeDetails = (results: SingleResult[]): TaskToolDetails => {
+				return { mode: normalized.value.mode, modelOverride: normalized.value.model, results };
+			};
+
+			const requiresFork = normalized.value.items.some((item) => item.fork);
+			const sessionFile = requiresFork ? ctx.sessionManager.getSessionFile() : undefined;
+			if (requiresFork && !sessionFile) {
+				return {
+					content: [
+						{
+							type: "text",
+							text: "Forked tasks require a persisted session file. Set fork: false or start pi with sessions enabled.",
+						},
+					],
+					details: makeDetails([]),
+					isError: true,
+				};
+			}
+
+			if (normalized.value.mode === "single") {
+				const prepared = prepareTaskExecutions({
+					items: normalized.value.items,
+					state: skillState,
+					skillListLimit: merged.skillListLimit,
+					defaultModel: normalized.value.model,
+					defaultThinking: normalized.value.thinking,
+					inheritedThinking,
+					ctxModel,
+					builtInTools,
+				});
+				if (!prepared.ok) {
+					return {
+						content: [{ type: "text", text: prepared.error }],
+						details: makeDetails([]),
+					};
+				}
+
+				const execution = prepared.executions[0];
+				const initial = createPlaceholderResult(
+					execution.task.item,
+					undefined,
+					execution.config.thinkingLevel,
+					execution.config.modelLabel,
+				);
+				const emitSingleUpdate = (result: SingleResult) => {
+					if (!onUpdate) return;
+					onUpdate({
+						content: [{ type: "text", text: getFinalOutput(result.messages) || "(running...)" }],
+						details: makeDetails([result]),
+					});
+				};
+				emitSingleUpdate(initial);
+
+				const result = await runSingleTask({
+					defaultCwd: ctx.cwd,
+					item: execution.task.item,
+					subprocessPrompt: execution.task.subprocessPrompt,
+					index: undefined,
+					subprocessArgs: execution.config.subprocessArgs,
+					modelLabel: execution.config.modelLabel,
+					thinking: execution.config.thinkingLevel,
+					fork: execution.task.item.fork,
+					sessionFile,
+					signal,
+					onResultUpdate: emitSingleUpdate,
+				});
+
+				const error = isTaskError(result);
+				if (error) {
+					return {
+						content: [{ type: "text", text: `Task failed: ${getTaskErrorText(result)}` }],
+						details: makeDetails([result]),
+						isError: true,
+					};
+				}
+
+				return {
+					content: [{ type: "text", text: getFinalOutput(result.messages) || "(no output)" }],
+					details: makeDetails([result]),
+				};
+			}
+
+			if (normalized.value.mode === "chain") {
+				const results = normalized.value.items.map((item, index) =>
+					createPlaceholderResult(
+						{ ...item, prompt: buildPendingPrompt(item.prompt) },
+						index + 1,
+						undefined,
+						undefined,
+						-2,
+					),
+				);
+				let previousOutput = "";
+
+				for (let index = 0; index < normalized.value.items.length; index++) {
+					const item = normalized.value.items[index];
+					const prompt = buildChainPrompt(item.prompt, previousOutput);
+					const stepItem = { ...item, prompt };
+
+					const config = resolveTaskConfig({
+						item,
+						defaultModel: normalized.value.model,
+						defaultThinking: normalized.value.thinking,
+						inheritedThinking,
+						ctxModel,
+						builtInTools,
+					});
+					if (!config.ok) {
+						return {
+							content: [{ type: "text", text: config.error }],
+							details: makeDetails([...results]),
+						};
+					}
+
+					const preparedPrompt = buildSubprocessPrompt(stepItem, skillState, merged.skillListLimit);
+					if (!preparedPrompt.ok) {
+						return {
+							content: [{ type: "text", text: preparedPrompt.error }],
+							details: makeDetails([...results]),
+						};
+					}
+
+					results[index] = createPlaceholderResult(
+						stepItem,
+						index + 1,
+						config.thinkingLevel,
+						config.modelLabel,
+					);
+					if (onUpdate) {
+						onUpdate({
+							content: [{ type: "text", text: "(running...)" }],
+							details: makeDetails([...results]),
+						});
+					}
+
+					const chainUpdate = onUpdate
+						? (partial: SingleResult) => {
+								results[index] = partial;
+								onUpdate({
+									content: [{ type: "text", text: getFinalOutput(partial.messages) || "(running...)" }],
+									details: makeDetails([...results]),
+								});
+							}
+						: undefined;
+
+					const result = await runSingleTask({
+						defaultCwd: ctx.cwd,
+						item: stepItem,
+						subprocessPrompt: preparedPrompt.prompt,
+						index: index + 1,
+						subprocessArgs: config.subprocessArgs,
+						modelLabel: config.modelLabel,
+						thinking: config.thinkingLevel,
+						fork: stepItem.fork,
+						sessionFile,
+						signal,
+						onResultUpdate: chainUpdate,
+					});
+					results[index] = result;
+					if (onUpdate) {
+						onUpdate({
+							content: [{ type: "text", text: getFinalOutput(result.messages) || "(no output)" }],
+							details: makeDetails([...results]),
+						});
+					}
+
+					if (isTaskError(result)) {
+						return {
+							content: [
+								{ type: "text", text: `Chain stopped at step ${index + 1}: ${getTaskErrorText(result)}` },
+							],
+							details: makeDetails([...results]),
+							isError: true,
+						};
+					}
+
+					previousOutput = getFinalOutput(result.messages);
+				}
+
+				const last = results[results.length - 1];
+				return {
+					content: [{ type: "text", text: getFinalOutput(last.messages) || "(no output)" }],
+					details: makeDetails([...results]),
+				};
+			}
+
+			const prepared = prepareTaskExecutions({
+				items: normalized.value.items,
+				state: skillState,
+				skillListLimit: merged.skillListLimit,
+				defaultModel: normalized.value.model,
+				defaultThinking: normalized.value.thinking,
+				inheritedThinking,
+				ctxModel,
+				builtInTools,
+			});
+			if (!prepared.ok) {
+				return {
+					content: [{ type: "text", text: prepared.error }],
+					details: makeDetails([]),
+				};
+			}
+
+			const allResults = prepared.executions.map((execution, index) =>
+				createPlaceholderResult(
+					execution.task.item,
+					index + 1,
+					execution.config.thinkingLevel,
+					execution.config.modelLabel,
+				),
+			);
+
+			const emitParallelUpdate = () => {
+				if (!onUpdate) return;
+				const running = allResults.filter((result) => result.exitCode === -1).length;
+				const done = allResults.filter((result) => result.exitCode !== -1).length;
+				onUpdate({
+					content: [{ type: "text", text: `Parallel: ${done}/${allResults.length} done, ${running} running...` }],
+					details: makeDetails([...allResults]),
+				});
+			};
+
+			emitParallelUpdate();
+
+			const results = await mapWithConcurrencyLimit(
+				prepared.executions,
+				merged.maxConcurrency,
+				async (execution, index) => {
+					const result = await runSingleTask({
+						defaultCwd: ctx.cwd,
+						item: execution.task.item,
+						subprocessPrompt: execution.task.subprocessPrompt,
+						index: index + 1,
+						subprocessArgs: execution.config.subprocessArgs,
+						modelLabel: execution.config.modelLabel,
+						thinking: execution.config.thinkingLevel,
+						fork: execution.task.item.fork,
+						sessionFile,
+						signal,
+						onResultUpdate: (partial) => {
+							allResults[index] = partial;
+							emitParallelUpdate();
+						},
+					});
+					allResults[index] = result;
+					emitParallelUpdate();
+					return result;
+				},
+			);
+
+			const successCount = results.filter((result) => !isTaskError(result)).length;
+			const summaries = results.map((result) => {
+				const output = getFinalOutput(result.messages);
+				const preview = output.slice(0, 100) + (output.length > 100 ? "..." : "");
+				return `[${getTaskSummaryLabel(result)}] ${isTaskError(result) ? "failed" : "completed"}: ${preview || "(no output)"}`;
+			});
+
+			return {
+				content: [
+					{
+						type: "text",
+						text: `Parallel: ${successCount}/${results.length} succeeded\n\n${summaries.join("\n\n")}`,
+					},
+				],
+				details: makeDetails(results),
+			};
+		},
+
+		renderCall(_args, _theme) {
+			return new Text("", 0, 0);
+		},
+
+		renderResult(result, { expanded }, theme) {
+			const details = result.details as TaskToolDetails | undefined;
+			if (!details || details.results.length === 0) {
+				const textBlock = result.content[0];
+				return new Text(textBlock?.type === "text" ? textBlock.text : "(no output)", 0, 0);
+			}
+
+			if (details.mode === "single" && details.results.length === 1) {
+				return renderSingleResult(details.results[0], expanded, theme);
+			}
+
+			if (details.mode === "chain") {
+				return renderChainResult(details.results, expanded, theme);
+			}
+
+			if (details.mode === "parallel") {
+				return renderParallelResult(details.results, expanded, theme);
+			}
+
+			const textBlock = result.content[0];
+			return new Text(textBlock?.type === "text" ? textBlock.text : "(no output)", 0, 0);
+		},
+	});
+
+	pi.on("before_agent_start", async (event, _ctx) => {
+		return {
+			systemPrompt: applyPromptPatches(event.systemPrompt, merged.systemPromptPatches),
+		};
+	});
+};

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
@@ -221,6 +221,49 @@ describe("ChatViewportController", () => {
 		root.dispose();
 	});
 
+	it("folds live task results into the active scroll block", async () => {
+		const { root, chat, controller } = await makeController();
+		const taskCall = {
+			type: "toolCall",
+			id: "tc-task",
+			name: "task",
+			arguments: {
+				type: "single",
+				model: "openai-codex/gpt-5.5",
+				thinking: "high",
+				tasks: [{ prompt: "You are Zeus.\n\n## Verify issue 194 scroll metadata rendering\n\nReturn one line." }],
+			},
+		};
+
+		controller.handleAgentEvent({ type: "message_start", message: { role: "assistant", content: "" } });
+		controller.handleAgentEvent({ type: "message_update", message: { role: "assistant", content: [taskCall] } });
+		controller.handleAgentEvent({ type: "message_end", message: { role: "assistant", content: [taskCall] } });
+		controller.handleAgentEvent({ type: "message_start", message: { role: "toolResult", toolCallId: "tc-task", toolName: "task", name: "task", content: [{ type: "text", text: "Task tool ran." }] } });
+
+		const messages = chat.getRenderedMessages().map((message) => message.toSnapshot());
+		expect(messages).toHaveLength(1);
+		expect(messages[0]?.role).toBe("sumo");
+		expect(messages[0]?.blocks).toEqual([
+			{
+				type: "delegation",
+				delegation: {
+					id: "tc-task",
+					title: "Verify issue 194 scroll metadata rendering",
+					agent: "scribe",
+					model: "openai-codex/gpt-5.5",
+					thinking: "high",
+					status: "success",
+					summary: "Task tool ran.",
+					nestedTools: [],
+					tokensIn: undefined,
+					tokensOut: undefined,
+					elapsedMs: undefined,
+				},
+			},
+		]);
+		root.dispose();
+	});
+
 	it("keeps assistant-only tool blocks under SUMO instead of TOOL", async () => {
 		const { root, chat, controller } = await makeController();
 

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
@@ -253,6 +253,7 @@ describe("ChatViewportController", () => {
 					model: "openai-codex/gpt-5.5",
 					thinking: "high",
 					status: "success",
+					prompt: "Return one line.",
 					summary: "Task tool ran.",
 					nestedTools: [],
 					tokensIn: undefined,
@@ -261,6 +262,120 @@ describe("ChatViewportController", () => {
 				},
 			},
 		]);
+		root.dispose();
+	});
+
+	it("does not merge explicit unmatched delegation ids into another running scroll", async () => {
+		const { root, chat, controller } = await makeController();
+		const firstCall = { type: "toolCall", id: "task-a", name: "task", arguments: { type: "single", tasks: [{ prompt: "## First task" }] } };
+		const secondCall = { type: "toolCall", id: "task-b", name: "task", arguments: { type: "single", tasks: [{ prompt: "## Second task" }] } };
+
+		controller.handleAgentEvent({ type: "message_start", message: { role: "assistant", content: "" } });
+		controller.handleAgentEvent({ type: "message_update", message: { role: "assistant", content: [firstCall] } });
+		controller.handleAgentEvent({
+			type: "tool_execution_update",
+			toolCallId: "task-b",
+			toolName: "task",
+			args: secondCall.arguments,
+			partialResult: {
+				content: [{ type: "text", text: "second running" }],
+				details: { mode: "single", results: [{ prompt: "## Second task", exitCode: -1, messages: [], usage: {} }] },
+			},
+		});
+
+		const blocks = chat.getRenderedMessages()[0]?.toSnapshot().blocks;
+		expect(blocks).toHaveLength(2);
+		expect(blocks?.[0]).toMatchObject({ type: "delegation", delegation: { id: "task-a", title: "First task" } });
+		expect(blocks?.[1]).toMatchObject({ type: "delegation", delegation: { id: "task-b", title: "Second task" } });
+		root.dispose();
+	});
+
+	it("ignores task execution start events without partial result details", async () => {
+		const { root, chat, controller } = await makeController();
+		const taskCall = { type: "toolCall", id: "tc-task", name: "task", arguments: { type: "single", tasks: [{ prompt: "## Running task" }] } };
+
+		controller.handleAgentEvent({ type: "message_start", message: { role: "assistant", content: "" } });
+		controller.handleAgentEvent({ type: "message_update", message: { role: "assistant", content: [taskCall] } });
+		controller.handleAgentEvent({ type: "tool_execution_start", toolCallId: "tc-task", toolName: "task", args: taskCall.arguments });
+
+		const block = chat.getRenderedMessages()[0]?.toSnapshot().blocks?.[0];
+		expect(block).toMatchObject({ type: "delegation", delegation: { title: "Running task", status: "running" } });
+		root.dispose();
+	});
+
+	it("updates the active task scroll from tool execution partial details", async () => {
+		const { root, chat, controller } = await makeController();
+		const taskCall = {
+			type: "toolCall",
+			id: "tc-task",
+			name: "task",
+			arguments: { type: "single", tasks: [{ prompt: "## Audit auth\n\nFind risky files." }] },
+		};
+
+		controller.handleAgentEvent({ type: "message_start", message: { role: "assistant", content: "" } });
+		controller.handleAgentEvent({ type: "message_update", message: { role: "assistant", content: [taskCall] } });
+		controller.handleAgentEvent({
+			type: "tool_execution_update",
+			toolCallId: "tc-task",
+			toolName: "task",
+			args: taskCall.arguments,
+			partialResult: {
+				content: [{ type: "text", text: "reading auth files" }],
+				details: {
+					mode: "single",
+					results: [{
+						prompt: "## Audit auth\n\nFind risky files.",
+						exitCode: -1,
+						messages: [],
+						toolEvents: [{ id: "read-1", name: "read", args: { path: "src/auth.ts" }, status: "running" }],
+						usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
+						model: "openai-codex/gpt-5.5",
+						thinking: "high",
+					}],
+				},
+			},
+		});
+
+		const message = chat.getRenderedMessages()[0]?.toSnapshot();
+		expect(message?.blocks?.[0]).toMatchObject({
+			type: "delegation",
+			delegation: {
+				title: "Audit auth",
+				model: "openai-codex/gpt-5.5",
+				thinking: "high",
+				status: "running",
+				nestedTools: [{ id: "read-1", name: "read", status: "running", input: { path: "src/auth.ts" } }],
+			},
+		});
+		root.dispose();
+	});
+
+	it("shows task body while a live scroll is still running", async () => {
+		const { root, chat, controller } = await makeController();
+		const taskCall = {
+			type: "toolCall",
+			id: "tc-task",
+			name: "task",
+			arguments: {
+				prompt: "You are Zeus.\n\n## Verify issue 194 live scroll result folding\n\nRespond with exactly this sentence:\nTask output visible inside scribe.",
+				thinking: "minimal",
+			},
+		};
+
+		controller.handleAgentEvent({ type: "message_start", message: { role: "assistant", content: "" } });
+		controller.handleAgentEvent({ type: "message_update", message: { role: "assistant", content: [taskCall] } });
+
+		const message = chat.getRenderedMessages()[0]?.toSnapshot();
+		expect(message?.blocks?.[0]).toMatchObject({
+			type: "delegation",
+			delegation: {
+				title: "Verify issue 194 live scroll result folding",
+				thinking: "minimal",
+				status: "running",
+				prompt: "Respond with exactly this sentence:\nTask output visible inside scribe.",
+				summary: undefined,
+			},
+		});
 		root.dispose();
 	});
 

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -224,7 +224,7 @@ function upsertFoldableBlock(blocks: readonly ChatBlock[], incoming: ChatBlock):
 		const byId = incomingId
 			? blocks.findIndex((block) => block.type === "delegation" && block.delegation.id === incomingId)
 			: -1;
-		const byRunning = byId === -1
+		const byRunning = !incomingId && byId === -1
 			? blocks.findIndex((block) => block.type === "delegation" && (block.delegation.status === "queued" || block.delegation.status === "running"))
 			: -1;
 		const index = byId !== -1 ? byId : byRunning;
@@ -524,6 +524,11 @@ export class ChatViewportController {
 			case "message_end":
 				this.handleMessageEnd(message);
 				break;
+			case "tool_execution_start":
+			case "tool_execution_update":
+			case "tool_execution_end":
+				this.handleToolExecutionEvent(record);
+				break;
 			case "agent_end":
 				this.chat.endStreaming();
 				break;
@@ -554,6 +559,27 @@ export class ChatViewportController {
 				archivedMessages: stats.archivedMessages,
 			});
 		}
+	}
+
+	private handleToolExecutionEvent(record: Record<string, unknown>): void {
+		if (record.toolName !== "task") return;
+		this.markRenderDirty();
+		if (record.type !== "tool_execution_end" && record.partialResult === undefined) return;
+		const result = record.type === "tool_execution_end" ? record.result : record.partialResult;
+		const resultRecord = asRecord(result);
+		const viewModel = this.viewModelMapper.messageFromPiMessage({
+			role: "toolResult",
+			toolCallId: record.toolCallId,
+			toolName: "task",
+			name: "task",
+			arguments: record.args,
+			content: resultRecord?.content ?? [],
+			details: resultRecord?.details,
+			isError: record.isError,
+		});
+		if (!viewModel || !isFoldableOnlyViewModel(viewModel) || !this.liveAssistant) return;
+		this.foldBlocksIntoAssistant(viewModel.blocks);
+		this.runtime.requestRender();
 	}
 
 	private handleMessageStart(message: unknown): void {

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -6,8 +6,8 @@ import { measureMaybe, ResumeProfiler, type ResumeProfileMetadata } from "../run
 import {
 	chatMessageViewModelFromPiMessage,
 	chatMessageViewModelToPlainText,
+	createTranscriptViewModelMapper,
 	markdownAndCodeBlocksFromText,
-	transcriptFromSessionContext,
 	type ChatBlock,
 	type ChatMessageViewModel,
 } from "../transcript/view-model.js";
@@ -159,12 +159,15 @@ function addViewModel(chat: ChatPager, message: ChatMessageViewModel): void {
 	chat.addViewModel(message);
 }
 
-function isToolOnlyViewModel(message: ChatMessageViewModel): boolean {
-	return message.blocks.length > 0 && message.blocks.every((block) => block.type === "tool");
+function isFoldableBlock(block: ChatBlock): boolean {
+	return block.type === "tool" || block.type === "delegation";
 }
 
-function mergeToolBlock(existing: ChatBlock, incoming: ChatBlock): ChatBlock {
-	if (existing.type !== "tool" || incoming.type !== "tool") return incoming;
+function isFoldableOnlyViewModel(message: ChatMessageViewModel): boolean {
+	return message.blocks.length > 0 && message.blocks.every(isFoldableBlock);
+}
+
+function mergeToolBlock(existing: Extract<ChatBlock, { type: "tool" }>, incoming: Extract<ChatBlock, { type: "tool" }>): ChatBlock {
 	return {
 		type: "tool",
 		tool: {
@@ -176,18 +179,60 @@ function mergeToolBlock(existing: ChatBlock, incoming: ChatBlock): ChatBlock {
 	};
 }
 
-function upsertToolBlock(blocks: readonly ChatBlock[], incoming: ChatBlock): ChatBlock[] {
-	if (incoming.type !== "tool") return [...blocks, incoming];
-	const incomingId = incoming.tool.id;
-	const byId = incomingId
-		? blocks.findIndex((block) => block.type === "tool" && block.tool.id === incomingId)
-		: -1;
-	const byName = byId === -1
-		? blocks.findIndex((block) => block.type === "tool" && block.tool.id === undefined && block.tool.name === incoming.tool.name && (block.tool.status === "pending" || block.tool.status === "running"))
-		: -1;
-	const index = byId !== -1 ? byId : byName;
-	if (index === -1) return [...blocks, incoming];
-	return blocks.map((block, blockIndex) => blockIndex === index ? mergeToolBlock(block, incoming) : block);
+function mergeDelegationBlock(existing: Extract<ChatBlock, { type: "delegation" }>, incoming: Extract<ChatBlock, { type: "delegation" }>): ChatBlock {
+	const incomingTitle = incoming.delegation.title;
+	const keepExistingTitle = existing.delegation.title !== "task" && (incomingTitle === "task" || incomingTitle === "delegation");
+	return {
+		type: "delegation",
+		delegation: {
+			...existing.delegation,
+			...incoming.delegation,
+			title: keepExistingTitle ? existing.delegation.title : incoming.delegation.title,
+			agent: incoming.delegation.agent ?? existing.delegation.agent,
+			model: incoming.delegation.model ?? existing.delegation.model,
+			thinking: incoming.delegation.thinking ?? existing.delegation.thinking,
+			nestedTools: (incoming.delegation.nestedTools?.length ?? 0) > 0 ? incoming.delegation.nestedTools : existing.delegation.nestedTools,
+			tokensIn: incoming.delegation.tokensIn ?? existing.delegation.tokensIn,
+			tokensOut: incoming.delegation.tokensOut ?? existing.delegation.tokensOut,
+			elapsedMs: incoming.delegation.elapsedMs ?? existing.delegation.elapsedMs,
+		},
+	};
+}
+
+function mergeFoldableBlock(existing: ChatBlock, incoming: ChatBlock): ChatBlock {
+	if (existing.type === "tool" && incoming.type === "tool") return mergeToolBlock(existing, incoming);
+	if (existing.type === "delegation" && incoming.type === "delegation") return mergeDelegationBlock(existing, incoming);
+	return incoming;
+}
+
+function upsertFoldableBlock(blocks: readonly ChatBlock[], incoming: ChatBlock): ChatBlock[] {
+	if (incoming.type === "tool") {
+		const incomingId = incoming.tool.id;
+		const byId = incomingId
+			? blocks.findIndex((block) => block.type === "tool" && block.tool.id === incomingId)
+			: -1;
+		const byName = byId === -1
+			? blocks.findIndex((block) => block.type === "tool" && block.tool.id === undefined && block.tool.name === incoming.tool.name && (block.tool.status === "pending" || block.tool.status === "running"))
+			: -1;
+		const index = byId !== -1 ? byId : byName;
+		if (index === -1) return [...blocks, incoming];
+		return blocks.map((block, blockIndex) => blockIndex === index ? mergeFoldableBlock(block, incoming) : block);
+	}
+
+	if (incoming.type === "delegation") {
+		const incomingId = incoming.delegation.id;
+		const byId = incomingId
+			? blocks.findIndex((block) => block.type === "delegation" && block.delegation.id === incomingId)
+			: -1;
+		const byRunning = byId === -1
+			? blocks.findIndex((block) => block.type === "delegation" && (block.delegation.status === "queued" || block.delegation.status === "running"))
+			: -1;
+		const index = byId !== -1 ? byId : byRunning;
+		if (index === -1) return [...blocks, incoming];
+		return blocks.map((block, blockIndex) => blockIndex === index ? mergeFoldableBlock(block, incoming) : block);
+	}
+
+	return [...blocks, incoming];
 }
 
 function renderableLineCount(component: PiRenderableComponent | undefined, width: number): number {
@@ -305,6 +350,7 @@ export class ChatViewportController {
 	private lastMouseRenderAt = 0;
 	private lastMouseInputAt = 0;
 	private renderRevision = 0;
+	private readonly viewModelMapper = createTranscriptViewModelMapper();
 	private cachedRender: { revision: number; requestedWidth: number; chatTop: number; chatWidth: number; chatHeight: number; terminalRows: number; lines: string[] } | undefined;
 
 	public constructor(
@@ -495,7 +541,10 @@ export class ChatViewportController {
 		const messages = measureMaybe(profile, "session_scan", () => sessionMessages(sessionContext));
 		this.markRenderDirty();
 		this.runtime.setEmptyChatQuoteState({ active: messages.length === 0, userMessageCount: countUserMessages(messages) });
-		const transcript = measureMaybe(profile, "transcript_model", () => transcriptFromSessionContext(sessionContext));
+		const transcript = measureMaybe(profile, "transcript_model", () => {
+			this.viewModelMapper.reset();
+			return this.viewModelMapper.transcriptFromSessionContext(sessionContext);
+		});
 		const stats = measureMaybe(profile, "transcript_hydrate", () => this.chat.replaceViewModels(transcript.messages));
 		if (profile) {
 			this.runtime.completeResumeHydration?.(profile, {
@@ -519,10 +568,10 @@ export class ChatViewportController {
 			this.startAssistantMessage(message);
 			return;
 		}
-		const viewModel = chatMessageViewModelFromPiMessage(message);
+		const viewModel = this.viewModelMapper.messageFromPiMessage(message);
 		if (!viewModel || chatMessageViewModelToPlainText(viewModel).length === 0) return;
-		if (isToolOnlyViewModel(viewModel) && this.liveAssistant) {
-			this.foldToolBlocksIntoAssistant(viewModel.blocks);
+		if (isFoldableOnlyViewModel(viewModel) && this.liveAssistant) {
+			this.foldBlocksIntoAssistant(viewModel.blocks);
 			return;
 		}
 		addViewModel(this.chat, viewModel);
@@ -538,7 +587,7 @@ export class ChatViewportController {
 			this.appendAssistantTextDelta(streamEvent.delta);
 			return;
 		}
-		const viewModel = chatMessageViewModelFromPiMessage(message);
+		const viewModel = this.viewModelMapper.messageFromPiMessage(message);
 		const text = viewModel ? chatMessageViewModelToPlainText(viewModel) : textFromAgentMessage(message);
 		if (text.length === 0 || text === this.lastAssistantText) return;
 		this.chat.beginStreaming();
@@ -556,7 +605,7 @@ export class ChatViewportController {
 	private handleMessageEnd(message: unknown): void {
 		this.markRenderDirty();
 		if (asRecord(message)?.role === "assistant") {
-			const viewModel = chatMessageViewModelFromPiMessage(message);
+			const viewModel = this.viewModelMapper.messageFromPiMessage(message);
 			const text = viewModel ? chatMessageViewModelToPlainText(viewModel) : textFromAgentMessage(message);
 			if (text.length > 0 && text !== this.lastAssistantText) {
 				if (viewModel) {
@@ -574,7 +623,7 @@ export class ChatViewportController {
 	}
 
 	private startAssistantMessage(message: unknown): void {
-		const viewModel = chatMessageViewModelFromPiMessage(message);
+		const viewModel = this.viewModelMapper.messageFromPiMessage(message);
 		this.liveAssistant = viewModel
 			? { ...viewModel, role: "sumo", displayName: "SUMO" }
 			: { id: "live-assistant", role: "sumo", displayName: "SUMO", blocks: [{ type: "markdown", text: "" }] };
@@ -599,9 +648,9 @@ export class ChatViewportController {
 		this.publishLiveAssistant();
 	}
 
-	private foldToolBlocksIntoAssistant(blocks: readonly ChatBlock[]): void {
+	private foldBlocksIntoAssistant(blocks: readonly ChatBlock[]): void {
 		for (const block of blocks) {
-			this.liveAssistantBlocks = upsertToolBlock(this.liveAssistantBlocks, block);
+			this.liveAssistantBlocks = upsertFoldableBlock(this.liveAssistantBlocks, block);
 		}
 		this.lastAssistantText = this.liveAssistant ? chatMessageViewModelToPlainText({ ...this.liveAssistant, blocks: this.liveAssistantBlocks }) : this.lastAssistantText;
 		this.publishLiveAssistant();

--- a/src/sumo-tui/transcript/scroll-renderer.test.ts
+++ b/src/sumo-tui/transcript/scroll-renderer.test.ts
@@ -33,6 +33,16 @@ describe("scroll/scribe renderer", () => {
 		expect(rows[0]).toContain("running");
 	});
 
+	it("renders task prompt in the outer scroll frame before the scribe frame", () => {
+		const rows = renderScrollBlock(delegation({ prompt: "Review architecture\nReturn risks.", summary: "Scribe result." }), 130).map(stripAnsi);
+		const taskHeaderIndex = rows.findIndex((r) => r.includes("┌ task"));
+		const scribeHeaderIndex = rows.findIndex((r) => r.includes("┌ scribe"));
+		expect(taskHeaderIndex).toBeGreaterThan(0);
+		expect(scribeHeaderIndex).toBeGreaterThan(taskHeaderIndex);
+		expect(rows.some((r) => r.includes("│ Review architecture"))).toBe(true);
+		expect(rows.some((r) => r.includes("│ Scribe result."))).toBe(true);
+	});
+
 	it("renders scribe header with agent, model, and thinking", () => {
 		const rows = renderScrollBlock(delegation(), 130).map(stripAnsi);
 		const header = rows.find((r) => r.includes("scribe"));

--- a/src/sumo-tui/transcript/scroll-renderer.test.ts
+++ b/src/sumo-tui/transcript/scroll-renderer.test.ts
@@ -46,6 +46,11 @@ describe("scroll/scribe renderer", () => {
 		expect(rows.some((r) => r.includes("▶") && r.includes("[bash]") && r.includes("pnpm test"))).toBe(true);
 	});
 
+	it("renders completed task summary inside the scribe body", () => {
+		const rows = renderScrollBlock(delegation({ status: "success", summary: "Task tool ran." }), 130).map(stripAnsi);
+		expect(rows.some((r) => r.includes("│ Task tool ran."))).toBe(true);
+	});
+
 	it("renders token and elapsed metadata", () => {
 		const rows = renderScrollBlock(delegation(), 130).map(stripAnsi);
 		const meta = rows.find((r) => r.includes("Tokens"));

--- a/src/sumo-tui/transcript/scroll-renderer.ts
+++ b/src/sumo-tui/transcript/scroll-renderer.ts
@@ -8,7 +8,7 @@
  *   docs/ui/bible/12-scroll-running.html
  *   docs/ui/bible/12-scroll-done.html
  */
-import { visibleWidth } from "@mariozechner/pi-tui";
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { CATHEDRAL_TOKENS } from "../../tokens.js";
 import { lineToAnsi, span, textLine, type Span } from "../render/primitives.js";
 import type { DelegationStatus, DelegationViewModel, ToolCallViewModel } from "./view-model.js";
@@ -157,6 +157,27 @@ function scribeBlankRow(width: number): string {
 	]), { width });
 }
 
+function scribeTextRow(text: string, width: number): string {
+	const contentWidth = Math.max(1, width - 6); // indent(3) + │ + spaces around content
+	const clipped = visibleWidth(text) > contentWidth ? truncateToWidth(text, contentWidth, "") : text;
+	return lineToAnsi(textLine([
+		span("   "),
+		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span(" "),
+		span(clipped, { fg: CATHEDRAL_TOKENS.colors.foreground }),
+	]), { width });
+}
+
+function scribeSummaryRows(summary: string | undefined, width: number): string[] {
+	if (!summary || summary.trim().length === 0) return [];
+	return summary
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0)
+		.slice(0, 4)
+		.map((line) => scribeTextRow(line, width));
+}
+
 function scribeMetadataRow(delegation: DelegationViewModel, width: number): string {
 	const parts: string[] = [];
 	const tokens = formatTokens(delegation.tokensIn, delegation.tokensOut);
@@ -194,7 +215,9 @@ export function renderScrollBlock(delegation: DelegationViewModel, width: number
 		rows.push(nestedToolRow(tool, safeWidth));
 	}
 
-	rows.push(scribeBlankRow(safeWidth));
+	const summaryRows = scribeSummaryRows(delegation.summary, safeWidth);
+	if (summaryRows.length > 0) rows.push(...summaryRows);
+	else rows.push(scribeBlankRow(safeWidth));
 
 	if (delegation.tokensIn !== undefined || delegation.elapsedMs !== undefined) {
 		rows.push(scribeMetadataRow(delegation, safeWidth));

--- a/src/sumo-tui/transcript/scroll-renderer.ts
+++ b/src/sumo-tui/transcript/scroll-renderer.ts
@@ -107,6 +107,47 @@ function scrollHeader(delegation: DelegationViewModel, width: number): string {
 	]), { width });
 }
 
+function scrollPromptRow(text: string, width: number): string {
+	const contentWidth = Math.max(1, width - 6);
+	const clipped = visibleWidth(text) > contentWidth ? truncateToWidth(text, contentWidth, "") : text;
+	return lineToAnsi(textLine([
+		span("   "),
+		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span(" "),
+		span(clipped, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+	]), { width });
+}
+
+function scrollPromptRows(prompt: string | undefined, width: number): string[] {
+	if (!prompt || prompt.trim().length === 0) return [];
+	const lines = prompt
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0)
+		.slice(0, 6);
+	if (lines.length === 0) return [];
+
+	const label = "task";
+	const left: Span[] = [
+		span("   "),
+		span("┌ ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span(label, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+		span(" ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+	];
+	const leftWidth = left.reduce((w, s) => w + visibleWidth(s.text), 0);
+	const ruleLen = Math.max(0, width - leftWidth - 2);
+	return [
+		lineToAnsi(textLine([...left, span("─".repeat(ruleLen), { fg: CATHEDRAL_TOKENS.colors.divider }), span("  ")]), { width }),
+		...lines.map((line) => scrollPromptRow(line, width)),
+		lineToAnsi(textLine([
+			span("   "),
+			span("└", { fg: CATHEDRAL_TOKENS.colors.divider }),
+			span("─".repeat(Math.max(0, width - 6)), { fg: CATHEDRAL_TOKENS.colors.divider }),
+			span("  "),
+		]), { width }),
+	];
+}
+
 function scribeHeader(delegation: DelegationViewModel, width: number): string {
 	const agent = delegation.agent ?? "scribe";
 	const metaParts = [agent];
@@ -205,11 +246,16 @@ function scribeBottom(width: number): string {
 
 export function renderScrollBlock(delegation: DelegationViewModel, width: number): string[] {
 	const safeWidth = Math.max(1, Math.floor(width));
+	const promptRows = scrollPromptRows(delegation.prompt, safeWidth);
 	const rows: string[] = [
 		scrollHeader(delegation, safeWidth),
-		lineToAnsi(textLine([" "]), { width: safeWidth }), // blank after header
-		scribeHeader(delegation, safeWidth),
 	];
+	if (promptRows.length > 0) {
+		rows.push(lineToAnsi(textLine([" "]), { width: safeWidth }));
+		rows.push(...promptRows);
+	}
+	rows.push(lineToAnsi(textLine([" "]), { width: safeWidth }));
+	rows.push(scribeHeader(delegation, safeWidth));
 
 	for (const tool of delegation.nestedTools ?? []) {
 		rows.push(nestedToolRow(tool, safeWidth));

--- a/src/sumo-tui/transcript/view-model.test.ts
+++ b/src/sumo-tui/transcript/view-model.test.ts
@@ -78,6 +78,29 @@ describe("structured transcript view model", () => {
 		expect(block.delegation.title).toBe("Implement Slice A: Yoga-flex outer chrome");
 		expect(block.delegation.model).toBe("openai-codex/gpt-5.5");
 		expect(block.delegation.thinking).toBe("high");
+		expect(block.delegation.prompt).toBe("Details follow...");
+		expect(block.delegation.summary).toBeUndefined();
+	});
+
+	it("extracts pi task body from single task-shaped arguments while running", () => {
+		const message = chatMessageViewModelFromPiMessage({
+			id: "a-task-single",
+			role: "assistant",
+			content: [
+				{ type: "toolCall", id: "tc-task", name: "task", arguments: {
+					prompt: "You are Zeus.\n\n## Verify issue 194 live scroll result folding\n\nRespond with exactly this sentence:\nTask output visible inside scribe.",
+					thinking: "minimal",
+				} },
+			],
+		});
+
+		const block = message?.blocks[0];
+		expect(block?.type).toBe("delegation");
+		if (block?.type !== "delegation") throw new Error("wrong block type");
+		expect(block.delegation.title).toBe("Verify issue 194 live scroll result folding");
+		expect(block.delegation.thinking).toBe("minimal");
+		expect(block.delegation.prompt).toBe("Respond with exactly this sentence:\nTask output visible inside scribe.");
+		expect(block.delegation.summary).toBeUndefined();
 	});
 
 	it("carries pi task metadata from tool calls into later tool results", () => {
@@ -114,6 +137,53 @@ describe("structured transcript view model", () => {
 		expect(completed.delegation.model).toBe("openai-codex/gpt-5.5");
 		expect(completed.delegation.thinking).toBe("high");
 		expect(completed.delegation.status).toBe("success");
+	});
+
+	it("aggregates native chain task details across all results", () => {
+		const message = chatMessageViewModelFromPiMessage({
+			role: "toolResult",
+			toolCallId: "tc-task",
+			toolName: "task",
+			name: "task",
+			type: "toolResult",
+			details: {
+				mode: "chain",
+				results: [
+					{
+						index: 1,
+						prompt: "## Inspect auth\n\nFind files.",
+						exitCode: 0,
+						messages: [],
+						finalOutput: "Found auth.ts",
+						usage: { input: 1000, output: 100 },
+						model: "openai-codex/gpt-5.5",
+						thinking: "high",
+					},
+					{
+						index: 2,
+						prompt: "## Verify auth\n\nRun tests.",
+						exitCode: 1,
+						messages: [],
+						errorMessage: "Tests failed",
+						toolEvents: [{ id: "bash-1", name: "bash", args: { command: "pnpm test" }, status: "error", output: "failed" }],
+						usage: { input: 2000, output: 200 },
+					},
+				],
+			},
+			content: [{ type: "text", text: "Chain stopped at step 2" }],
+		});
+
+		const block = message?.blocks[0];
+		expect(block?.type).toBe("delegation");
+		if (block?.type !== "delegation") throw new Error("wrong block type");
+		expect(block.delegation.status).toBe("error");
+		expect(block.delegation.title).toBe("Inspect auth");
+		expect(block.delegation.prompt).toBe("Task 1: Inspect auth\nTask 2: Verify auth");
+		expect(block.delegation.summary).toContain("Task 1: Found auth.ts");
+		expect(block.delegation.summary).toContain("Task 2: Tests failed");
+		expect(block.delegation.nestedTools).toEqual([{ id: "bash-1", name: "bash", status: "error", input: { command: "pnpm test" }, output: "failed" }]);
+		expect(block.delegation.tokensIn).toBe(3000);
+		expect(block.delegation.tokensOut).toBe(300);
 	});
 
 	it("maps pi task tool results to completed scroll blocks", () => {

--- a/src/sumo-tui/transcript/view-model.test.ts
+++ b/src/sumo-tui/transcript/view-model.test.ts
@@ -60,6 +60,62 @@ describe("structured transcript view model", () => {
 		expect(plainText).toContain("Implement Slice A");
 	});
 
+	it("extracts pi task titles from markdown headings after the role preamble", () => {
+		const message = chatMessageViewModelFromPiMessage({
+			id: "a-task-preamble",
+			role: "assistant",
+			content: [
+				{ type: "toolCall", id: "tc-task", name: "task", arguments: {
+					type: "single",
+					tasks: [{ prompt: "You are Zeus, a senior developer in the Temple of SumoDeus.\n\n## Implement Slice A: Yoga-flex outer chrome\n\nDetails follow...", model: "openai-codex/gpt-5.5", thinking: "high" }],
+				} },
+			],
+		});
+
+		const block = message?.blocks[0];
+		expect(block?.type).toBe("delegation");
+		if (block?.type !== "delegation") throw new Error("wrong block type");
+		expect(block.delegation.title).toBe("Implement Slice A: Yoga-flex outer chrome");
+		expect(block.delegation.model).toBe("openai-codex/gpt-5.5");
+		expect(block.delegation.thinking).toBe("high");
+	});
+
+	it("carries pi task metadata from tool calls into later tool results", () => {
+		const transcript = transcriptFromSessionContext({
+			messages: [
+				{
+					id: "a-task",
+					role: "assistant",
+					content: [
+						{ type: "toolCall", id: "tc-task", name: "task", arguments: {
+							type: "single",
+							tasks: [{ prompt: "You are Zeus.\n\n## Fix the scroll header\n\nUse the task metadata.", model: "openai-codex/gpt-5.5", thinking: "high" }],
+						} },
+					],
+				},
+				{
+					role: "toolResult",
+					toolCallId: "tc-task",
+					toolName: "task",
+					name: "task",
+					type: "toolResult",
+					content: [{ type: "text", text: "Task completed." }],
+				},
+			],
+		});
+
+		const running = transcript.messages[0]?.blocks[0];
+		const completed = transcript.messages[1]?.blocks[0];
+		expect(running?.type).toBe("delegation");
+		expect(completed?.type).toBe("delegation");
+		if (running?.type !== "delegation" || completed?.type !== "delegation") throw new Error("wrong block type");
+		expect(running.delegation.title).toBe("Fix the scroll header");
+		expect(completed.delegation.title).toBe("Fix the scroll header");
+		expect(completed.delegation.model).toBe("openai-codex/gpt-5.5");
+		expect(completed.delegation.thinking).toBe("high");
+		expect(completed.delegation.status).toBe("success");
+	});
+
 	it("maps pi task tool results to completed scroll blocks", () => {
 		const message = chatMessageViewModelFromPiMessage({
 			role: "toolResult",

--- a/src/sumo-tui/transcript/view-model.ts
+++ b/src/sumo-tui/transcript/view-model.ts
@@ -226,12 +226,104 @@ function parseDelegationTools(value: unknown): ToolCallViewModel[] {
 	return results;
 }
 
+interface TaskMetadata {
+	readonly id: string;
+	readonly arguments?: Record<string, unknown>;
+	readonly prompt?: string;
+	readonly model?: string;
+	readonly thinking?: string;
+}
+
+function taskRecordId(record: Record<string, unknown>): string | undefined {
+	return firstString(record.id, record.toolCallId);
+}
+
+function isTaskToolRecord(record: Record<string, unknown>): boolean {
+	return firstString(record.name, record.toolName) === "task";
+}
+
+function taskArgumentsFromRecord(record: Record<string, unknown>): Record<string, unknown> | undefined {
+	return asRecord(record.arguments ?? record.input);
+}
+
+function firstTaskFromArgs(args: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+	const tasks = Array.isArray(args?.tasks) ? args.tasks : [];
+	return asRecord(tasks[0]);
+}
+
+function taskMetadataFromRecord(record: Record<string, unknown>): TaskMetadata | undefined {
+	if (!isTaskToolRecord(record)) return undefined;
+	const id = taskRecordId(record);
+	if (!id) return undefined;
+	const args = taskArgumentsFromRecord(record);
+	const firstTask = firstTaskFromArgs(args);
+	return {
+		id,
+		arguments: args,
+		prompt: firstString(firstTask?.prompt, args?.prompt, record.prompt),
+		model: firstString(firstTask?.model, args?.model, record.model),
+		thinking: firstString(firstTask?.thinking, args?.thinking, record.thinking),
+	};
+}
+
+function collectTaskMetadataFromRecord(record: Record<string, unknown>, cache: Map<string, TaskMetadata>): void {
+	const metadata = taskMetadataFromRecord(record);
+	if (metadata && (metadata.arguments || metadata.prompt || metadata.model || metadata.thinking)) cache.set(metadata.id, metadata);
+	if (!Array.isArray(record.content)) return;
+	for (const part of record.content) {
+		const partRecord = asRecord(part);
+		if (partRecord) collectTaskMetadataFromRecord(partRecord, cache);
+	}
+}
+
+function enrichTaskRecordFromCache(record: Record<string, unknown>, cache: Map<string, TaskMetadata>): Record<string, unknown> {
+	const id = taskRecordId(record);
+	if (!id || !isTaskToolRecord(record)) return record;
+	const metadata = cache.get(id);
+	if (!metadata) return record;
+	return {
+		...record,
+		arguments: record.arguments ?? record.input ?? metadata.arguments,
+		prompt: record.prompt ?? metadata.prompt,
+		model: record.model ?? metadata.model,
+		thinking: record.thinking ?? metadata.thinking,
+	};
+}
+
+function enrichTaskResultsFromCache(record: Record<string, unknown>, cache: Map<string, TaskMetadata>): Record<string, unknown> {
+	const enriched = enrichTaskRecordFromCache(record, cache);
+	if (!Array.isArray(enriched.content)) return enriched;
+	return {
+		...enriched,
+		content: enriched.content.map((part) => {
+			const partRecord = asRecord(part);
+			return partRecord ? enrichTaskRecordFromCache(partRecord, cache) : part;
+		}),
+	};
+}
+
+function truncateTaskTitle(title: string): string {
+	return title.length > 80 ? `${title.slice(0, 77)}…` : title;
+}
+
+function taskTitleFromPrompt(rawPrompt: string): string {
+	const lines = rawPrompt.split("\n");
+	const heading = lines
+		.map((line) => line.trim().match(/^#{2,6}\s+(.+?)\s*#*$/)?.[1]?.trim())
+		.find((line): line is string => line !== undefined && line.length > 0);
+	if (heading) return truncateTaskTitle(heading);
+
+	const meaningful = lines
+		.map((line) => line.trim())
+		.find((line) => line.length > 0 && !/^you(?: are|'re)\b/i.test(line));
+	return truncateTaskTitle(meaningful ?? (rawPrompt.trim() || "task"));
+}
+
 function taskBlockFromRecord(record: Record<string, unknown>, fallbackStatus: ToolStatus): ChatBlock {
 	// Pi built-in `task` tool call → Cathedral scroll/scribe (Element 12).
 	// Extract title, agent metadata, and status from the task arguments/output.
-	const args = asRecord(record.arguments ?? record.input);
-	const tasks = Array.isArray(args?.tasks) ? args.tasks : [];
-	const firstTask = asRecord(tasks[0]);
+	const args = taskArgumentsFromRecord(record);
+	const firstTask = firstTaskFromArgs(args);
 	const model = firstString(
 		firstTask?.model,
 		args?.model,
@@ -239,9 +331,7 @@ function taskBlockFromRecord(record: Record<string, unknown>, fallbackStatus: To
 	);
 	const thinking = firstString(firstTask?.thinking, args?.thinking, record.thinking);
 	const rawPrompt = firstString(firstTask?.prompt, args?.prompt, record.prompt) ?? "task";
-	// Title: use first non-empty line, capped at 80 chars
-	const firstLine = rawPrompt.split("\n").find((l) => l.trim().length > 0) ?? rawPrompt;
-	const title = firstLine.length > 80 ? `${firstLine.slice(0, 77)}…` : firstLine;
+	const title = taskTitleFromPrompt(rawPrompt);
 	// Status from toolResult output
 	const outputText = (() => {
 		const content = record.content;
@@ -372,14 +462,41 @@ export function chatMessageViewModelFromPiMessage(message: unknown, index = 0): 
 	};
 }
 
-export function transcriptFromSessionContext(sessionContext: unknown): TranscriptViewModel {
-	const messages = asRecord(sessionContext)?.messages;
-	if (!Array.isArray(messages)) return { messages: [] };
+export interface TranscriptViewModelMapper {
+	reset(): void;
+	messageFromPiMessage(message: unknown, index?: number): ChatMessageViewModel | undefined;
+	transcriptFromSessionContext(sessionContext: unknown): TranscriptViewModel;
+}
+
+export function createTranscriptViewModelMapper(): TranscriptViewModelMapper {
+	const taskMetadata = new Map<string, TaskMetadata>();
 	return {
-		messages: messages
-			.map((message, index) => chatMessageViewModelFromPiMessage(message, index))
-			.filter((message): message is ChatMessageViewModel => message !== undefined),
+		reset(): void {
+			taskMetadata.clear();
+		},
+		messageFromPiMessage(message: unknown, index = 0): ChatMessageViewModel | undefined {
+			const record = asRecord(message);
+			if (!record) return undefined;
+			const enriched = enrichTaskResultsFromCache(record, taskMetadata);
+			const viewModel = chatMessageViewModelFromPiMessage(enriched, index);
+			collectTaskMetadataFromRecord(enriched, taskMetadata);
+			return viewModel;
+		},
+		transcriptFromSessionContext(sessionContext: unknown): TranscriptViewModel {
+			const messages = asRecord(sessionContext)?.messages;
+			if (!Array.isArray(messages)) return { messages: [] };
+			return {
+				messages: messages
+					.map((message, index) => this.messageFromPiMessage(message, index))
+					.filter((message): message is ChatMessageViewModel => message !== undefined),
+			};
+		},
 	};
+}
+
+export function transcriptFromSessionContext(sessionContext: unknown): TranscriptViewModel {
+	const mapper = createTranscriptViewModelMapper();
+	return mapper.transcriptFromSessionContext(sessionContext);
 }
 
 export function chatMessageViewModelToPlainText(message: ChatMessageViewModel): string {

--- a/src/sumo-tui/transcript/view-model.ts
+++ b/src/sumo-tui/transcript/view-model.ts
@@ -29,6 +29,9 @@ export interface DelegationViewModel {
 	readonly title: string;
 	readonly agent?: string;
 	readonly status: DelegationStatus;
+	/** Initial task prompt/body shown in the outer [scroll] frame. */
+	readonly prompt?: string;
+	/** Live/final scribe output shown inside the scribe frame. */
 	readonly summary?: string;
 	readonly model?: string;
 	readonly thinking?: string;
@@ -260,7 +263,7 @@ function taskMetadataFromRecord(record: Record<string, unknown>): TaskMetadata |
 	return {
 		id,
 		arguments: args,
-		prompt: firstString(firstTask?.prompt, args?.prompt, record.prompt),
+		prompt: firstString(firstTask?.prompt, firstTask?.task, args?.prompt, args?.task, record.prompt, record.task),
 		model: firstString(firstTask?.model, args?.model, record.model),
 		thinking: firstString(firstTask?.thinking, args?.thinking, record.thinking),
 	};
@@ -306,21 +309,209 @@ function truncateTaskTitle(title: string): string {
 	return title.length > 80 ? `${title.slice(0, 77)}…` : title;
 }
 
+function taskPromptLines(rawPrompt: string): string[] {
+	return rawPrompt
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0 && !/^you(?: are|'re)\b/i.test(line));
+}
+
+function taskHeadingFromLine(line: string): string | undefined {
+	return line.match(/^#{2,6}\s+(.+?)\s*#*$/)?.[1]?.trim();
+}
+
 function taskTitleFromPrompt(rawPrompt: string): string {
-	const lines = rawPrompt.split("\n");
+	const lines = taskPromptLines(rawPrompt);
 	const heading = lines
-		.map((line) => line.trim().match(/^#{2,6}\s+(.+?)\s*#*$/)?.[1]?.trim())
+		.map(taskHeadingFromLine)
 		.find((line): line is string => line !== undefined && line.length > 0);
 	if (heading) return truncateTaskTitle(heading);
 
-	const meaningful = lines
-		.map((line) => line.trim())
-		.find((line) => line.length > 0 && !/^you(?: are|'re)\b/i.test(line));
+	const meaningful = lines.find((line) => line.length > 0);
 	return truncateTaskTitle(meaningful ?? (rawPrompt.trim() || "task"));
 }
 
+function taskPromptBody(rawPrompt: string): string | undefined {
+	const lines = taskPromptLines(rawPrompt);
+	const headingIndex = lines.findIndex((line) => taskHeadingFromLine(line) !== undefined);
+	const body = (headingIndex >= 0 ? lines.slice(headingIndex + 1) : lines.slice(1))
+		.filter((line) => taskHeadingFromLine(line) === undefined)
+		.slice(0, 6);
+	return body.length > 0 ? body.join("\n") : undefined;
+}
+
+function firstOutputLine(outputText: string | undefined): string | undefined {
+	return outputText?.split("\n").find((line) => line.trim().length > 0);
+}
+
+function taskResultStatus(result: Record<string, unknown>, fallbackStatus: ToolStatus): DelegationStatus {
+	const exitCode = typeof result.exitCode === "number" ? result.exitCode : undefined;
+	const stopReason = asString(result.stopReason);
+	if (exitCode === -2) return "queued";
+	if (exitCode === -1) return "running";
+	if (exitCode === undefined) return normalizeDelegationStatus(fallbackStatus);
+	if (exitCode > 0 || stopReason === "error" || stopReason === "aborted") return stopReason === "aborted" ? "cancelled" : "error";
+	return "success";
+}
+
+function textFromTaskMessages(messages: unknown): string | undefined {
+	if (!Array.isArray(messages)) return undefined;
+	for (let index = messages.length - 1; index >= 0; index -= 1) {
+		const message = asRecord(messages[index]);
+		if (message?.role !== "assistant" || !Array.isArray(message.content)) continue;
+		for (const part of message.content) {
+			const record = asRecord(part);
+			if (record?.type === "text") return asString(record.text);
+		}
+	}
+	return undefined;
+}
+
+function taskToolStatusFrom(value: unknown): ToolStatus {
+	if (value === "success" || value === "error" || value === "cancelled" || value === "running" || value === "pending") return value;
+	if (value === "Done") return "success";
+	if (value === "Failed") return "error";
+	if (value === "Running") return "running";
+	return "pending";
+}
+
+function parseTaskToolEvents(value: unknown): ToolCallViewModel[] {
+	if (!Array.isArray(value)) return [];
+	return value.flatMap((item): ToolCallViewModel[] => {
+		const event = asRecord(item);
+		if (!event) return [];
+		return [{
+			id: firstString(event.id, event.toolCallId),
+			name: firstString(event.name, event.toolName) ?? "tool",
+			status: taskToolStatusFrom(event.status),
+			input: event.args ?? event.input ?? event.arguments,
+			output: firstString(event.output, event.text),
+		}];
+	});
+}
+
+function parseTaskToolCallsFromMessages(messages: unknown): ToolCallViewModel[] {
+	if (!Array.isArray(messages)) return [];
+	const results = new Map<string, ToolCallViewModel>();
+	for (const messageValue of messages) {
+		const message = asRecord(messageValue);
+		if (!message) continue;
+		if (message.role === "assistant" && Array.isArray(message.content)) {
+			for (const part of message.content) {
+				const record = asRecord(part);
+				if (record?.type !== "toolCall") continue;
+				const id = firstString(record.id, record.toolCallId) ?? `${results.size}`;
+				results.set(id, {
+					id,
+					name: firstString(record.name, record.toolName) ?? "tool",
+					status: "running",
+					input: record.arguments ?? record.input,
+				});
+			}
+		}
+		if (message.role === "toolResult") {
+			const id = firstString(message.toolCallId, message.id) ?? `${results.size}`;
+			const existing = results.get(id);
+			results.set(id, {
+				...existing,
+				id,
+				name: firstString(message.toolName, message.name, existing?.name) ?? "tool",
+				status: message.isError === true ? "error" : "success",
+				output: textFromContent(message.content) || asString(message.output),
+			});
+		}
+	}
+	return [...results.values()];
+}
+
+function aggregateTaskStatus(statuses: readonly DelegationStatus[]): DelegationStatus {
+	if (statuses.includes("error")) return "error";
+	if (statuses.includes("cancelled")) return "cancelled";
+	if (statuses.includes("running")) return "running";
+	if (statuses.includes("queued")) return "running";
+	return "success";
+}
+
+function taskResultLabel(result: Record<string, unknown>, index: number, total: number): string {
+	if (total === 1) return "";
+	const rawIndex = typeof result.index === "number" ? result.index : index + 1;
+	return `Task ${rawIndex}: `;
+}
+
+function taskResultSummaryLine(result: Record<string, unknown>, index: number, total: number, status: DelegationStatus): string | undefined {
+	const finalOutput = firstString(result.finalOutput, result.streamingText, textFromTaskMessages(result.messages));
+	const errorText = firstString(result.errorMessage, result.stderr);
+	const text = status === "running" || status === "queued"
+		? firstOutputLine(finalOutput)
+		: firstString(finalOutput, errorText);
+	if (!text) return undefined;
+	return `${taskResultLabel(result, index, total)}${text}`;
+}
+
+function taskPromptForResults(results: readonly Record<string, unknown>[], record: Record<string, unknown>): string | undefined {
+	if (results.length === 0) return undefined;
+	if (results.length === 1) return taskPromptBody(firstString(results[0]?.prompt, record.prompt) ?? "task");
+	return results
+		.map((result, index) => {
+			const prompt = firstString(result.prompt, record.prompt) ?? "task";
+			return `${taskResultLabel(result, index, results.length)}${taskTitleFromPrompt(prompt)}`;
+		})
+		.join("\n");
+}
+
+function numberFrom(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function sumNumbers(values: readonly (number | undefined)[]): number | undefined {
+	const numbers = values.filter((value): value is number => value !== undefined);
+	return numbers.length > 0 ? numbers.reduce((sum, value) => sum + value, 0) : undefined;
+}
+
+function taskBlockFromDetails(record: Record<string, unknown>, fallbackStatus: ToolStatus): ChatBlock | undefined {
+	const details = asRecord(record.details);
+	const resultRecords = (Array.isArray(details?.results) ? details.results : [])
+		.map(asRecord)
+		.filter((result): result is Record<string, unknown> => result !== undefined);
+	if (resultRecords.length === 0) return undefined;
+
+	const firstResult = resultRecords[0]!;
+	const statuses = resultRecords.map((result) => taskResultStatus(result, fallbackStatus));
+	const status = aggregateTaskStatus(statuses);
+	const summary = resultRecords
+		.map((result, index) => taskResultSummaryLine(result, index, resultRecords.length, statuses[index]!))
+		.filter((line): line is string => line !== undefined && line.trim().length > 0)
+		.join("\n") || undefined;
+	const nestedTools = resultRecords.flatMap((result) => {
+		const toolEvents = parseTaskToolEvents(result.toolEvents);
+		return toolEvents.length > 0 ? toolEvents : parseTaskToolCallsFromMessages(result.messages);
+	});
+	const tokensIn = sumNumbers(resultRecords.map((result) => numberFrom(asRecord(result.usage)?.input)));
+	const tokensOut = sumNumbers(resultRecords.map((result) => numberFrom(asRecord(result.usage)?.output)));
+	const prompt = firstString(firstResult.prompt, record.prompt) ?? "task";
+	return {
+		type: "delegation",
+		delegation: {
+			id: firstString(record.id, record.toolCallId),
+			title: taskTitleFromPrompt(prompt),
+			agent: "scribe",
+			model: firstString(...resultRecords.map((result) => result.model), record.model),
+			thinking: firstString(...resultRecords.map((result) => result.thinking), record.thinking),
+			status,
+			prompt: taskPromptForResults(resultRecords, record),
+			summary,
+			nestedTools,
+			tokensIn,
+			tokensOut,
+			elapsedMs: undefined,
+		},
+	};
+}
+
 function taskBlockFromRecord(record: Record<string, unknown>, fallbackStatus: ToolStatus): ChatBlock {
-	// Pi built-in `task` tool call → Cathedral scroll/scribe (Element 12).
+	const fromDetails = taskBlockFromDetails(record, fallbackStatus);
+	if (fromDetails) return fromDetails;
+	// Pi task tool call → Cathedral scroll/scribe (Element 12).
 	// Extract title, agent metadata, and status from the task arguments/output.
 	const args = taskArgumentsFromRecord(record);
 	const firstTask = firstTaskFromArgs(args);
@@ -330,7 +521,7 @@ function taskBlockFromRecord(record: Record<string, unknown>, fallbackStatus: To
 		record.model,
 	);
 	const thinking = firstString(firstTask?.thinking, args?.thinking, record.thinking);
-	const rawPrompt = firstString(firstTask?.prompt, args?.prompt, record.prompt) ?? "task";
+	const rawPrompt = firstString(firstTask?.prompt, firstTask?.task, args?.prompt, args?.task, record.prompt, record.task) ?? "task";
 	const title = taskTitleFromPrompt(rawPrompt);
 	// Status from toolResult output
 	const outputText = (() => {
@@ -353,7 +544,8 @@ function taskBlockFromRecord(record: Record<string, unknown>, fallbackStatus: To
 			model,
 			thinking,
 			status: normalizeDelegationStatus(status),
-			summary: outputText ? outputText.split("\n").find((l) => l.trim().length > 0) : undefined,
+			prompt: taskPromptBody(rawPrompt),
+			summary: firstOutputLine(outputText),
 			nestedTools: [],
 			tokensIn: undefined,
 			tokensOut: undefined,


### PR DESCRIPTION
## Summary
- replace the external task-tool dependency path with a SumoCode-native task implementation when the legacy global task extension is absent
- stream child Pi JSON events into structured task details, including scribe output, tool events, usage, model, and thinking
- render the initial task prompt in the outer scroll task frame while keeping scribe activity/output inside the scribe frame
- fold live task execution updates into the active SUMO scroll card to avoid duplicate SYSTEM scroll cards
- make the global sumocode launcher symlink-safe

## Verification
- live native task smoke tests in restarted SumoCode
- pnpm vitest run src/sumo-tui/transcript/view-model.test.ts src/sumo-tui/transcript/scroll-renderer.test.ts src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
- pnpm exec tsc --noEmit && pnpm build
- pnpm test
- pnpm test:integration
- pnpm visual:ci

Closes #194