### PR TITLE
feat(review): add scribe diff review command

### DIFF
--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it, vi } from "vitest";
+import { buildReviewPrompt, DEFAULT_REVIEW_MODEL, parseReviewScope, registerReviewCommand, resolveReviewModel } from "./review.js";
+
+describe("/sumo:review", () => {
+	describe("resolveReviewModel", () => {
+		it("uses deepseek v4 pro by default", () => {
+			expect(resolveReviewModel({})).toBe(DEFAULT_REVIEW_MODEL);
+			expect(DEFAULT_REVIEW_MODEL).toBe("deepseek/deepseek-v4-pro");
+		});
+
+		it("allows model override via SUMOCODE_REVIEW_MODEL", () => {
+			expect(resolveReviewModel({ SUMOCODE_REVIEW_MODEL: "openai-codex/gpt-5.5" })).toBe("openai-codex/gpt-5.5");
+		});
+	});
+
+	describe("parseReviewScope", () => {
+		it("returns working-tree for empty args", () => {
+			expect(parseReviewScope("")).toEqual({ kind: "working-tree" });
+			expect(parseReviewScope("   ")).toEqual({ kind: "working-tree" });
+		});
+
+		it("parses PR numbers with or without #", () => {
+			expect(parseReviewScope("#51")).toEqual({ kind: "pr", number: "51" });
+			expect(parseReviewScope("51")).toEqual({ kind: "pr", number: "51" });
+			expect(parseReviewScope(" #209 ")).toEqual({ kind: "pr", number: "209" });
+		});
+
+		it("returns explicit for git ranges and paths", () => {
+			expect(parseReviewScope("main...HEAD")).toEqual({ kind: "explicit", raw: "main...HEAD" });
+			expect(parseReviewScope("origin/main...HEAD")).toEqual({ kind: "explicit", raw: "origin/main...HEAD" });
+			expect(parseReviewScope("src/foo.ts")).toEqual({ kind: "explicit", raw: "src/foo.ts" });
+		});
+	});
+
+	describe("buildReviewPrompt", () => {
+		it("working-tree: instructs scribe to fall back to branch diff when working tree is empty", () => {
+			const prompt = buildReviewPrompt("", "deepseek/deepseek-v4-pro");
+			expect(prompt).toContain("git diff origin/main...HEAD");
+			expect(prompt).toContain("if `git diff HEAD` is empty");
+			expect(prompt).toContain("do NOT return GREEN");
+			expect(prompt).toContain("EMPTY");
+		});
+
+		it("pr: uses gh pr diff and gh pr view", () => {
+			const prompt = buildReviewPrompt("#42", "deepseek/deepseek-v4-pro");
+			expect(prompt).toContain("gh pr diff 42");
+			expect(prompt).toContain("gh pr view 42");
+			expect(prompt).toContain("PR #42");
+		});
+
+		it("explicit range: uses git diff with the raw range", () => {
+			const prompt = buildReviewPrompt("main...HEAD", "deepseek/deepseek-v4-pro");
+			expect(prompt).toContain("git diff main...HEAD");
+		});
+
+		it("includes relentless review loop and model", () => {
+			const prompt = buildReviewPrompt("", "deepseek/deepseek-v4-pro");
+			expect(prompt).toContain("model deepseek/deepseek-v4-pro");
+			expect(prompt).toContain("Relentlessly repeat review -> fix -> review until the scribe returns a GREEN signal");
+		});
+
+		it("includes P0/P1/P2 severity rubric", () => {
+			const prompt = buildReviewPrompt("", "deepseek/deepseek-v4-pro");
+			expect(prompt).toContain("P0: release blocker");
+			expect(prompt).toContain("P1: must fix before merge");
+			expect(prompt).toContain("P2: should fix before merge");
+		});
+
+		it("prohibits the scribe from delegating via task tool", () => {
+			const prompt = buildReviewPrompt("", "deepseek/deepseek-v4-pro");
+			expect(prompt).toContain("Do NOT use the task tool");
+			expect(prompt).toContain("Perform the entire review yourself");
+		});
+
+		it("includes DO NOT flag list to suppress noise", () => {
+			const prompt = buildReviewPrompt("", "deepseek/deepseek-v4-pro");
+			expect(prompt).toContain("DO NOT flag");
+			expect(prompt).toContain("formatting");
+			expect(prompt).toContain("Speculative");
+		});
+
+		it("requires per-finding reasoning trace", () => {
+			const prompt = buildReviewPrompt("", "deepseek/deepseek-v4-pro");
+			expect(prompt).toContain("Premise");
+			expect(prompt).toContain("Execution path");
+			expect(prompt).toContain("concrete execution path");
+		});
+
+		it("injects project context with build and test commands", () => {
+			const prompt = buildReviewPrompt("", "deepseek/deepseek-v4-pro");
+			expect(prompt).toContain("pnpm exec tsc --noEmit");
+			expect(prompt).toContain("pnpm vitest run");
+			expect(prompt).toContain("pnpm build");
+			expect(prompt).toContain("TypeScript");
+		});
+
+		it("instructs scribe to read enclosing functions, not just diff hunks", () => {
+			const prompt = buildReviewPrompt("", "deepseek/deepseek-v4-pro");
+			expect(prompt).toContain("full enclosing function body");
+		});
+
+		it("omit-empty-sections rule prevents filler", () => {
+			const prompt = buildReviewPrompt("", "deepseek/deepseek-v4-pro");
+			expect(prompt).toContain("Omit any severity level you have no finding for");
+		});
+	});
+
+	describe("registerReviewCommand", () => {
+		it("registers a command that queues the review prompt as a follow-up", async () => {
+			let handler: ((args: string, ctx: { hasUI: boolean; ui: { notify: ReturnType<typeof vi.fn> } }) => Promise<void>) | undefined;
+			const sendUserMessage = vi.fn();
+			const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
+				handler = options.handler;
+			});
+			const notify = vi.fn();
+
+			registerReviewCommand({ registerCommand, sendUserMessage } as never);
+			await handler?.("src/foo.ts", { hasUI: true, ui: { notify } });
+
+			expect(registerCommand).toHaveBeenCalledWith("sumo:review", expect.objectContaining({ description: expect.any(String) }));
+			expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("git diff src/foo.ts"), { deliverAs: "followUp" });
+			expect(notify).toHaveBeenCalledWith(expect.stringContaining("deepseek/deepseek-v4-pro"), "info");
+		});
+
+		it("includes scope label in notify for PR args", async () => {
+			let handler: ((args: string, ctx: { hasUI: boolean; ui: { notify: ReturnType<typeof vi.fn> } }) => Promise<void>) | undefined;
+			const sendUserMessage = vi.fn();
+			const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
+				handler = options.handler;
+			});
+			const notify = vi.fn();
+
+			registerReviewCommand({ registerCommand, sendUserMessage } as never);
+			await handler?.("#42", { hasUI: true, ui: { notify } });
+
+			expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("gh pr diff 42"), { deliverAs: "followUp" });
+			expect(notify).toHaveBeenCalledWith(expect.stringContaining("PR #42"), "info");
+		});
+	});
+});

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -1,0 +1,170 @@
+import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+export const DEFAULT_REVIEW_MODEL = "deepseek/deepseek-v4-pro";
+
+export function resolveReviewModel(env: NodeJS.ProcessEnv = process.env): string {
+	return env.SUMOCODE_REVIEW_MODEL?.trim() || DEFAULT_REVIEW_MODEL;
+}
+
+/**
+ * Parse the args string into a structured scope descriptor.
+ *
+ * Supported forms:
+ *   (empty)       → working tree + branch fallback
+ *   #51           → PR number via `gh pr diff`
+ *   51            → PR number via `gh pr diff`
+ *   main...HEAD   → explicit git range passthrough
+ *   src/foo.ts    → explicit path passthrough
+ */
+export type ReviewScope =
+	| { kind: "working-tree" }
+	| { kind: "pr"; number: string }
+	| { kind: "explicit"; raw: string };
+
+export function parseReviewScope(args: string): ReviewScope {
+	const trimmed = args.trim();
+	if (!trimmed) return { kind: "working-tree" };
+	const prMatch = /^#?(\d+)$/.exec(trimmed);
+	if (prMatch) return { kind: "pr", number: prMatch[1]! };
+	return { kind: "explicit", raw: trimmed };
+}
+
+function scopeDescription(scope: ReviewScope): string {
+	if (scope.kind === "working-tree") return "the current branch diff (working tree changes or branch vs main)";
+	if (scope.kind === "pr") return `PR #${scope.number}`;
+	return scope.raw;
+}
+
+function inspectInstructions(scope: ReviewScope): string {
+	if (scope.kind === "pr") {
+		return `\
+How to inspect:
+1. Run \`gh pr diff ${scope.number}\` to get the full PR diff. If that fails, try \`gh pr diff ${scope.number} --repo <owner/repo>\`.
+2. Run \`gh pr view ${scope.number}\` to read the PR title and description — this is the intent context.
+3. For every changed function/method in the diff, read the full enclosing function body from the file on disk — not just the diff hunk.
+4. Read the test files for each changed module.
+5. Run \`pnpm exec tsc --noEmit\` to confirm no type errors.
+6. Run \`pnpm vitest run <changed test files>\` to confirm tests pass.`;
+	}
+
+	if (scope.kind === "explicit") {
+		return `\
+How to inspect:
+1. Run \`git diff ${scope.raw}\` to get the diff for the requested scope.
+2. For every changed function/method, read the full enclosing function body from disk — not just the diff hunk.
+3. Read the test files for each changed module.
+4. Run \`pnpm exec tsc --noEmit\` to confirm no type errors.
+5. Run \`pnpm vitest run <changed test files>\` to confirm tests pass.`;
+	}
+
+	// working-tree: must not accept empty diff as GREEN
+	return `\
+How to inspect:
+1. Run \`git diff HEAD\` to see uncommitted changes. Also run \`git status\` to find untracked files and read them directly.
+2. IMPORTANT: if \`git diff HEAD\` is empty (working tree is clean), do NOT return GREEN — instead run \`git diff origin/main...HEAD\` to get the full branch diff vs main. If that is also empty (already on main with no commits ahead), explicitly state "scope is empty — nothing to review" rather than returning GREEN.
+3. For every changed function/method, read the full enclosing function body from disk — not just the diff hunk. Bugs caused by interaction with surrounding code are invisible from hunks alone.
+4. Read the test files for each changed module to assess test adequacy.
+5. Run \`pnpm exec tsc --noEmit\` to confirm no type errors.
+6. Run \`pnpm vitest run <changed test files>\` to confirm tests pass.`;
+}
+
+export function buildReviewPrompt(args: string, model = DEFAULT_REVIEW_MODEL): string {
+	const scope = parseReviewScope(args);
+	const description = scopeDescription(scope);
+	const inspect = inspectInstructions(scope);
+
+	return `Run SumoCode diff review for ${description}.
+
+Main-agent protocol:
+- Do not perform the final review yourself. Invoke the task tool as a scroll/scribe reviewer with model ${model}.
+- Use task type="single" with one task. Pass model="${model}" and thinking="high".
+- The scribe must inspect the requested scope directly with git commands and file reads.
+- If the scribe returns P0, P1, or P2 findings, fix the issues or ask me before making product-risk changes, then call the review task again.
+- Relentlessly repeat review -> fix -> review until the scribe returns a GREEN signal.
+- Stop only when there is a GREEN signal or when blocked by missing requirements/permissions.
+
+---
+
+Scribe instructions — read carefully before reviewing:
+
+Project context:
+- Language: TypeScript (strict, no emit — jiti runs TS directly)
+- Test runner: vitest (pnpm vitest run <file> or pnpm test)
+- Type check: pnpm exec tsc --noEmit
+- Build check: pnpm build
+- Integration tests: pnpm test:integration
+- Conventions: tabs, no unused locals/params, colocated tests (foo.ts next to foo.test.ts)
+
+Review scope: ${description}
+
+Your job: find bugs that matter. A false positive is worse than a missed finding — err on the side of precision.
+
+IMPORTANT: You are the reviewer. Do NOT use the task tool or delegate to any sub-agent. Use only bash, read, and write. Perform the entire review yourself in this session.
+
+DO NOT flag any of the following:
+- Code style, formatting, naming conventions, whitespace, or import ordering
+- Missing comments or documentation
+- Refactor opportunities that do not carry direct bug risk
+- Speculative "could be an issue if..." concerns — if you can't trace a concrete execution path to a failure, omit it
+- Test file structure, test naming, or test verbosity
+
+${inspect}
+
+Reasoning discipline — for every finding you report:
+- State the premise: what you observed in the code.
+- Trace the concrete execution path that leads to the failure.
+- State the conclusion: what breaks, under what condition.
+- If you cannot complete this trace, omit the finding.
+
+Severity rubric:
+- P0: release blocker. Causes data loss, security/privacy exposure, destructive behavior, unrecoverable crashes on core flows, or breaks build/startup for most users.
+- P1: must fix before merge. Causes incorrect behavior, significant regression, broken important workflow, race/leak, stale state, failed error handling, or missing validation likely to affect users. Build failure or test failure is always P1.
+- P2: should fix before merge when practical. Risky edge case, incomplete test coverage for changed behavior, confusing failure mode, maintainability issue with plausible bug risk.
+
+GREEN signal criteria:
+Return GREEN only when ALL of the following are true:
+- No P0/P1/P2 findings remain.
+- \`pnpm exec tsc --noEmit\` passes (or was already clean before this change).
+- Relevant tests pass.
+- You have read the enclosing function for every changed hunk, not just the diff lines.
+- Test coverage is adequate for the changed behavior, or any gap is explicitly low-risk and justified.
+- The diff was non-empty — if scope was empty, state that explicitly instead of returning GREEN.
+
+Output format:
+- First line: one of GREEN, P0, P1, P2 (highest severity found), or EMPTY (scope had no diff to review).
+- Findings: one block per issue, ordered by severity. Each block must contain:
+  - Severity, File, Line range
+  - Premise: what you observed
+  - Execution path: the concrete trace to failure
+  - Impact: what breaks
+  - Fix: concrete recommendation
+- Omit any severity level you have no finding for — do not write "No P1 issues found".
+- Tests/verification section: what commands you ran and what they returned.
+- If GREEN: state every file you read, every command you ran, and why no blocking issues remain.`;
+}
+
+function notify(ctx: ExtensionContext, message: string, type: "info" | "warning" = "info"): void {
+	if (ctx.hasUI) {
+		ctx.ui.notify(message, type);
+		return;
+	}
+	process.stdout.write(`${message}\n`);
+}
+
+export function registerReviewCommand(pi: ExtensionAPI): void {
+	pi.registerCommand("sumo:review", {
+		description: "Run scroll/scribe diff review until GREEN. Args: empty=branch diff, #51=PR, or git range/path",
+		handler: async (args, ctx) => {
+			const model = resolveReviewModel();
+			const prompt = buildReviewPrompt(args, model);
+			const scope = parseReviewScope(args);
+			const label = scope.kind === "pr" ? `PR #${scope.number}` : scope.kind === "explicit" ? scope.raw : "branch diff";
+			try {
+				pi.sendUserMessage(prompt, { deliverAs: "followUp" });
+			} catch {
+				pi.sendUserMessage(prompt);
+			}
+			notify(ctx, `review queued: ${model} · ${label}`);
+		},
+	});
+}

--- a/src/interaction-registry.test.ts
+++ b/src/interaction-registry.test.ts
@@ -79,13 +79,14 @@ describe("InteractionRegistry", () => {
 			"sumo:memory",
 			"sumo:persona",
 			"sumo:query",
+			"sumo:review",
 			"sumo:spinner",
 			"sumo:tabs",
 			"sumo:theme",
 			"sumo:theme-check",
 		]);
 		expect(snapshot.shortcuts.map(([id]) => id).sort()).toEqual(["ctrl+/", "ctrl+1", "ctrl+2"]);
-		expect(pi.registerCommand).toHaveBeenCalledTimes(11);
+		expect(pi.registerCommand).toHaveBeenCalledTimes(12);
 		expect(pi.registerShortcut).toHaveBeenCalledTimes(3);
 	});
 });

--- a/src/interaction-registry.ts
+++ b/src/interaction-registry.ts
@@ -6,6 +6,7 @@ import { registerDivineQueryCommand } from "./commands/divine-query.js";
 import { registerExitCommand } from "./commands/exit.js";
 import { registerSlateCommand } from "./commands/slate.js";
 import { registerPersonaCommand } from "./commands/persona.js";
+import { registerReviewCommand } from "./commands/review.js";
 import { registerSpinnerCommand } from "./commands/spinner.js";
 import { registerTabsCommand } from "./commands/tabs.js";
 import { registerThemeCommand } from "./commands/theme.js";
@@ -132,6 +133,7 @@ export function installSumoInteractions(pi: ExtensionAPI, options: InstallSumoIn
 	registry.install("commands.exit", registerExitCommand);
 	registry.install("commands.slate", registerSlateCommand);
 	registry.install("commands.persona", registerPersonaCommand);
+	registry.install("commands.review", registerReviewCommand);
 	registry.install("commands.spinner", registerSpinnerCommand);
 	registry.install("commands.tabs", registerTabsCommand);
 	registry.install("commands.theme", registerThemeCommand);

--- a/src/sumo-tui/transcript/scroll-renderer.test.ts
+++ b/src/sumo-tui/transcript/scroll-renderer.test.ts
@@ -56,6 +56,40 @@ describe("scroll/scribe renderer", () => {
 		expect(rows.some((r) => r.includes("▶") && r.includes("[bash]") && r.includes("pnpm test"))).toBe(true);
 	});
 
+	it("keeps multiline nested tool output inside the scribe frame", () => {
+		const rows = renderScrollBlock(delegation({
+			nestedTools: [
+				{
+					name: "read",
+					status: "success",
+					output: "import type { ExtensionAPI } from '@mariozechner/pi-coding-agent';\nindex abc123..def456\n--- a/src/foo.ts\n+++ b/src/foo.ts",
+				},
+			],
+		}), 80).map(stripAnsi);
+
+		for (const row of rows) {
+			expect(row.length, `row not clipped: ${JSON.stringify(row)}`).toBe(80);
+		}
+		const toolRow = rows.find((r) => r.includes("[read]"));
+		expect(toolRow).toContain("import type");
+		expect(toolRow).not.toContain("\n");
+		expect(rows.some((r) => r.startsWith("index "))).toBe(false);
+		expect(rows.some((r) => r.startsWith("--- a/"))).toBe(false);
+	});
+
+	it("renders up to 25 scribe summary lines with a collapsed marker", () => {
+		const summary = Array.from({ length: 30 }, (_, index) => `line ${index + 1}`).join("\n");
+		const rows = renderScrollBlock(delegation({ status: "success", summary }), 100).map(stripAnsi);
+
+		expect(rows.some((r) => r.includes("│ line 1"))).toBe(true);
+		expect(rows.some((r) => r.includes("│ line 25"))).toBe(true);
+		expect(rows.some((r) => r.includes("│ line 26"))).toBe(false);
+		expect(rows.some((r) => r.includes("… 5 lines collapsed"))).toBe(true);
+		for (const row of rows) {
+			expect(row.length, `row not padded: ${JSON.stringify(row)}`).toBe(100);
+		}
+	});
+
 	it("renders completed task summary inside the scribe body", () => {
 		const rows = renderScrollBlock(delegation({ status: "success", summary: "Task tool ran." }), 130).map(stripAnsi);
 		expect(rows.some((r) => r.includes("│ Task tool ran."))).toBe(true);

--- a/src/sumo-tui/transcript/scroll-renderer.ts
+++ b/src/sumo-tui/transcript/scroll-renderer.ts
@@ -49,11 +49,19 @@ const TOOL_STATUS_COLOR: Record<string, string> = {
 	cancelled: CATHEDRAL_TOKENS.colors.foregroundDim,
 };
 
+const SCRIBE_BODY_MAX_LINES = 25;
+
+function singleLinePreview(text: string): string {
+	return text.replace(/[\r\n]+/g, " ").replace(/\s+/g, " ").trim();
+}
+
 function toolTarget(tool: ToolCallViewModel): string {
 	const input = typeof tool.input === "object" && tool.input !== null ? tool.input as Record<string, unknown> : {};
-	return typeof input.path === "string" ? input.path
+	const target = typeof input.path === "string" ? input.path
 		: typeof input.command === "string" ? input.command
-		: tool.output ?? "";
+		: typeof tool.output === "string" ? tool.output
+		: "";
+	return singleLinePreview(target);
 }
 
 function formatTokens(tokensIn?: number, tokensOut?: number): string | undefined {
@@ -179,6 +187,9 @@ function nestedToolRow(tool: ToolCallViewModel, width: number): string {
 	const glyph = TOOL_STATUS_GLYPH[tool.status] ?? "○";
 	const color = TOOL_STATUS_COLOR[tool.status] ?? CATHEDRAL_TOKENS.colors.foregroundDim;
 	const target = toolTarget(tool);
+	const prefixWidth = visibleWidth(`   │ ${glyph} [${tool.name}]  `);
+	const contentWidth = Math.max(1, width - prefixWidth);
+	const clipped = visibleWidth(target) > contentWidth ? truncateToWidth(target, contentWidth, "") : target;
 
 	return lineToAnsi(textLine([
 		span("   "),
@@ -187,7 +198,8 @@ function nestedToolRow(tool: ToolCallViewModel, width: number): string {
 		span(glyph, { fg: color }),
 		span(" "),
 		span(`[${tool.name}]`, { fg: CATHEDRAL_TOKENS.colors.accent }),
-		span(`  ${target}`, { fg: CATHEDRAL_TOKENS.colors.foreground }),
+		span("  "),
+		span(clipped, { fg: CATHEDRAL_TOKENS.colors.foreground }),
 	]), { width });
 }
 
@@ -209,14 +221,25 @@ function scribeTextRow(text: string, width: number): string {
 	]), { width });
 }
 
+function scribeCollapsedRow(remaining: number, width: number): string {
+	return lineToAnsi(textLine([
+		span("   "),
+		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span(` … ${remaining} lines collapsed`, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+	]), { width });
+}
+
 function scribeSummaryRows(summary: string | undefined, width: number): string[] {
 	if (!summary || summary.trim().length === 0) return [];
-	return summary
+	const lines = summary
 		.split("\n")
 		.map((line) => line.trim())
-		.filter((line) => line.length > 0)
-		.slice(0, 4)
-		.map((line) => scribeTextRow(line, width));
+		.filter((line) => line.length > 0);
+	const visible = lines.slice(0, SCRIBE_BODY_MAX_LINES);
+	const rows = visible.map((line) => scribeTextRow(line, width));
+	const collapsed = lines.length - visible.length;
+	if (collapsed > 0) rows.push(scribeCollapsedRow(collapsed, width));
+	return rows;
 }
 
 function scribeMetadataRow(delegation: DelegationViewModel, width: number): string {


### PR DESCRIPTION
## Summary
- add `/sumo:review` to queue a scroll/scribe diff review using `deepseek/deepseek-v4-pro`
- encode P0/P1/P2 severity criteria and GREEN review loop protocol in the generated review prompt
- fix scroll/scribe rendering so nested multiline tool previews stay inside the frame
- expand scribe output body from 4 rows to 25 rows with a collapsed marker

## Verification
- scroll/scribe review returned GREEN
- pnpm vitest run src/sumo-tui/transcript/scroll-renderer.test.ts src/commands/review.test.ts src/interaction-registry.test.ts
- pnpm exec tsc --noEmit && pnpm build
- pnpm test
- pnpm test:integration
- pnpm visual:ci