### PR TITLE
fix(tui): preserve retained lifecycle across session switches

### DIFF
--- a/src/render-diagnostics.ts
+++ b/src/render-diagnostics.ts
@@ -325,7 +325,15 @@ function round(n: number): number {
 	return Math.round(n * 100) / 100;
 }
 
-const stats = new RenderStats();
+const GLOBAL_RENDER_STATS_KEY = "__sumoRenderDiagnosticsStats";
+const GLOBAL_EVENT_LOOP_PROBE_KEY = "__sumoRenderDiagnosticsEventLoopProbeStarted";
+type GlobalWithRenderDiagnostics = typeof globalThis & {
+	[GLOBAL_RENDER_STATS_KEY]?: RenderStats;
+	[GLOBAL_EVENT_LOOP_PROBE_KEY]?: boolean;
+};
+const globalForRenderDiagnostics = globalThis as GlobalWithRenderDiagnostics;
+if (!globalForRenderDiagnostics[GLOBAL_RENDER_STATS_KEY]) globalForRenderDiagnostics[GLOBAL_RENDER_STATS_KEY] = new RenderStats();
+const stats = globalForRenderDiagnostics[GLOBAL_RENDER_STATS_KEY] as RenderStats;
 
 /** Counters that other modules can poke into. No-op when diagnostics are disabled. */
 export const renderDiagnosticsCounters = {
@@ -589,6 +597,8 @@ function instrumentModuleLoad(): void {
  * way to detect "something is blocking the event loop" without knowing what.
  */
 function startEventLoopLagProbe(): void {
+	if (globalForRenderDiagnostics[GLOBAL_EVENT_LOOP_PROBE_KEY]) return;
+	globalForRenderDiagnostics[GLOBAL_EVENT_LOOP_PROBE_KEY] = true;
 	let lastTick = performance.now();
 	const probe = (): void => {
 		const now = performance.now();

--- a/src/sumo-tui/runtime/lifecycle.test.ts
+++ b/src/sumo-tui/runtime/lifecycle.test.ts
@@ -125,7 +125,14 @@ describe("useTerminalDimensions", () => {
 });
 
 describe("LifecycleRuntime", () => {
-	afterEach(() => { setActiveEditorDraftController(undefined); });
+	afterEach(() => {
+		setActiveEditorDraftController(undefined);
+		delete process.env.SUMO_TUI;
+		// Always clear the global retained-runtime symbol between tests so a stale
+		// runtime from one test cannot bleed into another.
+		const host = globalThis as unknown as Record<symbol, unknown>;
+		delete host[Symbol.for("sumocode.activeSumoRuntime")];
+	});
 	it("registers process signal handlers exactly once", () => {
 		const fakeProcess = new FakeProcess();
 		const output = outputStub();
@@ -161,6 +168,63 @@ describe("LifecycleRuntime", () => {
 			CURSOR_COLOR_SET,
 			`${CURSOR_COLOR_RESET}${TERMINAL_BG_RESET}${TERMINAL_CLEANUP_SEQUENCE}`,
 		]);
+	});
+
+	it("keeps altscreen active across session switches when SUMO_TUI=1 env is set", () => {
+		process.env.SUMO_TUI = "1";
+		const fakeProcess = new FakeProcess();
+		const fakeInput = new FakeInput();
+		const output = outputStub();
+		const terminalSession = new TerminalSessionOwner({ output });
+		const runtime = createLifecycleRuntime({ process: fakeProcess, input: fakeInput, terminalSession });
+		const { pi, handlers } = buildPiStub();
+
+		runtime.installLifecycle(pi);
+		for (const handler of handlers.get("session_start") ?? []) {
+			handler({ type: "session_start" }, { hasUI: true });
+		}
+		for (const handler of handlers.get("session_shutdown") ?? []) {
+			handler({ type: "session_shutdown" }, { hasUI: true });
+		}
+
+		expect(terminalSession.getState().altscreenActive).toBe(true);
+		expect(output.writes).toEqual([
+			`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`,
+			MOUSE_SGR_ENABLE_SEQUENCE,
+			CURSOR_COLOR_SET,
+		]);
+		expect(fakeInput.rawModes).toEqual([true, false]);
+	});
+
+	it("keeps altscreen active across session switches when retained runtime is registered (e.g. --sumo-tui CLI flag)", () => {
+		// Simulate the --sumo-tui launch path: SumoInteractiveRuntime registers itself
+		// on the globalThis symbol but SUMO_TUI env is NOT set.
+		delete process.env.SUMO_TUI;
+		const host = globalThis as unknown as Record<symbol, { runtime: unknown }>;
+		host[Symbol.for("sumocode.activeSumoRuntime")] = { runtime: { fake: true } };
+
+		const fakeProcess = new FakeProcess();
+		const fakeInput = new FakeInput();
+		const output = outputStub();
+		const terminalSession = new TerminalSessionOwner({ output });
+		const runtime = createLifecycleRuntime({ process: fakeProcess, input: fakeInput, terminalSession });
+		const { pi, handlers } = buildPiStub();
+
+		runtime.installLifecycle(pi);
+		for (const handler of handlers.get("session_start") ?? []) {
+			handler({ type: "session_start" }, { hasUI: true });
+		}
+		for (const handler of handlers.get("session_shutdown") ?? []) {
+			handler({ type: "session_shutdown" }, { hasUI: true });
+		}
+
+		expect(terminalSession.getState().altscreenActive).toBe(true);
+		expect(output.writes).toEqual([
+			`${ALTSCREEN_ENTER_SEQUENCE}${TERMINAL_BG_SET}`,
+			MOUSE_SGR_ENABLE_SEQUENCE,
+			CURSOR_COLOR_SET,
+		]);
+		expect(fakeInput.rawModes).toEqual([true, false]);
 	});
 
 	it("session_start ignores non-UI contexts", () => {

--- a/src/sumo-tui/runtime/lifecycle.ts
+++ b/src/sumo-tui/runtime/lifecycle.ts
@@ -60,6 +60,25 @@ export interface LifecycleRuntimeOptions {
 
 const EXIT_SIGNALS = ["SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT"] as const;
 
+/**
+ * Detect whether the retained SumoTUI runtime is active, regardless of how it
+ * was launched (`SUMO_TUI=1` env or `--sumo-tui` CLI flag — see
+ * `patches/@mariozechner__pi-coding-agent@*.patch`).
+ *
+ * Reads the same `globalThis` symbol that `SumoInteractiveRuntime` registers
+ * itself under in `pi-compat/sumo-interactive-mode.ts`. Avoids a backwards
+ * import from `runtime/` to `pi-compat/`. Falls back to the env flag for
+ * tests and early-init paths that run before the runtime has registered.
+ */
+const ACTIVE_SUMO_RUNTIME_KEY = Symbol.for("sumocode.activeSumoRuntime");
+
+export function isRetainedSumoRuntimeActive(): boolean {
+	type ActiveRuntimeBox = { runtime: unknown };
+	const host = globalThis as unknown as Record<symbol, ActiveRuntimeBox | undefined>;
+	if (host[ACTIVE_SUMO_RUNTIME_KEY]?.runtime) return true;
+	return process.env.SUMO_TUI === "1";
+}
+
 function getNodeProcess(): LifecycleProcess {
 	const processLike = process as unknown as {
 		pid: number;
@@ -159,6 +178,17 @@ export class LifecycleRuntime {
 		});
 
 		pi.on("session_shutdown", () => {
+			// In retained SumoTUI mode the process-level runtime owns altscreen for
+			// the whole interactive process. Pi emits session_shutdown during in-process
+			// switches (/new, /resume, /fork); leaving altscreen there clears the
+			// terminal while the retained renderer still holds a previous-frame cache,
+			// so the next paint diffs against stale cells and only repaints a fragment.
+			// Keep the terminal session active across session switches, but release raw
+			// mode so Pi can safely rebuild stdin for the next session_start.
+			if (isRetainedSumoRuntimeActive()) {
+				this.releaseRawMode();
+				return;
+			}
 			this.restoreTerminal();
 		});
 
@@ -299,7 +329,11 @@ export function createLifecycleRuntime(options: LifecycleRuntimeOptions = {}): L
 	return new LifecycleRuntime(options);
 }
 
-const defaultLifecycle = createLifecycleRuntime();
+const GLOBAL_LIFECYCLE_KEY = "__sumoDefaultLifecycleRuntime";
+type GlobalWithLifecycle = typeof globalThis & { [GLOBAL_LIFECYCLE_KEY]?: LifecycleRuntime };
+const globalForLifecycle = globalThis as GlobalWithLifecycle;
+if (!globalForLifecycle[GLOBAL_LIFECYCLE_KEY]) globalForLifecycle[GLOBAL_LIFECYCLE_KEY] = createLifecycleRuntime();
+const defaultLifecycle = globalForLifecycle[GLOBAL_LIFECYCLE_KEY] as LifecycleRuntime;
 defaultLifecycle.installProcessHandlers();
 
 export function installLifecycle(pi: ExtensionAPI): LifecycleRenderControls {

--- a/test/integration/session-switch-retained-lifecycle.test.ts
+++ b/test/integration/session-switch-retained-lifecycle.test.ts
@@ -1,0 +1,59 @@
+import { readFileSync, unlinkSync } from "node:fs";
+import { pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { spawnPiPty, type SpawnedPiPty } from "./spawn-pi-pty.js";
+
+function countOccurrences(text: string, needle: string): number {
+	return text.split(needle).length - 1;
+}
+
+/**
+ * Match `bin/sumocode.sh`: when SUMO_TUI is truthy, the launcher resolves
+ * SUMO_TUI_MODULE to a file URL pointing at the local retained mode module.
+ * Without both env vars, the patched Pi binary falls back to classic
+ * `InteractiveMode` and this test would silently exercise the wrong path.
+ */
+function retainedModeEnv(): Record<string, string> {
+	return {
+		SUMO_TUI: "1",
+		SUMO_TUI_MODULE: pathToFileURL(resolve(process.cwd(), "sumo-interactive-mode.js")).href,
+		SUMO_TUI_DIAG_FILE: "/tmp/sumocode-session-switch-test.jsonl",
+	};
+}
+
+describe("retained lifecycle across session switches", () => {
+	let app: SpawnedPiPty | undefined;
+	beforeEach(() => {
+		try { unlinkSync(retainedModeEnv().SUMO_TUI_DIAG_FILE); } catch {}
+	});
+	afterEach(() => {
+		app?.cleanup();
+		app = undefined;
+	});
+
+	it("does not leave altscreen during /new", async () => {
+		app = spawnPiPty({
+			args: ["--offline", "--no-extensions", "-e", "./src/extension.ts", "--no-session"],
+			env: retainedModeEnv(),
+		});
+		await app.waitForOutput(/DIVINE INVOCATION/, 12_000);
+
+		// Confirm retained mode actually started — if Pi fell back to classic
+		// InteractiveMode, the diagnostics file would not contain owned_shell
+		// events. Read SUMO_TUI_DIAG_FILE to verify the retained runtime ran.
+		await new Promise((resolve) => setTimeout(resolve, 200));
+		const diagFile = retainedModeEnv().SUMO_TUI_DIAG_FILE;
+		const diagContents = readFileSync(diagFile, "utf8");
+		expect(diagContents, "retained SumoTUI runtime did not start").toMatch(/owned_shell_installed|sumo_runtime_top_chrome_publication|retainedTui/);
+
+		app.sendInput("/new");
+		app.sendInput("\x1b[13u");
+		await app.waitForOutput(/Ask anything/, 12_000);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		const output = app.getOutput();
+		expect(countOccurrences(output, "\x1b[?1049h")).toBe(1);
+		expect(countOccurrences(output, "\x1b[?1049l")).toBe(0);
+	});
+});


### PR DESCRIPTION
## Summary
- keep retained SumoTUI altscreen active across in-process session switches like /new, /resume, and /fork
- pin lifecycle and diagnostics singletons on globalThis to avoid duplicate module-load owners/timers under jiti reload boundaries
- add node-pty integration coverage for /new staying inside altscreen

## Verification
- manual node-pty repro: /new no longer emits ?1049l during active process
- pnpm exec tsc --noEmit && pnpm build
- pnpm test
- pnpm test:integration
- pnpm visual:ci (review pack generated; existing review scenarios unchanged)