### PR TITLE
refactor(theme): introduce registry

### DIFF
--- a/src/answer-tool.ts
+++ b/src/answer-tool.ts
@@ -14,7 +14,7 @@ import { BorderedLoader } from "@mariozechner/pi-coding-agent";
 import { Editor, type EditorTheme, Key, matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import type { Component, TUI } from "@mariozechner/pi-tui";
 import { DIVINE_QUERY_OVERLAY_OPTIONS } from "./divine-query.js";
-import { CATHEDRAL_TOKENS } from "./tokens.js";
+import { activeThemeColors } from "./themes/index.js";
 
 // ── Types ────────────────────────────────────────────────────
 
@@ -96,12 +96,12 @@ function cathedralFg(text: string, hex: string): string {
 	return `\u001b[38;2;${r};${g};${b}m${text}${RESET}`;
 }
 
-const accent = (s: string) => cathedralFg(s, CATHEDRAL_TOKENS.colors.accent);
-const fg = (s: string) => cathedralFg(s, CATHEDRAL_TOKENS.colors.foreground);
-const dim = (s: string) => cathedralFg(s, CATHEDRAL_TOKENS.colors.foregroundDim);
-const divider = (s: string) => cathedralFg(s, CATHEDRAL_TOKENS.colors.divider);
-const idle = (s: string) => cathedralFg(s, CATHEDRAL_TOKENS.colors.states.idle);
-const thinking = (s: string) => cathedralFg(s, CATHEDRAL_TOKENS.colors.states.thinking);
+const accent = (s: string) => cathedralFg(s, activeThemeColors().accent);
+const fg = (s: string) => cathedralFg(s, activeThemeColors().foreground);
+const dim = (s: string) => cathedralFg(s, activeThemeColors().foregroundDim);
+const divider = (s: string) => cathedralFg(s, activeThemeColors().divider);
+const idle = (s: string) => cathedralFg(s, activeThemeColors().states.idle);
+const thinking = (s: string) => cathedralFg(s, activeThemeColors().states.thinking);
 const liftedBg = `\u001b[48;2;61;48;36m`; // surfaceLifted
 
 class CathedralQnAComponent implements Component {
@@ -121,13 +121,13 @@ class CathedralQnAComponent implements Component {
 		this.onDone = onDone;
 
 		const editorTheme: EditorTheme = {
-			borderColor: (s) => cathedralFg(s, CATHEDRAL_TOKENS.colors.accent),
+			borderColor: (s) => cathedralFg(s, activeThemeColors().accent),
 			selectList: {
-				selectedPrefix: (t) => cathedralFg(t, CATHEDRAL_TOKENS.colors.accent),
-				selectedText: (t) => cathedralFg(t, CATHEDRAL_TOKENS.colors.accent),
-				description: (t) => cathedralFg(t, CATHEDRAL_TOKENS.colors.foregroundDim),
-				scrollInfo: (t) => cathedralFg(t, CATHEDRAL_TOKENS.colors.foregroundDim),
-				noMatch: (t) => cathedralFg(t, CATHEDRAL_TOKENS.colors.states.approval),
+				selectedPrefix: (t) => cathedralFg(t, activeThemeColors().accent),
+				selectedText: (t) => cathedralFg(t, activeThemeColors().accent),
+				description: (t) => cathedralFg(t, activeThemeColors().foregroundDim),
+				scrollInfo: (t) => cathedralFg(t, activeThemeColors().foregroundDim),
+				noMatch: (t) => cathedralFg(t, activeThemeColors().states.approval),
 			},
 		};
 		this.editor = new Editor(tui, editorTheme);

--- a/src/approval-modal.ts
+++ b/src/approval-modal.ts
@@ -31,7 +31,7 @@
 import type { Component } from "@mariozechner/pi-tui";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
-import { CATHEDRAL_TOKENS } from "./tokens.js";
+import { activeThemeColors } from "./themes/index.js";
 
 const RESET = "\u001b[0m";
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
@@ -80,12 +80,12 @@ function center(line: string, width: number): string {
 }
 
 function panelRow(inner: string, width: number): string {
-	return persistentBg(padRight(inner, width), CATHEDRAL_TOKENS.colors.foreground, CATHEDRAL_TOKENS.colors.surfaceLifted);
+	return persistentBg(padRight(inner, width), activeThemeColors().foreground, activeThemeColors().surfaceLifted);
 }
 
 function splitRule(width: number): string {
 	const ruleLength = Math.max(1, Math.min(22, Math.floor((width - 5) / 2)));
-	const divider = CATHEDRAL_TOKENS.colors.divider;
+	const divider = activeThemeColors().divider;
 	return center(`${fg("─".repeat(ruleLength), divider)}  ${fg("·", divider)}  ${fg("─".repeat(ruleLength), divider)}`, width);
 }
 
@@ -104,9 +104,9 @@ function renderButton(choice: ApprovalChoice, isActive: boolean): string {
 	const rest = choice === "yes" ? "ES" : choice === "no" ? "O" : "LWAYS";
 	if (isActive) {
 		const label = choice === "yes" ? " YES " : choice === "no" ? "  NO  " : " ALWAYS ";
-		return `${sgr(CATHEDRAL_TOKENS.colors.states.approval, 48)}${sgr(CATHEDRAL_TOKENS.colors.background, 38)}${label}${RESET}`;
+		return `${sgr(activeThemeColors().states.approval, 48)}${sgr(activeThemeColors().background, 38)}${label}${RESET}`;
 	}
-	return `${fg("[", CATHEDRAL_TOKENS.colors.divider)}${fg(key, CATHEDRAL_TOKENS.colors.foreground)}${fg("]", CATHEDRAL_TOKENS.colors.divider)}${fg(rest, CATHEDRAL_TOKENS.colors.foreground)}`;
+	return `${fg("[", activeThemeColors().divider)}${fg(key, activeThemeColors().foreground)}${fg("]", activeThemeColors().divider)}${fg(rest, activeThemeColors().foreground)}`;
 }
 
 function commandBoxWidth(width: number): number {
@@ -119,15 +119,15 @@ function renderCommandFrame(command: string, width: number): string[] {
 	const boxWidth = commandBoxWidth(width);
 	const innerWidth = Math.max(0, boxWidth - 2);
 	const commandWidth = Math.max(1, innerWidth - 2);
-	const border = CATHEDRAL_TOKENS.colors.divider;
+	const border = activeThemeColors().divider;
 	const commandRows = wrapTextWithAnsi(command, commandWidth);
 	const safeRows = commandRows.length > 0 ? commandRows : [""];
 	const boxRows = [
 		fg(`┌${"─".repeat(innerWidth)}┐`, border),
-		...safeRows.map((row) => `${fg("│", border)} ${fg(fitLine(row, commandWidth), CATHEDRAL_TOKENS.colors.foreground)}${" ".repeat(Math.max(0, commandWidth - visibleLength(row)))} ${fg("│", border)}`),
+		...safeRows.map((row) => `${fg("│", border)} ${fg(fitLine(row, commandWidth), activeThemeColors().foreground)}${" ".repeat(Math.max(0, commandWidth - visibleLength(row)))} ${fg("│", border)}`),
 		fg(`└${"─".repeat(innerWidth)}┘`, border),
 	];
-	return boxRows.map((row) => `${PANEL_INDENT}${persistentBg(padRight(row, boxWidth), CATHEDRAL_TOKENS.colors.foreground, CATHEDRAL_TOKENS.colors.surfaceRecess)}`);
+	return boxRows.map((row) => `${PANEL_INDENT}${persistentBg(padRight(row, boxWidth), activeThemeColors().foreground, activeThemeColors().surfaceRecess)}`);
 }
 
 function renderDescriptionRows(descriptionLines: readonly string[], width: number): string[] {
@@ -139,7 +139,7 @@ function renderDescriptionRows(descriptionLines: readonly string[], width: numbe
 		const lines = wrapped.length > 0 ? wrapped : [""];
 		for (let rowIndex = 0; rowIndex < lines.length; rowIndex += 1) {
 			const rowPrefix = rowIndex === 0 ? prefix : "  ";
-			rows.push(`${PANEL_INDENT}${fg(`${rowPrefix}${lines[rowIndex]}`, CATHEDRAL_TOKENS.colors.foregroundDim)}`);
+			rows.push(`${PANEL_INDENT}${fg(`${rowPrefix}${lines[rowIndex]}`, activeThemeColors().foregroundDim)}`);
 		}
 	}
 	return rows;
@@ -153,12 +153,12 @@ export function renderApprovalModal(snapshot: ApprovalModalSnapshot, width: numb
 	const lines: string[] = [];
 
 	lines.push(panelRow("", safeWidth));
-	lines.push(panelRow(center(`${fg("✾", CATHEDRAL_TOKENS.colors.states.approval)}  ${fg("APPROVAL REQUIRED", CATHEDRAL_TOKENS.colors.states.approval)}  ${fg("✾", CATHEDRAL_TOKENS.colors.states.approval)}`, safeWidth), safeWidth));
+	lines.push(panelRow(center(`${fg("✾", activeThemeColors().states.approval)}  ${fg("APPROVAL REQUIRED", activeThemeColors().states.approval)}  ${fg("✾", activeThemeColors().states.approval)}`, safeWidth), safeWidth));
 	lines.push(panelRow("", safeWidth));
 	lines.push(panelRow(splitRule(safeWidth), safeWidth));
 	lines.push(panelRow("", safeWidth));
 
-	lines.push(panelRow(`${PANEL_INDENT}${fg("You are about to execute:", CATHEDRAL_TOKENS.colors.foreground)}`, safeWidth));
+	lines.push(panelRow(`${PANEL_INDENT}${fg("You are about to execute:", activeThemeColors().foreground)}`, safeWidth));
 	lines.push(panelRow("", safeWidth));
 
 	for (const row of renderCommandFrame(snapshot.command, safeWidth)) lines.push(panelRow(row, safeWidth));
@@ -170,7 +170,7 @@ export function renderApprovalModal(snapshot: ApprovalModalSnapshot, width: numb
 	lines.push(panelRow(splitRule(safeWidth), safeWidth));
 	lines.push(panelRow("", safeWidth));
 
-	const systemNotice = `${fg("■", CATHEDRAL_TOKENS.colors.states.approval)} ${fg("SYSTEM NOTICE", CATHEDRAL_TOKENS.colors.foregroundDim)}`;
+	const systemNotice = `${fg("■", activeThemeColors().states.approval)} ${fg("SYSTEM NOTICE", activeThemeColors().foregroundDim)}`;
 	const buttons = DEFAULT_BUTTON_ORDER.map((choice) => renderButton(choice, choice === snapshot.activeButton)).join("  ");
 	const left = `${PANEL_INDENT}${systemNotice}`;
 	const right = `${buttons}${PANEL_INDENT}`;

--- a/src/cathedral/cathedral-editor.ts
+++ b/src/cathedral/cathedral-editor.ts
@@ -40,7 +40,7 @@ import type {
 import { CustomEditor } from "@mariozechner/pi-coding-agent";
 import { CURSOR_MARKER, truncateToWidth, visibleWidth, type EditorTheme, type TUI } from "@mariozechner/pi-tui";
 import { sessionHasMessages as cachedSessionHasMessages } from "../session-cache.js";
-import { CATHEDRAL_TOKENS } from "../tokens.js";
+import { activeThemeColors } from "../themes/index.js";
 import { setActiveEditorDraftController } from "./editor-draft-state.js";
 import {
 	INPUT_FRAME_LABEL_ACTIVE,
@@ -92,14 +92,21 @@ function color(text: string, hex: string): string {
 	return `${fg(hex)}${text}${RESET}`;
 }
 
-const DIVIDER_FG = fg(CATHEDRAL_TOKENS.colors.divider);
-const RECESS_BG = bg(CATHEDRAL_TOKENS.colors.surfaceRecess);
+function dividerFg(): string {
+	return fg(activeThemeColors().divider);
+}
+
+function recessBg(): string {
+	return bg(activeThemeColors().surfaceRecess);
+}
+
 const RESET_BG = "\u001b[49m";
 
 function withFrameBackground(line: string): string {
 	// Any nested RESET clears the background. Re-apply the frame background so
 	// the whole input frame row remains the recessed #120D0A Bible well.
-	return `${RECESS_BG}${line.replaceAll(RESET, `${RESET}${RECESS_BG}`)}${RESET_BG}`;
+	const frameBg = recessBg();
+	return `${frameBg}${line.replaceAll(RESET, `${RESET}${frameBg}`)}${RESET_BG}`;
 }
 
 function maybeWithFrameBackground(line: string, enabled: boolean): string {
@@ -111,23 +118,24 @@ function maybeWithFrameBackground(line: string, enabled: boolean): string {
  * input is label-less; splash uses `DIVINE INVOCATION`.
  */
 function renderTopBorder(width: number, label: string | undefined, paintBackground: boolean): string {
-	if (width < 6) return maybeWithFrameBackground(color("─".repeat(width), CATHEDRAL_TOKENS.colors.divider), paintBackground);
+	if (width < 6) return maybeWithFrameBackground(color("─".repeat(width), activeThemeColors().divider), paintBackground);
 	const inner = width - 2;
-	if (!label) return maybeWithFrameBackground(color(`┌${"─".repeat(inner)}┐`, CATHEDRAL_TOKENS.colors.divider), paintBackground);
+	if (!label) return maybeWithFrameBackground(color(`┌${"─".repeat(inner)}┐`, activeThemeColors().divider), paintBackground);
 	const leftDashes = "─".repeat(Math.min(1, inner));
 	const maxLabelText = Math.max(0, inner - leftDashes.length - 2); // 2 = spaces around label
 	const labelText = ellipsize(label, maxLabelText);
 	const labelInner = labelText.length > 0 ? ` ${labelText} ` : "";
 	const rightDashes = "─".repeat(Math.max(0, inner - leftDashes.length - labelInner.length));
-	const left = `${DIVIDER_FG}┌${leftDashes}`;
-	const labelSegment = color(labelInner, CATHEDRAL_TOKENS.colors.accent);
-	const right = `${DIVIDER_FG}${rightDashes}┐${RESET}`;
+	const divider = dividerFg();
+	const left = `${divider}┌${leftDashes}`;
+	const labelSegment = color(labelInner, activeThemeColors().accent);
+	const right = `${divider}${rightDashes}┐${RESET}`;
 	return maybeWithFrameBackground(`${left}${labelSegment}${right}`, paintBackground);
 }
 
 function renderBottomBorder(width: number, paintBackground: boolean): string {
-	if (width < 6) return maybeWithFrameBackground(color("─".repeat(width), CATHEDRAL_TOKENS.colors.divider), paintBackground);
-	return maybeWithFrameBackground(color(`└${"─".repeat(width - 2)}┘`, CATHEDRAL_TOKENS.colors.divider), paintBackground);
+	if (width < 6) return maybeWithFrameBackground(color("─".repeat(width), activeThemeColors().divider), paintBackground);
+	return maybeWithFrameBackground(color(`└${"─".repeat(width - 2)}┘`, activeThemeColors().divider), paintBackground);
 }
 
 /**
@@ -146,7 +154,8 @@ function wrapRow(inner: string, width: number, paintBackground: boolean): string
 	const visible = visibleLength(fitted);
 	const pad = Math.max(0, innerWidth - visible);
 	const padded = `${fitted}${" ".repeat(pad)}`;
-	return maybeWithFrameBackground(`${DIVIDER_FG}│${RESET}${padded}${DIVIDER_FG}│${RESET}`, paintBackground);
+	const divider = dividerFg();
+	return maybeWithFrameBackground(`${divider}│${RESET}${padded}${divider}│${RESET}`, paintBackground);
 }
 
 /**
@@ -163,9 +172,10 @@ function wrapActiveRow(inner: string, width: number, paintBackground: boolean, i
 	const pad = Math.max(0, contentWidth - visible);
 	const padded = `${fitted}${" ".repeat(pad)}`;
 	const prompt = isFirstRow
-		? ` ${color(">", CATHEDRAL_TOKENS.colors.accent)} `
+		? ` ${color(">", activeThemeColors().accent)} `
 		: "   ";
-	return maybeWithFrameBackground(`${DIVIDER_FG}│${RESET}${prompt}${padded}${DIVIDER_FG}│${RESET}`, paintBackground);
+	const divider = dividerFg();
+	return maybeWithFrameBackground(`${divider}│${RESET}${prompt}${padded}${divider}│${RESET}`, paintBackground);
 }
 
 function centerRow(row: string, width: number): string {
@@ -279,10 +289,10 @@ class CathedralEditor extends CustomEditor {
 				// Preserve Pi's zero-width cursor marker while painting our ghost text.
 				// Without this, TUI.positionHardwareCursor() sees no marker on the
 				// splash empty state and emits \x1b[?25l after every render.
-				const prompt = ` ${color(">", CATHEDRAL_TOKENS.colors.accent)} ${CURSOR_MARKER}`;
+				const prompt = ` ${color(">", activeThemeColors().accent)} ${CURSOR_MARKER}`;
 				const maxPlaceholder = Math.max(0, frameWidth - 2 - visibleLength(prompt));
 				const placeholder = ellipsize(INPUT_FRAME_PLACEHOLDER, maxPlaceholder);
-				const ghost = `${prompt}${color(placeholder, CATHEDRAL_TOKENS.colors.foregroundDim)}`;
+				const ghost = `${prompt}${color(placeholder, activeThemeColors().foregroundDim)}`;
 				return fullRow(wrapRow(ghost, frameWidth, paintFrameBackground));
 			}
 			if (!splash) return wrapActiveRow(row, frameWidth, paintFrameBackground, isFirstContent);

--- a/src/cathedral/input-frame.ts
+++ b/src/cathedral/input-frame.ts
@@ -30,7 +30,7 @@
  * `src/cathedral/cathedral-editor.ts`.
  */
 
-import { CATHEDRAL_TOKENS } from "../tokens.js";
+import { activeThemeColors } from "../themes/index.js";
 
 const RESET = "\u001b[0m";
 const RESET_BG = "\u001b[49m";
@@ -110,11 +110,11 @@ export type InputFrameOptions = {
  */
 export function renderInputFrame(input: string, width: number, options: InputFrameOptions = {}): string[] {
 	if (width < 4) {
-		return [padToWidth(color("█", CATHEDRAL_TOKENS.colors.accent), width)];
+		return [padToWidth(color("█", activeThemeColors().accent), width)];
 	}
 
 	const inner = width - 2;
-	const dividerCh = (ch: string): string => color(ch, CATHEDRAL_TOKENS.colors.divider);
+	const dividerCh = (ch: string): string => color(ch, activeThemeColors().divider);
 
 	// Top border with optional label. Label punches through the border with
 	// accent foreground over recess background so it reads as a notch.
@@ -126,7 +126,7 @@ export function renderInputFrame(input: string, width: number, options: InputFra
 		const labelText = ellipsize(options.label, maxLabelText);
 		const labelInner = labelText.length > 0 ? ` ${labelText} ` : "";
 		const rightDashes = "─".repeat(Math.max(0, inner - leftDashes.length - labelInner.length));
-		top = `${dividerCh("┌")}${dividerCh(leftDashes)}${color(labelInner, CATHEDRAL_TOKENS.colors.accent)}${dividerCh(rightDashes)}${dividerCh("┐")}`;
+		top = `${dividerCh("┌")}${dividerCh(leftDashes)}${color(labelInner, activeThemeColors().accent)}${dividerCh(rightDashes)}${dividerCh("┐")}`;
 	} else {
 		top = `${dividerCh("┌")}${dividerCh("─".repeat(inner))}${dividerCh("┐")}`;
 	}
@@ -137,12 +137,12 @@ export function renderInputFrame(input: string, width: number, options: InputFra
 	const showPlaceholder = input.length === 0 && options.placeholder !== undefined;
 	const promptHex =
 		options.promptColor === "accent"
-			? CATHEDRAL_TOKENS.colors.accent
-			: CATHEDRAL_TOKENS.colors.foregroundDim;
+			? activeThemeColors().accent
+			: activeThemeColors().foregroundDim;
 	const promptArrow = color(">", promptHex);
-	const cursor = color("█", CATHEDRAL_TOKENS.colors.accent);
+	const cursor = color("█", activeThemeColors().accent);
 	const rawText = showPlaceholder ? options.placeholder! : input;
-	const textColor = showPlaceholder ? CATHEDRAL_TOKENS.colors.foregroundDim : CATHEDRAL_TOKENS.colors.foreground;
+	const textColor = showPlaceholder ? activeThemeColors().foregroundDim : activeThemeColors().foreground;
 	let innerContent: string;
 	if (inner >= 4) {
 		const maxText = Math.max(0, inner - 4); // leading space + prompt + separator + cursor
@@ -163,7 +163,7 @@ export function renderInputFrame(input: string, width: number, options: InputFra
 
 	// Bottom border
 	const bottom = `${dividerCh("└")}${dividerCh("─".repeat(inner))}${dividerCh("┘")}`;
-	const frameBg = CATHEDRAL_TOKENS.colors.surfaceRecess;
+	const frameBg = activeThemeColors().surfaceRecess;
 
 	return [
 		withBackground(padToWidth(top, width), frameBg),
@@ -200,18 +200,18 @@ export function renderInputHints(width: number, options: InputHintsOptions = {})
 	const rightLen = rightPlain.length;
 	const left = options.leftHint;
 
-	const dimFg = fg(CATHEDRAL_TOKENS.colors.foregroundDim);
-	const accent = fg(CATHEDRAL_TOKENS.colors.accent);
+	const dimFg = fg(activeThemeColors().foregroundDim);
+	const accent = fg(activeThemeColors().accent);
 
 	// Build the colored right-hand string: CTRL+/ in accent, label in dim.
 	const rightColored = `${accent}CTRL+/${RESET} ${dimFg}· COMMANDS${RESET}`;
 	const colorLeftHint = (text: string): string => {
 		if (options.leftHintStyle !== "project-branch") return `${dimFg}${text}${RESET}`;
 		const branchStart = text.indexOf(" (");
-		if (branchStart === -1) return color(text, CATHEDRAL_TOKENS.colors.foreground);
+		if (branchStart === -1) return color(text, activeThemeColors().foreground);
 		const project = text.slice(0, branchStart);
 		const branch = text.slice(branchStart);
-		return `${color(project, CATHEDRAL_TOKENS.colors.foreground)}${dimFg}${branch}${RESET}`;
+		return `${color(project, activeThemeColors().foreground)}${dimFg}${branch}${RESET}`;
 	};
 
 	// At narrow widths, drop the left hint first unless the caller explicitly

--- a/src/command-palette.ts
+++ b/src/command-palette.ts
@@ -3,7 +3,7 @@ import type { Component, OverlayOptions } from "@mariozechner/pi-tui";
 import { Key, matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import type { ThinkingLevel } from "./footer.js";
 import { showDivineQuery } from "./divine-query.js";
-import { CATHEDRAL_TOKENS } from "./tokens.js";
+import { activeThemeColors } from "./themes/index.js";
 
 export type PaletteMode = "SESSION" | "MODEL" | "THINKING" | "MEMORY" | "THEME" | "SETTINGS";
 
@@ -54,8 +54,13 @@ export const COMMAND_PALETTE_MODE_ROWS: readonly PaletteRow[] = [
 
 const RESET = "\u001b[0m";
 const FG_RESET = "\u001b[39m";
-const PANEL_BG = CATHEDRAL_TOKENS.colors.surfaceLifted;
-const PALETTE_DIVIDER = CATHEDRAL_TOKENS.colors.divider;
+function panelBg(): string {
+	return activeThemeColors().surfaceLifted;
+}
+
+function paletteDivider(): string {
+	return activeThemeColors().divider;
+}
 
 function ansiColor(hex: string, channel: 38 | 48): string {
 	const normalized = hex.replace("#", "");
@@ -70,23 +75,23 @@ function fg(text: string, hex: string): string {
 }
 
 function dim(text: string): string {
-	return fg(text, CATHEDRAL_TOKENS.colors.foregroundDim);
+	return fg(text, activeThemeColors().foregroundDim);
 }
 
 function accent(text: string): string {
-	return fg(text, CATHEDRAL_TOKENS.colors.accent);
+	return fg(text, activeThemeColors().accent);
 }
 
 function dividerText(text: string): string {
-	return fg(text, PALETTE_DIVIDER);
+	return fg(text, paletteDivider());
 }
 
 function foreground(text: string): string {
-	return fg(text, CATHEDRAL_TOKENS.colors.foreground);
+	return fg(text, activeThemeColors().foreground);
 }
 
 function cursorCell(): string {
-	return `${ansiColor(CATHEDRAL_TOKENS.colors.accent, 48)}${ansiColor(CATHEDRAL_TOKENS.colors.background, 38)} ${FG_RESET}${ansiColor(PANEL_BG, 48)}`;
+	return `${ansiColor(activeThemeColors().accent, 48)}${ansiColor(activeThemeColors().background, 38)} ${FG_RESET}${ansiColor(panelBg(), 48)}`;
 }
 
 function padToWidth(text: string, width: number): string {
@@ -96,7 +101,7 @@ function padToWidth(text: string, width: number): string {
 }
 
 function panelLine(text: string, width: number): string {
-	return `${ansiColor(PANEL_BG, 48)}${ansiColor(CATHEDRAL_TOKENS.colors.foreground, 38)}${padToWidth(text, width)}${RESET}`;
+	return `${ansiColor(panelBg(), 48)}${ansiColor(activeThemeColors().foreground, 38)}${padToWidth(text, width)}${RESET}`;
 }
 
 function center(text: string, width: number): string {

--- a/src/commands/spinner.ts
+++ b/src/commands/spinner.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { CATHEDRAL_TOKENS } from "../tokens.js";
+import { activeThemeColors } from "../themes/index.js";
 import {
 	CATHEDRAL_INDICATOR_FRAMES,
 	CATHEDRAL_INDICATOR_INTERVAL_MS,
@@ -21,7 +21,7 @@ export function registerSpinnerCommand(pi: ExtensionAPI): void {
 		handler: async (_args, ctx: ExtensionContext) => {
 			const report = formatSpinnerInspection(
 				CATHEDRAL_INDICATOR_FRAMES,
-				CATHEDRAL_TOKENS.colors.accent,
+				activeThemeColors().accent,
 				CATHEDRAL_INDICATOR_INTERVAL_MS,
 			);
 

--- a/src/divine-query.ts
+++ b/src/divine-query.ts
@@ -30,7 +30,7 @@
 import type { Component, OverlayOptions } from "@mariozechner/pi-tui";
 import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { CATHEDRAL_TOKENS } from "./tokens.js";
+import { activeThemeColors } from "./themes/index.js";
 
 const RESET = "[0m";
 const ANSI_PATTERN = /\[[0-9;]*m/g;
@@ -119,9 +119,9 @@ const UNFOCUSED_MARK = "·";
 
 function splitRule(width: number): string {
 	const ruleLen = Math.max(1, Math.min(22, Math.floor((width - 5) / 2)));
-	const left = fg("─".repeat(ruleLen), CATHEDRAL_TOKENS.colors.divider);
-	const dot = fg("·", CATHEDRAL_TOKENS.colors.divider);
-	const right = fg("─".repeat(ruleLen), CATHEDRAL_TOKENS.colors.divider);
+	const left = fg("─".repeat(ruleLen), activeThemeColors().divider);
+	const dot = fg("·", activeThemeColors().divider);
+	const right = fg("─".repeat(ruleLen), activeThemeColors().divider);
 	return center(`${left}  ${dot}  ${right}`, width);
 }
 
@@ -142,7 +142,7 @@ function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, ext
 	inner.push("");
 
 	// Title: ✾  DIVINE QUERY  ✾
-	const titleText = `${fg(TITLE_MARK, CATHEDRAL_TOKENS.colors.accent)}  ${fg("DIVINE QUERY", CATHEDRAL_TOKENS.colors.accent)}  ${fg(TITLE_MARK, CATHEDRAL_TOKENS.colors.accent)}`;
+	const titleText = `${fg(TITLE_MARK, activeThemeColors().accent)}  ${fg("DIVINE QUERY", activeThemeColors().accent)}  ${fg(TITLE_MARK, activeThemeColors().accent)}`;
 	inner.push(center(titleText, contentWidth));
 
 	// Blank
@@ -157,7 +157,7 @@ function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, ext
 	// Question body. Bible Element 11 keeps a generous right margin: text wraps
 	// at `cols - 12`, then gets a 5-col left indent.
 	for (const questionLine of wrapIndentedText(snapshot.title, Math.max(1, contentWidth - 7), indent)) {
-		inner.push(fg(questionLine, CATHEDRAL_TOKENS.colors.foreground));
+		inner.push(fg(questionLine, activeThemeColors().foreground));
 	}
 
 	// Blank
@@ -167,8 +167,8 @@ function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, ext
 	for (let i = 0; i < snapshot.options.length; i += 1) {
 		const focused = i === snapshot.focusedIndex;
 		const mark = focused
-			? fg(FOCUSED_MARK, CATHEDRAL_TOKENS.colors.accent)
-			: fg(UNFOCUSED_MARK, CATHEDRAL_TOKENS.colors.divider);
+			? fg(FOCUSED_MARK, activeThemeColors().accent)
+			: fg(UNFOCUSED_MARK, activeThemeColors().divider);
 		const optionIndent = `${indent}${mark}   `;
 		const continuationIndent = `${indent}    `;
 		const label = `${optionLabel(i)}${snapshot.options[i]}`;
@@ -177,8 +177,8 @@ function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, ext
 			const raw = (wrappedOption[optionRow] ?? "").slice(continuationIndent.length);
 			const prefix = optionRow === 0 ? optionIndent : continuationIndent;
 			const text = focused
-				? fg(raw, CATHEDRAL_TOKENS.colors.foreground)
-				: fg(raw, CATHEDRAL_TOKENS.colors.foregroundDim);
+				? fg(raw, activeThemeColors().foreground)
+				: fg(raw, activeThemeColors().foregroundDim);
 			inner.push(`${prefix}${text}`);
 		}
 	}
@@ -190,7 +190,7 @@ function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, ext
 	inner.push(splitRule(contentWidth));
 
 	// Footer
-	const footer = fg("↑↓ wander    ⏎ answer    ⎋ retreat", CATHEDRAL_TOKENS.colors.foregroundDim);
+	const footer = fg("↑↓ wander    ⏎ answer    ⎋ retreat", activeThemeColors().foregroundDim);
 	inner.push(center(footer, contentWidth));
 
 	// Extras (e.g. edit-mode editor rows from question-tool)
@@ -209,8 +209,8 @@ function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, ext
 function wrapPanelRow(innerLine: string, contentWidth: number): string {
 	return persistentBg(
 		padRight(innerLine, contentWidth),
-		CATHEDRAL_TOKENS.colors.foreground,
-		CATHEDRAL_TOKENS.colors.surfaceLifted,
+		activeThemeColors().foreground,
+		activeThemeColors().surfaceLifted,
 	);
 }
 

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -10,7 +10,7 @@ import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
  */
 export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 import { getSessionUsage as getCachedSessionUsage, sessionHasMessages as cachedSessionHasMessages, linkGitBranchProvider } from "./session-cache.js";
-import { CATHEDRAL_TOKENS, type SumoCodeState } from "./tokens.js";
+import { activeThemeColors, type SumoCodeState } from "./themes/index.js";
 import { VOICE } from "./voice.js";
 
 type Usage = {
@@ -113,11 +113,11 @@ function padAnsiToWidth(line: string, width: number): string {
 }
 
 function formatFooterLineInner(snapshot: FooterSnapshot, width: number): string {
-	const dot = colorHex("●", CATHEDRAL_TOKENS.colors.states[snapshot.state]);
-	const stateLabel = colorHex(VOICE.status[snapshot.state], CATHEDRAL_TOKENS.colors.foreground);
-	const model = colorHex(snapshot.modelId, CATHEDRAL_TOKENS.colors.foreground);
-	const thinking = colorHex(snapshot.thinkingLevel, CATHEDRAL_TOKENS.colors.foreground);
-	const sep = colorHex(" · ", CATHEDRAL_TOKENS.colors.foregroundDim);
+	const dot = colorHex("●", activeThemeColors().states[snapshot.state]);
+	const stateLabel = colorHex(VOICE.status[snapshot.state], activeThemeColors().foreground);
+	const model = colorHex(snapshot.modelId, activeThemeColors().foreground);
+	const thinking = colorHex(snapshot.thinkingLevel, activeThemeColors().foreground);
+	const sep = colorHex(" · ", activeThemeColors().foregroundDim);
 
 	const leftZone = [`${dot} ${stateLabel}`, model, thinking].join(sep);
 	const leftLen = visibleWidth(leftZone);
@@ -127,8 +127,8 @@ function formatFooterLineInner(snapshot: FooterSnapshot, width: number): string 
 	const tokensText = contextWindow > 0
 		? `${formatTokenCount(contextTokens)}/${formatTokenCount(contextWindow)}`
 		: formatTokenCount(contextTokens);
-	const tokens = colorHex(tokensText, CATHEDRAL_TOKENS.colors.foreground);
-	const cost = colorHex(`$${snapshot.costUsd.toFixed(2)}`, CATHEDRAL_TOKENS.colors.foreground);
+	const tokens = colorHex(tokensText, activeThemeColors().foreground);
+	const cost = colorHex(`$${snapshot.costUsd.toFixed(2)}`, activeThemeColors().foreground);
 
 	// Build right zone progressively, dropping rightmost fields if they don't fit.
 	const rightCandidates: string[][] = [
@@ -163,7 +163,7 @@ export function renderSplashVersionLine(width: number): string {
 	if (width <= 0 || SPLASH_VERSION_LINE.length > width) return "";
 	const padLeft = Math.floor((width - SPLASH_VERSION_LINE.length) / 2);
 	const padRight = width - SPLASH_VERSION_LINE.length - padLeft;
-	const dim = colorHex(SPLASH_VERSION_LINE, CATHEDRAL_TOKENS.colors.foregroundDim);
+	const dim = colorHex(SPLASH_VERSION_LINE, activeThemeColors().foregroundDim);
 	return `${" ".repeat(padLeft)}${dim}${" ".repeat(padRight)}`;
 }
 

--- a/src/memory-editor.ts
+++ b/src/memory-editor.ts
@@ -28,7 +28,7 @@ import {
 	type PanelGroup,
 	type PanelId,
 } from "./memory-categorization.js";
-import { CATHEDRAL_TOKENS } from "./tokens.js";
+import { activeThemeColors } from "./themes/index.js";
 
 const RESET = "\u001b[0m";
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
@@ -52,7 +52,7 @@ function padToWidth(line: string, width: number): string {
 }
 
 function divider(width: number): string {
-	return colorHex("─".repeat(Math.max(0, width - 6)), CATHEDRAL_TOKENS.colors.divider);
+	return colorHex("─".repeat(Math.max(0, width - 6)), activeThemeColors().divider);
 }
 
 export type MemoryEditorSnapshot = {
@@ -74,27 +74,27 @@ function renderPanel(group: PanelGroup, width: number): string[] {
 	const bottom = `╰${"─".repeat(innerWidth - 2)}╯`;
 
 	const lines: string[] = [];
-	lines.push(colorHex(top, CATHEDRAL_TOKENS.colors.divider).replace(
+	lines.push(colorHex(top, activeThemeColors().divider).replace(
 		labelInner,
-		colorHex(labelInner, CATHEDRAL_TOKENS.colors.accent),
+		colorHex(labelInner, activeThemeColors().accent),
 	));
 
 	if (group.facts.length === 0) {
-		const empty = ` ${colorHex("(empty)", CATHEDRAL_TOKENS.colors.foregroundDim)} `;
-		lines.push(`${colorHex("│", CATHEDRAL_TOKENS.colors.divider)}${padToWidth(empty, innerWidth - 2)}${colorHex("│", CATHEDRAL_TOKENS.colors.divider)}`);
+		const empty = ` ${colorHex("(empty)", activeThemeColors().foregroundDim)} `;
+		lines.push(`${colorHex("│", activeThemeColors().divider)}${padToWidth(empty, innerWidth - 2)}${colorHex("│", activeThemeColors().divider)}`);
 	} else {
 		for (const fact of group.facts) {
-			const bullet = colorHex("❧", CATHEDRAL_TOKENS.colors.accent);
+			const bullet = colorHex("❧", activeThemeColors().accent);
 			const text = colorHex(
 				fact.text.length > innerWidth - 6 ? `${fact.text.slice(0, innerWidth - 7)}…` : fact.text,
-				CATHEDRAL_TOKENS.colors.foreground,
+				activeThemeColors().foreground,
 			);
 			const content = ` ${bullet} ${text}`;
-			lines.push(`${colorHex("│", CATHEDRAL_TOKENS.colors.divider)}${padToWidth(content, innerWidth - 2)}${colorHex("│", CATHEDRAL_TOKENS.colors.divider)}`);
+			lines.push(`${colorHex("│", activeThemeColors().divider)}${padToWidth(content, innerWidth - 2)}${colorHex("│", activeThemeColors().divider)}`);
 		}
 	}
 
-	lines.push(colorHex(bottom, CATHEDRAL_TOKENS.colors.divider));
+	lines.push(colorHex(bottom, activeThemeColors().divider));
 	return lines;
 }
 
@@ -107,17 +107,17 @@ export function renderMemoryEditor(snapshot: MemoryEditorSnapshot, width: number
 
 	// Title
 	lines.push("");
-	lines.push(center(colorHex("SUMOCODE MEMORY", CATHEDRAL_TOKENS.colors.accent), width));
+	lines.push(center(colorHex("SUMOCODE MEMORY", activeThemeColors().accent), width));
 	lines.push(divider(width));
 	lines.push("");
 
 	// Search input row
-	const searchPrompt = colorHex("│ ", CATHEDRAL_TOKENS.colors.divider);
+	const searchPrompt = colorHex("│ ", activeThemeColors().divider);
 	const searchPlaceholder = snapshot.searchQuery === ""
-		? `${DIM}${colorHex("search…", CATHEDRAL_TOKENS.colors.foregroundDim)}${RESET}`
-		: colorHex(snapshot.searchQuery, CATHEDRAL_TOKENS.colors.foreground);
-	const factsCount = colorHex(`${snapshot.factsTotal} facts`, CATHEDRAL_TOKENS.colors.foregroundDim);
-	const searchClose = colorHex(" │", CATHEDRAL_TOKENS.colors.divider);
+		? `${DIM}${colorHex("search…", activeThemeColors().foregroundDim)}${RESET}`
+		: colorHex(snapshot.searchQuery, activeThemeColors().foreground);
+	const factsCount = colorHex(`${snapshot.factsTotal} facts`, activeThemeColors().foregroundDim);
+	const searchClose = colorHex(" │", activeThemeColors().divider);
 
 	const searchLineLeft = `   ${searchPrompt}${searchPlaceholder}`;
 	const searchLineRight = `${factsCount}${searchClose}`;
@@ -141,7 +141,7 @@ export function renderMemoryEditor(snapshot: MemoryEditorSnapshot, width: number
 	}
 
 	lines.push(divider(width));
-	lines.push(`   ${DIM}${colorHex(MEMORY_EDITOR_HINTS, CATHEDRAL_TOKENS.colors.foregroundDim)}${RESET}`);
+	lines.push(`   ${DIM}${colorHex(MEMORY_EDITOR_HINTS, activeThemeColors().foregroundDim)}${RESET}`);
 
 	return lines;
 }

--- a/src/splash.ts
+++ b/src/splash.ts
@@ -22,7 +22,7 @@ import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-age
 import { truncateToWidth } from "@mariozechner/pi-tui";
 import type { Component } from "@mariozechner/pi-tui";
 import { sessionHasMessages as cachedSessionHasMessages } from "./session-cache.js";
-import { CATHEDRAL_TOKENS } from "./tokens.js";
+import { activeThemeColors } from "./themes/index.js";
 
 const RESET = "\u001b[0m";
 const ANSI_PATTERN = /\u001b(?:\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001b\\))/g;
@@ -36,8 +36,14 @@ function fg(hex: string): string {
 	return `\u001b[38;2;${r};${g};${b}m`;
 }
 
-const ACCENT = fg(CATHEDRAL_TOKENS.colors.accent);
-const MUTED = fg(CATHEDRAL_TOKENS.colors.foregroundDim);
+function accentFg(): string {
+	return fg(activeThemeColors().accent);
+}
+
+function mutedFg(): string {
+	return fg(activeThemeColors().foregroundDim);
+}
+
 const DIM = "\u001b[2m";
 
 function visibleLength(text: string): number {
@@ -127,15 +133,15 @@ export function renderSplashContent(snapshot: SplashSnapshot, width: number): st
 
 	// SUMOCODE wordmark in burnt orange.
 	for (const row of SUMOCODE_WORDMARK) {
-		content.push(center(`${ACCENT}${row}${RESET}`, width));
+		content.push(center(`${accentFg()}${row}${RESET}`, width));
 	}
 
 	content.push("");
 	content.push("");
 
 	// V2 Visual Bible quote in dim muted brown.
-	content.push(center(`${DIM}${MUTED}${snapshot.quote}${RESET}`, width));
-	content.push(center(`${DIM}${MUTED}${snapshot.quoteAttribution}${RESET}`, width));
+	content.push(center(`${DIM}${mutedFg()}${snapshot.quote}${RESET}`, width));
+	content.push(center(`${DIM}${mutedFg()}${snapshot.quoteAttribution}${RESET}`, width));
 
 	return content;
 }

--- a/src/sumo-tui/cathedral/ansi.ts
+++ b/src/sumo-tui/cathedral/ansi.ts
@@ -1,5 +1,5 @@
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { activeThemeColors } from "../../themes/index.js";
 import { lineToAnsi, span, textLine } from "../render/primitives.js";
 
 export const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
@@ -59,8 +59,8 @@ export function padAnsiToWidth(line: string, width: number): string {
 /** Wrap a logical sidebar row in the cathedral mahogany surface background. */
 export function surfaceLine(content: string, width: number): string {
 	return lineToAnsi(textLine([span(content)], {
-		fg: CATHEDRAL_TOKENS.colors.foreground,
-		bg: CATHEDRAL_TOKENS.colors.surface,
+		fg: activeThemeColors().foreground,
+		bg: activeThemeColors().surface,
 	}), { width });
 }
 
@@ -74,7 +74,7 @@ export function renderSidebarSectionHeader(label: string, width: number, indent 
 	const prefixWidth = 2 + label.length + 1; // "┌ " + label + " "
 	const dashCount = Math.max(4, innerWidth - prefixWidth);
 	return padAnsiToWidth(
-		`${indent}${colorHex("┌", CATHEDRAL_TOKENS.colors.divider)} ${colorHex(label, CATHEDRAL_TOKENS.colors.accent)} ${colorHex("─".repeat(dashCount), CATHEDRAL_TOKENS.colors.divider)}`,
+		`${indent}${colorHex("┌", activeThemeColors().divider)} ${colorHex(label, activeThemeColors().accent)} ${colorHex("─".repeat(dashCount), activeThemeColors().divider)}`,
 		safeWidth,
 	);
 }

--- a/src/sumo-tui/cathedral/empty-chat-quote.ts
+++ b/src/sumo-tui/cathedral/empty-chat-quote.ts
@@ -1,4 +1,4 @@
-import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { activeThemeColors } from "../../themes/index.js";
 import { SumoNode } from "../layout/node.js";
 import { MEASURE_MODE_EXACTLY, type MeasureMode, type YogaNode } from "../layout/yoga.js";
 import type { CellBuffer, Rect } from "../render/buffer.js";
@@ -27,7 +27,7 @@ function centerPlain(text: string, width: number): string {
 }
 
 export function renderEmptyChatQuoteLines(width: number): string[] {
-	const quoteColor = CATHEDRAL_TOKENS.colors.foregroundDim;
+	const quoteColor = activeThemeColors().foregroundDim;
 	return [
 		padAnsiToWidth(italic(colorHex(centerPlain(EMPTY_CHAT_QUOTE_TEXT[0], width), quoteColor)), width),
 		padAnsiToWidth(italic(colorHex(centerPlain(EMPTY_CHAT_QUOTE_TEXT[1], width), quoteColor)), width),

--- a/src/sumo-tui/cathedral/metrics-hud.ts
+++ b/src/sumo-tui/cathedral/metrics-hud.ts
@@ -1,4 +1,4 @@
-import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { activeThemeColors } from "../../themes/index.js";
 import { colorHex, padAnsiToWidth, renderSidebarSectionHeader, SIDEBAR_INDENT } from "./ansi.js";
 
 export interface MetricsHudSnapshot {
@@ -46,22 +46,22 @@ export function renderSparkline(values: readonly number[], maxValue: number): st
 }
 
 export function cpuMetricColor(cpuPercent: number): string {
-	if (cpuPercent < 5) return CATHEDRAL_TOKENS.colors.foregroundDim;
-	if (cpuPercent <= 20) return CATHEDRAL_TOKENS.colors.states.thinking;
-	return CATHEDRAL_TOKENS.colors.states.approval;
+	if (cpuPercent < 5) return activeThemeColors().foregroundDim;
+	if (cpuPercent <= 20) return activeThemeColors().states.thinking;
+	return activeThemeColors().states.approval;
 }
 
 export function memoryMetricColor(memoryMiB: number): string {
-	if (memoryMiB < 200) return CATHEDRAL_TOKENS.colors.foregroundDim;
-	if (memoryMiB <= 300) return CATHEDRAL_TOKENS.colors.states.thinking;
-	return CATHEDRAL_TOKENS.colors.states.approval;
+	if (memoryMiB < 200) return activeThemeColors().foregroundDim;
+	if (memoryMiB <= 300) return activeThemeColors().states.thinking;
+	return activeThemeColors().states.approval;
 }
 
 export function fpsMetricColor(fps: number): string {
-	if (fps === 0) return CATHEDRAL_TOKENS.colors.foregroundDim;
-	if (fps <= 5) return CATHEDRAL_TOKENS.colors.states.idle;
-	if (fps <= 30) return CATHEDRAL_TOKENS.colors.states.thinking;
-	return CATHEDRAL_TOKENS.colors.states.approval;
+	if (fps === 0) return activeThemeColors().foregroundDim;
+	if (fps <= 5) return activeThemeColors().states.idle;
+	if (fps <= 30) return activeThemeColors().states.thinking;
+	return activeThemeColors().states.approval;
 }
 
 function formatCpu(cpuPercent: number): string {

--- a/src/sumo-tui/cathedral/sidebar-rendering.ts
+++ b/src/sumo-tui/cathedral/sidebar-rendering.ts
@@ -1,4 +1,4 @@
-import { CATHEDRAL_TOKENS, type SumoCodeState } from "../../tokens.js";
+import { activeThemeColors, type SumoCodeState } from "../../themes/index.js";
 import { formatTokenCount } from "../../footer.js";
 import { VOICE } from "../../voice.js";
 import { fgHex, padAnsiToWidth, SIDEBAR_INDENT, stripAnsi, visibleLength } from "./ansi.js";
@@ -83,7 +83,7 @@ function blank(width: number): string {
 
 function rule(width: number): string {
 	const count = Math.max(1, width - visibleLength(SIDEBAR_INDENT) - 2);
-	return padAnsiToWidth(indented(colorHex("━".repeat(count), CATHEDRAL_TOKENS.colors.divider)), width);
+	return padAnsiToWidth(indented(colorHex("━".repeat(count), activeThemeColors().divider)), width);
 }
 
 function row(content: string, width: number): string {
@@ -92,10 +92,10 @@ function row(content: string, width: number): string {
 
 export function tokenMeterColor(used: number, total: number): string {
 	const ratio = tokenUsageRatio(used, total);
-	if (ratio > 1) return CATHEDRAL_TOKENS.colors.states.approval;
-	if (ratio >= 0.8) return CATHEDRAL_TOKENS.colors.accent;
-	if (ratio >= 0.5) return CATHEDRAL_TOKENS.colors.states.thinking;
-	return CATHEDRAL_TOKENS.colors.states.idle;
+	if (ratio > 1) return activeThemeColors().states.approval;
+	if (ratio >= 0.8) return activeThemeColors().accent;
+	if (ratio >= 0.5) return activeThemeColors().states.thinking;
+	return activeThemeColors().states.idle;
 }
 
 /** Cathedral V2 editorial token gauge: `▉▉▉▉▉░░░...` on its own row. */
@@ -104,29 +104,29 @@ export function renderTokenMeter(used: number, total: number): string {
 	const filled = ratio > 1 ? TOKEN_BAR_CELLS : Math.round(clampRatio(ratio) * TOKEN_BAR_CELLS);
 	const empty = TOKEN_BAR_CELLS - filled;
 	const meterColor = tokenMeterColor(used, total);
-	return `${colorHex("▉".repeat(filled), meterColor)}${colorHex("░".repeat(empty), CATHEDRAL_TOKENS.colors.divider)}`;
+	return `${colorHex("▉".repeat(filled), meterColor)}${colorHex("░".repeat(empty), activeThemeColors().divider)}`;
 }
 
 function contextLines(snapshot: RegistrySidebarSnapshot, width: number): string[] {
 	const used = snapshot.currentContextTokens ?? (snapshot.inputTokens + snapshot.outputTokens);
 	const overBudget = snapshot.contextWindow > 0 && used > snapshot.contextWindow;
 	return [
-		row(colorHex(snapshot.projectName, CATHEDRAL_TOKENS.colors.foreground), width),
-		row(colorHex(`on ${snapshot.branch ?? "unknown"}`, CATHEDRAL_TOKENS.colors.foregroundDim), width),
+		row(colorHex(snapshot.projectName, activeThemeColors().foreground), width),
+		row(colorHex(`on ${snapshot.branch ?? "unknown"}`, activeThemeColors().foregroundDim), width),
 		blank(width),
-		row(colorHex(tracked("CONTEXT"), CATHEDRAL_TOKENS.colors.foregroundDim), width),
+		row(colorHex(tracked("CONTEXT"), activeThemeColors().foregroundDim), width),
 		row(renderTokenMeter(used, snapshot.contextWindow), width),
 		row(
-			`${colorHex(formatTokenCount(used), overBudget ? CATHEDRAL_TOKENS.colors.states.approval : CATHEDRAL_TOKENS.colors.foreground)} ` +
-				`${colorHex(`/ ${formatTokenCount(snapshot.contextWindow)}`, CATHEDRAL_TOKENS.colors.foregroundDim)}` +
-				(overBudget ? ` ${colorHex("OVER", CATHEDRAL_TOKENS.colors.states.approval)}` : ""),
+			`${colorHex(formatTokenCount(used), overBudget ? activeThemeColors().states.approval : activeThemeColors().foreground)} ` +
+				`${colorHex(`/ ${formatTokenCount(snapshot.contextWindow)}`, activeThemeColors().foregroundDim)}` +
+				(overBudget ? ` ${colorHex("OVER", activeThemeColors().states.approval)}` : ""),
 			width,
 		),
 		blank(width),
-		row(colorHex(tracked("SESSION"), CATHEDRAL_TOKENS.colors.foregroundDim), width),
+		row(colorHex(tracked("SESSION"), activeThemeColors().foregroundDim), width),
 		row(
-			`${colorHex(`$${snapshot.costUsd.toFixed(2)}`, CATHEDRAL_TOKENS.colors.foreground)} ` +
-				`${colorHex(`· ${formatTokenCount(snapshot.cumulativeTokens ?? used)} cumul`, CATHEDRAL_TOKENS.colors.foregroundDim)}`,
+			`${colorHex(`$${snapshot.costUsd.toFixed(2)}`, activeThemeColors().foreground)} ` +
+				`${colorHex(`· ${formatTokenCount(snapshot.cumulativeTokens ?? used)} cumul`, activeThemeColors().foregroundDim)}`,
 			width,
 		),
 	];
@@ -153,14 +153,14 @@ export function normalizeMcpStatus(status: McpServerStatusLike): McpServerStatus
 export function mcpStatusColor(status: McpServerStatusLike): string {
 	switch (normalizeMcpStatus(status)) {
 		case "ok":
-			return CATHEDRAL_TOKENS.colors.states.idle;
+			return activeThemeColors().states.idle;
 		case "idle":
-			return CATHEDRAL_TOKENS.colors.foregroundDim;
+			return activeThemeColors().foregroundDim;
 		case "in-flight":
-			return CATHEDRAL_TOKENS.colors.states.thinking;
+			return activeThemeColors().states.thinking;
 		case "error":
 		case "down":
-			return CATHEDRAL_TOKENS.colors.states.approval;
+			return activeThemeColors().states.approval;
 	}
 }
 
@@ -171,28 +171,28 @@ export function mcpStatusLabel(status: McpServerStatusLike): string {
 export function renderMcpServerRow(server: McpServerSnapshot, width: number): string {
 	const status = mcpStatusLabel(server.status);
 	const dot = colorHex("●", mcpStatusColor(server.status));
-	const statusText = colorHex(status, CATHEDRAL_TOKENS.colors.foregroundDim);
+	const statusText = colorHex(status, activeThemeColors().foregroundDim);
 	const reserve = visibleLength(SIDEBAR_INDENT) + 1 + 1 + status.length + 2;
 	const name = truncatePlainText(server.name, Math.max(1, width - reserve));
 	const gap = Math.max(1, width - visibleLength(SIDEBAR_INDENT) - 2 - visibleLength(name) - status.length - 2);
-	return padAnsiToWidth(indented(`${dot} ${colorHex(name, CATHEDRAL_TOKENS.colors.foreground)}${" ".repeat(gap)}${statusText}  `), width);
+	return padAnsiToWidth(indented(`${dot} ${colorHex(name, activeThemeColors().foreground)}${" ".repeat(gap)}${statusText}  `), width);
 }
 
 function mcpLines(snapshot: RegistrySidebarSnapshot, width: number): string[] {
-	const lines = [row(colorHex(tracked("MCP"), CATHEDRAL_TOKENS.colors.foregroundDim), width), blank(width)];
+	const lines = [row(colorHex(tracked("MCP"), activeThemeColors().foregroundDim), width), blank(width)];
 	for (const server of snapshot.mcpServers) lines.push(renderMcpServerRow(server, width));
 	return lines;
 }
 
 export function renderMemoryFactLine(item: string, width: number): string {
 	const available = Math.max(0, width - visibleLength(SIDEBAR_INDENT) - 2);
-	const bullet = colorHex("❧", CATHEDRAL_TOKENS.colors.accent);
-	const text = colorHex(truncatePlainText(item, available), CATHEDRAL_TOKENS.colors.foreground);
+	const bullet = colorHex("❧", activeThemeColors().accent);
+	const text = colorHex(truncatePlainText(item, available), activeThemeColors().foreground);
 	return padAnsiToWidth(indented(`${bullet} ${text}`), width);
 }
 
 function memoryLines(snapshot: RegistrySidebarSnapshot, width: number): string[] {
-	const lines = [row(colorHex(tracked("MEMORY"), CATHEDRAL_TOKENS.colors.foregroundDim), width), blank(width)];
+	const lines = [row(colorHex(tracked("MEMORY"), activeThemeColors().foregroundDim), width), blank(width)];
 	if (snapshot.memoryUnavailable) {
 		lines.push(row(dim(VOICE.errors.daemonDown), width));
 		return lines;
@@ -210,7 +210,7 @@ function memoryLines(snapshot: RegistrySidebarSnapshot, width: number): string[]
 	if (hidden > 0) {
 		lines.push(blank(width));
 		lines.push(rule(width));
-		lines.push(row(colorHex(`${hidden} more · ⌘M`, CATHEDRAL_TOKENS.colors.foregroundDim), width));
+		lines.push(row(colorHex(`${hidden} more · ⌘M`, activeThemeColors().foregroundDim), width));
 	}
 	return lines;
 }
@@ -219,14 +219,14 @@ export function renderRegistryHeaderLines(snapshot: RegistrySidebarSnapshot, wid
 	const active = snapshot.activeSubTab ?? "CONTEXT";
 	const lines: string[] = [
 		blank(width),
-		row(colorHex("REGISTRY", CATHEDRAL_TOKENS.colors.accent), width),
+		row(colorHex("REGISTRY", activeThemeColors().accent), width),
 		blank(width),
 	];
 
 	for (const tab of SIDEBAR_SUB_TABS) {
 		const isActive = tab === active;
-		const marker = colorHex(isActive ? "◆" : "▢", isActive ? CATHEDRAL_TOKENS.colors.accent : CATHEDRAL_TOKENS.colors.foregroundDim);
-		const label = colorHex(tracked(tab), isActive ? CATHEDRAL_TOKENS.colors.foreground : CATHEDRAL_TOKENS.colors.foregroundDim);
+		const marker = colorHex(isActive ? "◆" : "▢", isActive ? activeThemeColors().accent : activeThemeColors().foregroundDim);
+		const label = colorHex(tracked(tab), isActive ? activeThemeColors().foreground : activeThemeColors().foregroundDim);
 		lines.push(padAnsiToWidth(indented(`${marker} ${label}`), width));
 	}
 	lines.push(blank(width));

--- a/src/sumo-tui/cathedral/theme-bridge.ts
+++ b/src/sumo-tui/cathedral/theme-bridge.ts
@@ -1,24 +1,25 @@
 import { createAttrs, type Cell } from "../render/cell.js";
-import { CATHEDRAL_TOKENS, type SumoCodeState } from "../../tokens.js";
+import { activeThemeColors, setActiveTheme, type SumoCodeState, type ThemeColors } from "../../themes/index.js";
 
-export type CathedralColorToken = keyof typeof CATHEDRAL_TOKENS.colors;
+export type CathedralColorToken = keyof ThemeColors;
 export type ThemeChangedListener = (themeName: string) => void;
 
-let themeVersion = 0;
-const themeListeners = new Set<ThemeChangedListener>();
+let bridgeThemeVersion = 0;
+const bridgeThemeListeners = new Set<ThemeChangedListener>();
 
 export function getCathedralThemeVersion(): number {
-	return themeVersion;
+	return bridgeThemeVersion;
 }
 
 export function onCathedralThemeChanged(listener: ThemeChangedListener): () => void {
-	themeListeners.add(listener);
-	return () => themeListeners.delete(listener);
+	bridgeThemeListeners.add(listener);
+	return () => bridgeThemeListeners.delete(listener);
 }
 
 export function emitCathedralThemeChanged(themeName: string): void {
-	themeVersion += 1;
-	for (const listener of themeListeners) listener(themeName);
+	setActiveTheme(themeName);
+	bridgeThemeVersion += 1;
+	for (const listener of bridgeThemeListeners) listener(themeName);
 }
 
 export function cathedralCell(options: { char?: string; fg?: string; bg?: string; dim?: boolean } = {}): Cell {
@@ -31,17 +32,17 @@ export function cathedralCell(options: { char?: string; fg?: string; bg?: string
 }
 
 export function cathedralStateColor(state: SumoCodeState): string {
-	return CATHEDRAL_TOKENS.colors.states[state];
+	return activeThemeColors().states[state];
 }
 
 export function cathedralBackdropCell(): Cell {
-	return cathedralCell({ bg: CATHEDRAL_TOKENS.colors.surfaceRecess, dim: true });
+	return cathedralCell({ bg: activeThemeColors().surfaceRecess, dim: true });
 }
 
 export function cathedralSurfaceCell(): Cell {
-	return cathedralCell({ bg: CATHEDRAL_TOKENS.colors.surface });
+	return cathedralCell({ bg: activeThemeColors().surface });
 }
 
 export function cathedralRecessCell(): Cell {
-	return cathedralCell({ bg: CATHEDRAL_TOKENS.colors.surfaceRecess });
+	return cathedralCell({ bg: activeThemeColors().surfaceRecess });
 }

--- a/src/sumo-tui/demo/issue56-polish-demo.ts
+++ b/src/sumo-tui/demo/issue56-polish-demo.ts
@@ -2,7 +2,7 @@ import { EmptyChatQuoteNode } from "../cathedral/empty-chat-quote.js";
 import { createSidebarTree, type SidebarLayoutSnapshot } from "../cathedral/sidebar-tree.js";
 import { SumoNode } from "../layout/node.js";
 import { DIRECTION_LTR, FLEX_DIRECTION_COLUMN, loadYoga, type Yoga } from "../layout/yoga.js";
-import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { activeThemeColors } from "../../themes/index.js";
 import { colorHex } from "../cathedral/ansi.js";
 import { bufferToAnsiLines } from "../render/ansi-writer.js";
 import { CellBuffer, type Rect } from "../render/buffer.js";
@@ -105,27 +105,27 @@ async function createTree(yoga: Yoga, scenario: string): Promise<ReturnType<type
 
 	if (scenario === "sidebar") {
 		const text = new DemoTextNode(yoga.Node.create(), [
-			`${colorHex("SYSTEM >", CATHEDRAL_TOKENS.colors.foregroundDim)} ${colorHex("Sidebar fixture: all UX_SPEC §4.2 panels are populated for visual verification.", CATHEDRAL_TOKENS.colors.foreground)}`,
+			`${colorHex("SYSTEM >", activeThemeColors().foregroundDim)} ${colorHex("Sidebar fixture: all UX_SPEC §4.2 panels are populated for visual verification.", activeThemeColors().foreground)}`,
 		], tree.root);
 		placeChatOverlay(text);
 		return tree;
 	}
 
 	const text = new DemoTextNode(yoga.Node.create(), [
-		`${colorHex("USER >", CATHEDRAL_TOKENS.colors.accent)} ${colorHex("Can you polish the cathedral chat and sidebar without expanding v1 scope?", CATHEDRAL_TOKENS.colors.foreground)}`,
-		`${colorHex("SUMO >", CATHEDRAL_TOKENS.colors.states.idle)} ${colorHex("Yes — keeping DECISIONS locked. Code block theme audit sample:", CATHEDRAL_TOKENS.colors.foreground)}`,
-		colorHex("       ```ts", CATHEDRAL_TOKENS.colors.foregroundDim),
-		`${colorHex("       function", CATHEDRAL_TOKENS.colors.accent)} ${colorHex("initializeCathedralEngine", CATHEDRAL_TOKENS.colors.states.thinking)}${colorHex("(config) {", CATHEDRAL_TOKENS.colors.foreground)}`,
-		`${colorHex("         const", CATHEDRAL_TOKENS.colors.accent)} ${colorHex("status", CATHEDRAL_TOKENS.colors.foreground)} ${colorHex("=", CATHEDRAL_TOKENS.colors.foreground)} ${colorHex("\"yellow_protocol_active\"", CATHEDRAL_TOKENS.colors.states.idle)}${colorHex(";", CATHEDRAL_TOKENS.colors.foreground)}`,
-		`${colorHex("         return", CATHEDRAL_TOKENS.colors.accent)} ${colorHex("status", CATHEDRAL_TOKENS.colors.foreground)}${colorHex(";", CATHEDRAL_TOKENS.colors.foreground)}`,
-		colorHex("       }", CATHEDRAL_TOKENS.colors.foreground),
-		colorHex("       ```", CATHEDRAL_TOKENS.colors.foregroundDim),
-		`${colorHex("USER >", CATHEDRAL_TOKENS.colors.accent)} ${colorHex("Show the htop HUD and memory bullets too.", CATHEDRAL_TOKENS.colors.foreground)}`,
-		`${colorHex("TOOL >", CATHEDRAL_TOKENS.colors.states.tool)} ${colorHex("$ pnpm test", CATHEDRAL_TOKENS.colors.foreground)}`,
-		colorHex("       ✓ src/sidebar-token-bar.test.ts", CATHEDRAL_TOKENS.colors.states.idle),
-		colorHex("       ✓ src/sidebar-mcp-pills.test.ts", CATHEDRAL_TOKENS.colors.states.idle),
-		colorHex("       ✓ src/empty-chat-quote.test.ts", CATHEDRAL_TOKENS.colors.states.idle),
-		`${colorHex("SUMO >", CATHEDRAL_TOKENS.colors.states.idle)} ${colorHex("Done. ACTIVE_CONTEXT, MCP, ACTIVE_MEMORY, and METRICS now share the §4.2 carved header style.", CATHEDRAL_TOKENS.colors.foreground)}`,
+		`${colorHex("USER >", activeThemeColors().accent)} ${colorHex("Can you polish the cathedral chat and sidebar without expanding v1 scope?", activeThemeColors().foreground)}`,
+		`${colorHex("SUMO >", activeThemeColors().states.idle)} ${colorHex("Yes — keeping DECISIONS locked. Code block theme audit sample:", activeThemeColors().foreground)}`,
+		colorHex("       ```ts", activeThemeColors().foregroundDim),
+		`${colorHex("       function", activeThemeColors().accent)} ${colorHex("initializeCathedralEngine", activeThemeColors().states.thinking)}${colorHex("(config) {", activeThemeColors().foreground)}`,
+		`${colorHex("         const", activeThemeColors().accent)} ${colorHex("status", activeThemeColors().foreground)} ${colorHex("=", activeThemeColors().foreground)} ${colorHex("\"yellow_protocol_active\"", activeThemeColors().states.idle)}${colorHex(";", activeThemeColors().foreground)}`,
+		`${colorHex("         return", activeThemeColors().accent)} ${colorHex("status", activeThemeColors().foreground)}${colorHex(";", activeThemeColors().foreground)}`,
+		colorHex("       }", activeThemeColors().foreground),
+		colorHex("       ```", activeThemeColors().foregroundDim),
+		`${colorHex("USER >", activeThemeColors().accent)} ${colorHex("Show the htop HUD and memory bullets too.", activeThemeColors().foreground)}`,
+		`${colorHex("TOOL >", activeThemeColors().states.tool)} ${colorHex("$ pnpm test", activeThemeColors().foreground)}`,
+		colorHex("       ✓ src/sidebar-token-bar.test.ts", activeThemeColors().states.idle),
+		colorHex("       ✓ src/sidebar-mcp-pills.test.ts", activeThemeColors().states.idle),
+		colorHex("       ✓ src/empty-chat-quote.test.ts", activeThemeColors().states.idle),
+		`${colorHex("SUMO >", activeThemeColors().states.idle)} ${colorHex("Done. ACTIVE_CONTEXT, MCP, ACTIVE_MEMORY, and METRICS now share the §4.2 carved header style.", activeThemeColors().foreground)}`,
 	], tree.root);
 	placeChatOverlay(text);
 	return tree;

--- a/src/sumo-tui/pi-compat/owned-shell-renderer.ts
+++ b/src/sumo-tui/pi-compat/owned-shell-renderer.ts
@@ -35,7 +35,7 @@ import {
 	JUSTIFY_CENTER,
 	type Yoga,
 } from "../layout/yoga.js";
-import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { activeThemeColors } from "../../themes/index.js";
 import { withPersistentStyle } from "../render/primitives.js";
 import { CellBuffer, type Rect } from "../render/buffer.js";
 import { composite, dispatchMouseEvent, type CompositeSelectionPass, type HardwareCursor } from "../render/compositor.js";
@@ -499,7 +499,7 @@ export class OwnedShellRenderer {
 			const top = chatBottom - height;
 			if (top < 0) return;
 
-			const T = CATHEDRAL_TOKENS.colors;
+			const T = activeThemeColors();
 			for (let i = 0; i < height; i += 1) {
 				const plain = (contentLines[i] ?? "").replace(/\x1b\[[0-9;]*m/g, "");
 				const padded = plain.length < chatWidth ? `${plain}${" ".repeat(chatWidth - plain.length)}` : plain.slice(0, chatWidth);

--- a/src/sumo-tui/render/compositor.ts
+++ b/src/sumo-tui/render/compositor.ts
@@ -1,4 +1,4 @@
-import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { activeThemeColors } from "../../themes/index.js";
 import { POSITION_TYPE_ABSOLUTE } from "../layout/yoga.js";
 import type { SumoNode, SumoNodeEventHandlerResult } from "../layout/node.js";
 import type { MouseEvent } from "../input/mouse.js";
@@ -83,8 +83,8 @@ function orderedChildren(node: SumoNode): PositionedChild[] {
  * while the retained frame shape follows the OpenTUI host-frame model.
  */
 export function composite(root: SumoNode, buffer: CellBuffer, options: CompositeOptions = {}): CompositeResult {
-	buffer.setDefaultBackground(CATHEDRAL_TOKENS.colors.background);
-	buffer.setDefaultForeground(CATHEDRAL_TOKENS.colors.foreground);
+	buffer.setDefaultBackground(activeThemeColors().background);
+	buffer.setDefaultForeground(activeThemeColors().foreground);
 	buffer.clear();
 
 	let hardwareCursor: HardwareCursor | null = null;

--- a/src/sumo-tui/transcript/code-renderer.ts
+++ b/src/sumo-tui/transcript/code-renderer.ts
@@ -10,7 +10,7 @@
  *   docs/ui/bible/10-code-bash.html
  */
 import { visibleWidth } from "@mariozechner/pi-tui";
-import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { activeThemeColors } from "../../themes/index.js";
 import { lineToAnsi, span, textLine, withPersistentStyle, type Span } from "../render/primitives.js";
 
 const MAX_VISIBLE_LINES = 20;
@@ -44,11 +44,11 @@ function isFunctionCall(rest: string): boolean {
  */
 function highlightLine(line: string, lang: string): SyntaxSpan[] {
 	const spans: SyntaxSpan[] = [];
-	const fg = CATHEDRAL_TOKENS.colors.foreground;
-	const kw = CATHEDRAL_TOKENS.colors.accent;
-	const str = CATHEDRAL_TOKENS.colors.states.idle;
-	const num = CATHEDRAL_TOKENS.colors.states.thinking;
-	const fn = CATHEDRAL_TOKENS.colors.states.thinking;
+	const fg = activeThemeColors().foreground;
+	const kw = activeThemeColors().accent;
+	const str = activeThemeColors().states.idle;
+	const num = activeThemeColors().states.thinking;
+	const fn = activeThemeColors().states.thinking;
 	const comment = "#6F5D46";
 
 	let i = 0;
@@ -147,29 +147,29 @@ function takeVisible(input: string, maxWidth: number): string {
 
 function codeFrameTop(lang: string, width: number): string {
 	const labelParts: (Span | string)[] = lang.length > 0
-		? [span("── ", { fg: CATHEDRAL_TOKENS.colors.divider }), span(lang, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }), span(" ─", { fg: CATHEDRAL_TOKENS.colors.divider })]
-		: [span("──", { fg: CATHEDRAL_TOKENS.colors.divider })];
+		? [span("── ", { fg: activeThemeColors().divider }), span(lang, { fg: activeThemeColors().foregroundDim }), span(" ─", { fg: activeThemeColors().divider })]
+		: [span("──", { fg: activeThemeColors().divider })];
 	const labelWidth = lang.length > 0 ? 5 + lang.length : 2;
 	const ruleLen = Math.max(0, width - 3 - labelWidth);
 	return lineToAnsi(textLine([
-		span("╭─", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("╭─", { fg: activeThemeColors().divider }),
 		...labelParts,
-		span("─".repeat(ruleLen), { fg: CATHEDRAL_TOKENS.colors.divider }),
-		span("╮", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("─".repeat(ruleLen), { fg: activeThemeColors().divider }),
+		span("╮", { fg: activeThemeColors().divider }),
 	]), { width });
 }
 
 function codeFrameBottom(width: number): string {
 	return lineToAnsi(textLine([
-		span("╰", { fg: CATHEDRAL_TOKENS.colors.divider }),
-		span("─".repeat(Math.max(0, width - 2)), { fg: CATHEDRAL_TOKENS.colors.divider }),
-		span("╯", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("╰", { fg: activeThemeColors().divider }),
+		span("─".repeat(Math.max(0, width - 2)), { fg: activeThemeColors().divider }),
+		span("╯", { fg: activeThemeColors().divider }),
 	]), { width });
 }
 
 function codeBodyRow(lineNumber: number, syntaxSpans: SyntaxSpan[], width: number): string {
 	const gutter = `${String(lineNumber).padStart(3)} `;
-	const gutterSpan = span(gutter, { fg: CATHEDRAL_TOKENS.colors.foregroundDim });
+	const gutterSpan = span(gutter, { fg: activeThemeColors().foregroundDim });
 	const bodySpans: Span[] = syntaxSpans.map((s) => span(s.text, { fg: s.color }));
 	const innerWidth = Math.max(0, width - 4); // 2 for │+space, 1 for space+│
 	const contentWidth = GUTTER_WIDTH + syntaxSpans.reduce((w, s) => w + visibleWidth(s.text), 0);
@@ -177,14 +177,14 @@ function codeBodyRow(lineNumber: number, syntaxSpans: SyntaxSpan[], width: numbe
 
 	const inner = withPersistentStyle(
 		lineToAnsi(textLine([span(" "), gutterSpan, ...bodySpans, span(" ".repeat(pad + 1))]), { width: innerWidth + 2 }),
-		CATHEDRAL_TOKENS.colors.foreground,
-		CATHEDRAL_TOKENS.colors.surfaceRecess,
+		activeThemeColors().foreground,
+		activeThemeColors().surfaceRecess,
 	);
 
 	return lineToAnsi(textLine([
-		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("│", { fg: activeThemeColors().divider }),
 		span(inner),
-		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("│", { fg: activeThemeColors().divider }),
 	]), { width });
 }
 
@@ -193,14 +193,14 @@ function collapsedRow(remaining: number, width: number): string {
 	const innerWidth = Math.max(0, width - 4);
 	const pad = Math.max(0, innerWidth - GUTTER_WIDTH - visibleWidth(text));
 	const inner = withPersistentStyle(
-		lineToAnsi(textLine([span(" "), span(" ".repeat(GUTTER_WIDTH), { fg: CATHEDRAL_TOKENS.colors.foregroundDim }), span(text, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }), span(" ".repeat(pad + 1))]), { width: innerWidth + 2 }),
-		CATHEDRAL_TOKENS.colors.foreground,
-		CATHEDRAL_TOKENS.colors.surfaceRecess,
+		lineToAnsi(textLine([span(" "), span(" ".repeat(GUTTER_WIDTH), { fg: activeThemeColors().foregroundDim }), span(text, { fg: activeThemeColors().foregroundDim }), span(" ".repeat(pad + 1))]), { width: innerWidth + 2 }),
+		activeThemeColors().foreground,
+		activeThemeColors().surfaceRecess,
 	);
 	return lineToAnsi(textLine([
-		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("│", { fg: activeThemeColors().divider }),
 		span(inner),
-		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("│", { fg: activeThemeColors().divider }),
 	]), { width });
 }
 

--- a/src/sumo-tui/transcript/scroll-renderer.ts
+++ b/src/sumo-tui/transcript/scroll-renderer.ts
@@ -9,7 +9,7 @@
  *   docs/ui/bible/12-scroll-done.html
  */
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { activeThemeColors } from "../../themes/index.js";
 import { lineToAnsi, span, textLine, type Span } from "../render/primitives.js";
 import type { DelegationStatus, DelegationViewModel, ToolCallViewModel } from "./view-model.js";
 
@@ -21,13 +21,6 @@ const STATUS_GLYPH: Record<DelegationStatus, string> = {
 	cancelled: "✗",
 };
 
-const STATUS_COLOR: Record<DelegationStatus, string> = {
-	queued: CATHEDRAL_TOKENS.colors.foregroundDim,
-	running: CATHEDRAL_TOKENS.colors.states.tool,
-	success: CATHEDRAL_TOKENS.colors.states.idle,
-	error: CATHEDRAL_TOKENS.colors.states.approval,
-	cancelled: CATHEDRAL_TOKENS.colors.foregroundDim,
-};
 
 const STATUS_LABEL: Record<DelegationStatus, string> = {
 	queued: "queued",
@@ -41,15 +34,32 @@ const TOOL_STATUS_GLYPH: Record<string, string> = {
 	pending: "○", running: "▶", success: "✓", error: "✗", cancelled: "✗",
 };
 
-const TOOL_STATUS_COLOR: Record<string, string> = {
-	pending: CATHEDRAL_TOKENS.colors.foregroundDim,
-	running: CATHEDRAL_TOKENS.colors.states.tool,
-	success: CATHEDRAL_TOKENS.colors.states.idle,
-	error: CATHEDRAL_TOKENS.colors.states.approval,
-	cancelled: CATHEDRAL_TOKENS.colors.foregroundDim,
-};
 
 const SCRIBE_BODY_MAX_LINES = 25;
+
+function delegationStatusColor(status: DelegationStatus): string {
+	const colors = activeThemeColors();
+	const statusColor: Record<DelegationStatus, string> = {
+		queued: colors.foregroundDim,
+		running: colors.states.tool,
+		success: colors.states.idle,
+		error: colors.states.approval,
+		cancelled: colors.foregroundDim,
+	};
+	return statusColor[status];
+}
+
+function toolStatusColor(status: string): string {
+	const colors = activeThemeColors();
+	const statusColor: Record<string, string> = {
+		pending: colors.foregroundDim,
+		running: colors.states.tool,
+		success: colors.states.idle,
+		error: colors.states.approval,
+		cancelled: colors.foregroundDim,
+	};
+	return statusColor[status] ?? colors.foregroundDim;
+}
 
 function singleLinePreview(text: string): string {
 	return text.replace(/[\r\n]+/g, " ").replace(/\s+/g, " ").trim();
@@ -90,18 +100,18 @@ function formatElapsed(ms?: number): string | undefined {
 
 function scrollHeader(delegation: DelegationViewModel, width: number): string {
 	const statusGlyph = STATUS_GLYPH[delegation.status];
-	const statusColor = STATUS_COLOR[delegation.status];
+	const statusColor = delegationStatusColor(delegation.status);
 	const statusLabel = STATUS_LABEL[delegation.status];
 
 	const left: Span[] = [
-		span("━━━ ", { fg: CATHEDRAL_TOKENS.colors.divider }),
-		span("[scroll]", { fg: CATHEDRAL_TOKENS.colors.accent }),
-		span(`  ${delegation.title} `, { fg: CATHEDRAL_TOKENS.colors.foreground }),
+		span("━━━ ", { fg: activeThemeColors().divider }),
+		span("[scroll]", { fg: activeThemeColors().accent }),
+		span(`  ${delegation.title} `, { fg: activeThemeColors().foreground }),
 	];
 	const right: Span[] = [
-		span(" ━━━ ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span(" ━━━ ", { fg: activeThemeColors().divider }),
 		span(statusGlyph, { fg: statusColor }),
-		span(` ${statusLabel}`, { fg: CATHEDRAL_TOKENS.colors.foreground }),
+		span(` ${statusLabel}`, { fg: activeThemeColors().foreground }),
 	];
 
 	const leftWidth = left.reduce((w, s) => w + visibleWidth(s.text), 0);
@@ -110,7 +120,7 @@ function scrollHeader(delegation: DelegationViewModel, width: number): string {
 
 	return lineToAnsi(textLine([
 		...left,
-		span("━".repeat(ruleLen), { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("━".repeat(ruleLen), { fg: activeThemeColors().divider }),
 		...right,
 	]), { width });
 }
@@ -120,9 +130,9 @@ function scrollPromptRow(text: string, width: number): string {
 	const clipped = visibleWidth(text) > contentWidth ? truncateToWidth(text, contentWidth, "") : text;
 	return lineToAnsi(textLine([
 		span("   "),
-		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("│", { fg: activeThemeColors().divider }),
 		span(" "),
-		span(clipped, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+		span(clipped, { fg: activeThemeColors().foregroundDim }),
 	]), { width });
 }
 
@@ -138,19 +148,19 @@ function scrollPromptRows(prompt: string | undefined, width: number): string[] {
 	const label = "task";
 	const left: Span[] = [
 		span("   "),
-		span("┌ ", { fg: CATHEDRAL_TOKENS.colors.divider }),
-		span(label, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
-		span(" ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("┌ ", { fg: activeThemeColors().divider }),
+		span(label, { fg: activeThemeColors().foregroundDim }),
+		span(" ", { fg: activeThemeColors().divider }),
 	];
 	const leftWidth = left.reduce((w, s) => w + visibleWidth(s.text), 0);
 	const ruleLen = Math.max(0, width - leftWidth - 2);
 	return [
-		lineToAnsi(textLine([...left, span("─".repeat(ruleLen), { fg: CATHEDRAL_TOKENS.colors.divider }), span("  ")]), { width }),
+		lineToAnsi(textLine([...left, span("─".repeat(ruleLen), { fg: activeThemeColors().divider }), span("  ")]), { width }),
 		...lines.map((line) => scrollPromptRow(line, width)),
 		lineToAnsi(textLine([
 			span("   "),
-			span("└", { fg: CATHEDRAL_TOKENS.colors.divider }),
-			span("─".repeat(Math.max(0, width - 6)), { fg: CATHEDRAL_TOKENS.colors.divider }),
+			span("└", { fg: activeThemeColors().divider }),
+			span("─".repeat(Math.max(0, width - 6)), { fg: activeThemeColors().divider }),
 			span("  "),
 		]), { width }),
 	];
@@ -165,9 +175,9 @@ function scribeHeader(delegation: DelegationViewModel, width: number): string {
 
 	const left: Span[] = [
 		span("   "),
-		span("┌ ", { fg: CATHEDRAL_TOKENS.colors.divider }),
-		span(meta, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
-		span(" ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("┌ ", { fg: activeThemeColors().divider }),
+		span(meta, { fg: activeThemeColors().foregroundDim }),
+		span(" ", { fg: activeThemeColors().divider }),
 	];
 	const leftWidth = left.reduce((w, s) => w + visibleWidth(s.text), 0);
 	// Match bottom border alignment: indent(3) + └(1) + dashes + trailing(2)
@@ -178,14 +188,14 @@ function scribeHeader(delegation: DelegationViewModel, width: number): string {
 
 	return lineToAnsi(textLine([
 		...left,
-		span("─".repeat(ruleLen), { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("─".repeat(ruleLen), { fg: activeThemeColors().divider }),
 		span(" ".repeat(trailing)),
 	]), { width });
 }
 
 function nestedToolRow(tool: ToolCallViewModel, width: number): string {
 	const glyph = TOOL_STATUS_GLYPH[tool.status] ?? "○";
-	const color = TOOL_STATUS_COLOR[tool.status] ?? CATHEDRAL_TOKENS.colors.foregroundDim;
+	const color = toolStatusColor(tool.status);
 	const target = toolTarget(tool);
 	const prefixWidth = visibleWidth(`   │ ${glyph} [${tool.name}]  `);
 	const contentWidth = Math.max(1, width - prefixWidth);
@@ -193,20 +203,20 @@ function nestedToolRow(tool: ToolCallViewModel, width: number): string {
 
 	return lineToAnsi(textLine([
 		span("   "),
-		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("│", { fg: activeThemeColors().divider }),
 		span(" "),
 		span(glyph, { fg: color }),
 		span(" "),
-		span(`[${tool.name}]`, { fg: CATHEDRAL_TOKENS.colors.accent }),
+		span(`[${tool.name}]`, { fg: activeThemeColors().accent }),
 		span("  "),
-		span(clipped, { fg: CATHEDRAL_TOKENS.colors.foreground }),
+		span(clipped, { fg: activeThemeColors().foreground }),
 	]), { width });
 }
 
 function scribeBlankRow(width: number): string {
 	return lineToAnsi(textLine([
 		span("   "),
-		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("│", { fg: activeThemeColors().divider }),
 	]), { width });
 }
 
@@ -215,17 +225,17 @@ function scribeTextRow(text: string, width: number): string {
 	const clipped = visibleWidth(text) > contentWidth ? truncateToWidth(text, contentWidth, "") : text;
 	return lineToAnsi(textLine([
 		span("   "),
-		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("│", { fg: activeThemeColors().divider }),
 		span(" "),
-		span(clipped, { fg: CATHEDRAL_TOKENS.colors.foreground }),
+		span(clipped, { fg: activeThemeColors().foreground }),
 	]), { width });
 }
 
 function scribeCollapsedRow(remaining: number, width: number): string {
 	return lineToAnsi(textLine([
 		span("   "),
-		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
-		span(` … ${remaining} lines collapsed`, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+		span("│", { fg: activeThemeColors().divider }),
+		span(` … ${remaining} lines collapsed`, { fg: activeThemeColors().foregroundDim }),
 	]), { width });
 }
 
@@ -252,8 +262,8 @@ function scribeMetadataRow(delegation: DelegationViewModel, width: number): stri
 
 	return lineToAnsi(textLine([
 		span("   "),
-		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
-		span(` ${text}`, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+		span("│", { fg: activeThemeColors().divider }),
+		span(` ${text}`, { fg: activeThemeColors().foregroundDim }),
 	]), { width });
 }
 
@@ -261,8 +271,8 @@ function scribeBottom(width: number): string {
 	const ruleLen = Math.max(0, width - 6); // 3(indent) + 1(└) + dashes + 2(trailing)
 	return lineToAnsi(textLine([
 		span("   "),
-		span("└", { fg: CATHEDRAL_TOKENS.colors.divider }),
-		span("─".repeat(ruleLen), { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("└", { fg: activeThemeColors().divider }),
+		span("─".repeat(ruleLen), { fg: activeThemeColors().divider }),
 		span("  "),
 	]), { width });
 }

--- a/src/sumo-tui/transcript/tool-renderer.ts
+++ b/src/sumo-tui/transcript/tool-renderer.ts
@@ -1,5 +1,5 @@
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
-import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { activeThemeColors } from "../../themes/index.js";
 import { lineToAnsi, span, textLine, type Span } from "../render/primitives.js";
 import type { ToolCallViewModel, ToolStatus } from "./view-model.js";
 
@@ -11,13 +11,6 @@ const STATUS_GLYPH: Record<ToolStatus, string> = {
 	cancelled: "✗",
 };
 
-const STATUS_COLOR: Record<ToolStatus, string> = {
-	pending: CATHEDRAL_TOKENS.colors.foregroundDim,
-	running: CATHEDRAL_TOKENS.colors.states.tool,
-	success: CATHEDRAL_TOKENS.colors.states.idle,
-	error: CATHEDRAL_TOKENS.colors.states.approval,
-	cancelled: CATHEDRAL_TOKENS.colors.foregroundDim,
-};
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
 	return typeof value === "object" && value !== null ? (value as Record<string, unknown>) : undefined;
@@ -46,7 +39,15 @@ export function toolStatusGlyph(status: ToolStatus): string {
 }
 
 export function toolStatusColor(status: ToolStatus): string {
-	return STATUS_COLOR[status] ?? CATHEDRAL_TOKENS.colors.foregroundDim;
+	const colors = activeThemeColors();
+	const statusColor: Record<ToolStatus, string> = {
+		pending: colors.foregroundDim,
+		running: colors.states.tool,
+		success: colors.states.idle,
+		error: colors.states.approval,
+		cancelled: colors.foregroundDim,
+	};
+	return statusColor[status] ?? colors.foregroundDim;
 }
 
 export function toolTarget(tool: ToolCallViewModel): string {
@@ -86,9 +87,9 @@ function styledToolHeaderParts(tool: ToolCallViewModel): Span[] {
 	return [
 		span(toolStatusGlyph(tool.status), { fg: toolStatusColor(tool.status) }),
 		span(" "),
-		span(`[${tool.name}]`, { fg: CATHEDRAL_TOKENS.colors.accent }),
+		span(`[${tool.name}]`, { fg: activeThemeColors().accent }),
 		span("  "),
-		span(toolTarget(tool), { fg: CATHEDRAL_TOKENS.colors.foreground }),
+		span(toolTarget(tool), { fg: activeThemeColors().foreground }),
 	];
 }
 
@@ -103,9 +104,9 @@ export function renderCompactToolPill(tool: ToolCallViewModel): string {
 	const note = toolNote(tool);
 	return lineToAnsi(textLine([
 		...styledToolHeaderParts(tool),
-		...(note ? [span("  · ", { fg: CATHEDRAL_TOKENS.colors.foregroundDim }), span(note, { fg: CATHEDRAL_TOKENS.colors.foregroundDim })] : []),
-		span("  · ", { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
-		span(compactHint(tool), { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+		...(note ? [span("  · ", { fg: activeThemeColors().foregroundDim }), span(note, { fg: activeThemeColors().foregroundDim })] : []),
+		span("  · ", { fg: activeThemeColors().foregroundDim }),
+		span(compactHint(tool), { fg: activeThemeColors().foregroundDim }),
 	]));
 }
 
@@ -124,14 +125,16 @@ function headerNote(tool: ToolCallViewModel): string | undefined {
 /** Maximum body lines shown in an expanded tool ledger row before collapsing. */
 const TOOL_BODY_MAX_LINES = 25;
 
-const TOOL_LEDGER_STYLE = { bg: CATHEDRAL_TOKENS.colors.surfaceRecess } as const;
+function toolLedgerStyle(): { bg: string } {
+	return { bg: activeThemeColors().surfaceRecess };
+}
 
 function renderHeader(tool: ToolCallViewModel, width: number): string {
 	const note = headerNote(tool);
 	const right: Span[] = [
 		span(" "),
 		span(toolStatusGlyph(tool.status), { fg: toolStatusColor(tool.status) }),
-		...(note ? [span(" "), span(note, { fg: CATHEDRAL_TOKENS.colors.foregroundDim })] : []),
+		...(note ? [span(" "), span(note, { fg: activeThemeColors().foregroundDim })] : []),
 		span(" "),
 	];
 	const input = asRecord(tool.input);
@@ -144,29 +147,29 @@ function renderHeader(tool: ToolCallViewModel, width: number): string {
 		? (maxPathWidth > 3 ? `…${rawFilePath.slice(-(maxPathWidth - 1))}` : undefined)
 		: rawFilePath;
 	const left: Span[] = [
-		span("╭─ ", { fg: CATHEDRAL_TOKENS.colors.divider }),
-		span(`[${tool.name}]`, { fg: CATHEDRAL_TOKENS.colors.accent }),
-		...(filePath ? [span("  "), span(filePath, { fg: CATHEDRAL_TOKENS.colors.foreground })] : []),
+		span("╭─ ", { fg: activeThemeColors().divider }),
+		span(`[${tool.name}]`, { fg: activeThemeColors().accent }),
+		...(filePath ? [span("  "), span(filePath, { fg: activeThemeColors().foreground })] : []),
 		span(" "),
 	];
 	const used = [...left, ...right].reduce((sum, part) => sum + visibleWidth(part.text), 0);
 	const rule = Math.max(1, width - used);
-	return lineToAnsi(textLine([...left, span("─".repeat(rule), { fg: CATHEDRAL_TOKENS.colors.divider }), ...right]), { width, style: TOOL_LEDGER_STYLE });
+	return lineToAnsi(textLine([...left, span("─".repeat(rule), { fg: activeThemeColors().divider }), ...right]), { width, style: toolLedgerStyle() });
 }
 
 function renderBodyLine(parts: readonly (Span | string)[], width: number): string {
 	return lineToAnsi(textLine([
-		span("│", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("│", { fg: activeThemeColors().divider }),
 		span(" "),
-		...parts.map((part) => typeof part === "string" ? span(part, { fg: CATHEDRAL_TOKENS.colors.foreground }) : part),
-	]), { width, style: TOOL_LEDGER_STYLE });
+		...parts.map((part) => typeof part === "string" ? span(part, { fg: activeThemeColors().foreground }) : part),
+	]), { width, style: toolLedgerStyle() });
 }
 
 function renderBottom(width: number): string {
 	return lineToAnsi(textLine([
-		span("╰", { fg: CATHEDRAL_TOKENS.colors.divider }),
-		span("─".repeat(Math.max(0, width - 1)), { fg: CATHEDRAL_TOKENS.colors.divider }),
-	]), { width, style: TOOL_LEDGER_STYLE });
+		span("╰", { fg: activeThemeColors().divider }),
+		span("─".repeat(Math.max(0, width - 1)), { fg: activeThemeColors().divider }),
+	]), { width, style: toolLedgerStyle() });
 }
 
 function outputLines(tool: ToolCallViewModel): string[] {
@@ -185,10 +188,10 @@ function collapsedMarker(details: Record<string, unknown> | undefined, fallback 
 	return count > 0 ? `… ${count} lines collapsed` : undefined;
 }
 
-function renderGutterLine(lineNumber: number | undefined, text: string, width: number, style: string = CATHEDRAL_TOKENS.colors.foreground): string {
+function renderGutterLine(lineNumber: number | undefined, text: string, width: number, style: string = activeThemeColors().foreground): string {
 	const gutter = lineNumber === undefined ? "      " : `${String(lineNumber).padStart(4)}  `;
 	return renderBodyLine([
-		span(gutter, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+		span(gutter, { fg: activeThemeColors().foregroundDim }),
 		span(text, { fg: style }),
 	], width);
 }
@@ -199,8 +202,8 @@ function renderReadLikeBody(tool: ToolCallViewModel, width: number): string[] {
 	const startLine = typeof details?.startLine === "number" ? details.startLine : 1;
 	const rows = excerpt.slice(0, TOOL_BODY_MAX_LINES).map((line, index) => renderGutterLine(startLine + index, line, width));
 	const collapsed = collapsedMarker(details, typeof details?.totalLines === "number" ? Math.max(0, details.totalLines - excerpt.length) : 0);
-	if (collapsed) rows.push(renderBodyLine([span("      ", { fg: CATHEDRAL_TOKENS.colors.foregroundDim }), span(collapsed, { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width));
-	if (rows.length === 0) rows.push(renderBodyLine([span("preview collapsed", { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width));
+	if (collapsed) rows.push(renderBodyLine([span("      ", { fg: activeThemeColors().foregroundDim }), span(collapsed, { fg: activeThemeColors().foregroundDim })], width));
+	if (rows.length === 0) rows.push(renderBodyLine([span("preview collapsed", { fg: activeThemeColors().foregroundDim })], width));
 	return rows;
 }
 
@@ -209,9 +212,9 @@ function renderEditSummary(text: string, width: number): string[] {
 	const removals = text.match(/-(\d+)/)?.[0];
 	const rest = text.replace(/\+\d+|-\d+/g, "").trim();
 	return [renderBodyLine([
-		...(additions ? [span(additions, { fg: CATHEDRAL_TOKENS.colors.states.idle }), span(" ")] : []),
-		...(removals ? [span(removals, { fg: CATHEDRAL_TOKENS.colors.states.approval }), span(" ")] : []),
-		span(rest || "diff collapsed", { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+		...(additions ? [span(additions, { fg: activeThemeColors().states.idle }), span(" ")] : []),
+		...(removals ? [span(removals, { fg: activeThemeColors().states.approval }), span(" ")] : []),
+		span(rest || "diff collapsed", { fg: activeThemeColors().foregroundDim }),
 	], width)];
 }
 
@@ -228,13 +231,13 @@ function renderEditBody(tool: ToolCallViewModel, width: number): string[] {
 	// Render actual diff lines with gutter
 	const startLine = typeof details?.startLine === "number" ? details.startLine : 1;
 	const rows = diffLines.slice(0, TOOL_BODY_MAX_LINES).map((line, index) => {
-		const color = line.trimStart().startsWith("+") ? CATHEDRAL_TOKENS.colors.states.idle
-			: line.trimStart().startsWith("-") ? CATHEDRAL_TOKENS.colors.states.approval
-			: CATHEDRAL_TOKENS.colors.foreground;
+		const color = line.trimStart().startsWith("+") ? activeThemeColors().states.idle
+			: line.trimStart().startsWith("-") ? activeThemeColors().states.approval
+			: activeThemeColors().foreground;
 		return renderGutterLine(startLine + index, line, width, color);
 	});
 	const collapsed = collapsedMarker(details, Math.max(0, diffLines.length - rows.length));
-	if (collapsed) rows.push(renderBodyLine([span("      ", { fg: CATHEDRAL_TOKENS.colors.foregroundDim }), span(collapsed, { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width));
+	if (collapsed) rows.push(renderBodyLine([span("      ", { fg: activeThemeColors().foregroundDim }), span(collapsed, { fg: activeThemeColors().foregroundDim })], width));
 	return rows;
 }
 
@@ -243,14 +246,14 @@ function renderBashLine(line: string): (Span | string)[] {
 	const indent = line.slice(0, line.length - trimmed.length);
 	// Lines starting with ✓ or ✗: color only the glyph, rest stays foreground
 	if (trimmed.startsWith("✓")) {
-		return [span(`${indent}✓`, { fg: CATHEDRAL_TOKENS.colors.states.idle }), span(trimmed.slice(1))];
+		return [span(`${indent}✓`, { fg: activeThemeColors().states.idle }), span(trimmed.slice(1))];
 	}
 	if (trimmed.startsWith("✗")) {
-		return [span(`${indent}✗`, { fg: CATHEDRAL_TOKENS.colors.states.approval }), span(trimmed.slice(1))];
+		return [span(`${indent}✗`, { fg: activeThemeColors().states.approval }), span(trimmed.slice(1))];
 	}
 	// Summary / result lines (no leading > or glyph): dim
 	if (!trimmed.startsWith(">")) {
-		return [span(line, { fg: CATHEDRAL_TOKENS.colors.foregroundDim })];
+		return [span(line, { fg: activeThemeColors().foregroundDim })];
 	}
 	return [line];
 }
@@ -261,11 +264,11 @@ function renderBashBody(tool: ToolCallViewModel, width: number): string[] {
 	const lines = outputLines(tool).slice(0, TOOL_BODY_MAX_LINES).map(terminalSafeText);
 	const body = [renderBodyLine([`> ${target}`], width)];
 	const collapsed = collapsedMarker(details, Math.max(0, outputLines(tool).length - lines.length));
-	if (collapsed) body.push(renderBodyLine([span(`  ${collapsed}`, { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width));
+	if (collapsed) body.push(renderBodyLine([span(`  ${collapsed}`, { fg: activeThemeColors().foregroundDim })], width));
 	for (const line of lines) {
 		body.push(renderBodyLine(renderBashLine(line), width));
 	}
-	if (lines.length === 0 && tool.status === "running") body.push(renderBodyLine([span("watching stdout…", { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width));
+	if (lines.length === 0 && tool.status === "running") body.push(renderBodyLine([span("watching stdout…", { fg: activeThemeColors().foregroundDim })], width));
 	return body;
 }
 
@@ -273,7 +276,7 @@ function renderToolBody(tool: ToolCallViewModel, width: number): string[] {
 	if (tool.name === "edit") return renderEditBody(tool, width);
 	if (tool.name === "read" || tool.name === "write") return renderReadLikeBody(tool, width);
 	if (tool.name === "bash") return renderBashBody(tool, width);
-	return [renderBodyLine([span("preview collapsed", { fg: CATHEDRAL_TOKENS.colors.foregroundDim })], width)];
+	return [renderBodyLine([span("preview collapsed", { fg: activeThemeColors().foregroundDim })], width)];
 }
 
 export function renderToolLedgerRows(tool: ToolCallViewModel, width: number): string[] {

--- a/src/sumo-tui/widgets/chat-message.ts
+++ b/src/sumo-tui/widgets/chat-message.ts
@@ -1,6 +1,6 @@
 import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import { DEFAULT_SUMOCODE_CONFIG } from "../../config/sumocode-config.js";
-import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { activeThemeColors } from "../../themes/index.js";
 import { fgHex, RESET } from "../cathedral/ansi.js";
 import { SumoNode } from "../layout/node.js";
 import { MEASURE_MODE_EXACTLY, type MeasureMode, type Yoga, type YogaNode } from "../layout/yoga.js";
@@ -60,10 +60,10 @@ function roleLabel(role: ChatMessageRole, primaryAgentName?: string): string {
 }
 
 function roleColor(role: ChatMessageRole): string {
-	if (role === "user") return CATHEDRAL_TOKENS.colors.foreground;
-	if (role === "sumo" || role === "assistant") return CATHEDRAL_TOKENS.colors.accent;
-	if (role === "tool") return CATHEDRAL_TOKENS.colors.states.tool;
-	return CATHEDRAL_TOKENS.colors.foregroundDim;
+	if (role === "user") return activeThemeColors().foreground;
+	if (role === "sumo" || role === "assistant") return activeThemeColors().accent;
+	if (role === "tool") return activeThemeColors().states.tool;
+	return activeThemeColors().foregroundDim;
 }
 
 function takeVisible(input: string, maxWidth: number): { head: string; tail: string } {
@@ -175,17 +175,17 @@ function formatTime(timestamp: Date): string {
 function frameTop(role: ChatMessageRole, timestamp: Date | undefined, width: number, primaryAgentName?: string): string {
 	const label = roleLabel(role, primaryAgentName);
 	const leftParts: (Span | string)[] = [
-		span("╭ ", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("╭ ", { fg: activeThemeColors().divider }),
 		span(label, { fg: roleColor(role) }),
-		span(" ", { fg: CATHEDRAL_TOKENS.colors.foreground }),
+		span(" ", { fg: activeThemeColors().foreground }),
 	];
 
 	const showTime = (role === "sumo" || role === "assistant") && timestamp !== undefined;
 	const rightParts: (Span | string)[] = showTime
 		? [
-			span(" ", { fg: CATHEDRAL_TOKENS.colors.divider }),
-			span(formatTime(timestamp), { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
-			span(" \u2500", { fg: CATHEDRAL_TOKENS.colors.divider }),
+			span(" ", { fg: activeThemeColors().divider }),
+			span(formatTime(timestamp), { fg: activeThemeColors().foregroundDim }),
+			span(" \u2500", { fg: activeThemeColors().divider }),
 		]
 		: [];
 
@@ -193,42 +193,42 @@ function frameTop(role: ChatMessageRole, timestamp: Date | undefined, width: num
 	const rule = Math.max(0, width - used);
 	return lineToAnsi(textLine([
 		...leftParts,
-		span("─".repeat(rule), { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("─".repeat(rule), { fg: activeThemeColors().divider }),
 		...rightParts,
-		span("╮", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("╮", { fg: activeThemeColors().divider }),
 	]), { width });
 }
 
 function frameBody(row: string, width: number): string {
 	const inner = Math.max(0, width - 4);
 	const text = fitAnsiText(row, inner);
-	const divider = fgHex(CATHEDRAL_TOKENS.colors.divider);
-	const foreground = fgHex(CATHEDRAL_TOKENS.colors.foreground);
+	const divider = fgHex(activeThemeColors().divider);
+	const foreground = fgHex(activeThemeColors().foreground);
 	return `${divider}│${RESET} ${foreground}${text}${RESET} ${divider}│${RESET}`;
 }
 
 function frameBottom(width: number): string {
 	return lineToAnsi(textLine([
-		span("╰", { fg: CATHEDRAL_TOKENS.colors.divider }),
-		span("─".repeat(Math.max(0, width - 2)), { fg: CATHEDRAL_TOKENS.colors.divider }),
-		span("╯", { fg: CATHEDRAL_TOKENS.colors.divider }),
+		span("╰", { fg: activeThemeColors().divider }),
+		span("─".repeat(Math.max(0, width - 2)), { fg: activeThemeColors().divider }),
+		span("╯", { fg: activeThemeColors().divider }),
 	]), { width });
 }
 
 function renderSkillRow(block: Extract<ChatBlock, { type: "skill" }>): string {
 	const hint = block.expanded ? "(expanded)" : "(⌘O to expand)";
 	return lineToAnsi(textLine([
-		span("[skill]", { fg: CATHEDRAL_TOKENS.colors.accent }),
-		span(` ${block.name} `, { fg: CATHEDRAL_TOKENS.colors.foreground }),
-		span(hint, { fg: CATHEDRAL_TOKENS.colors.foregroundDim }),
+		span("[skill]", { fg: activeThemeColors().accent }),
+		span(` ${block.name} `, { fg: activeThemeColors().foreground }),
+		span(hint, { fg: activeThemeColors().foregroundDim }),
 	]));
 }
 
 function renderThinkingRows(block: Extract<ChatBlock, { type: "thinking" }>, width: number): string[] {
 	const prefix = block.hidden ? "◌ " : "✦ ";
 	return wrapPlainText(block.text, Math.max(1, width - visibleWidth(prefix))).map((row) => lineToAnsi(textLine([
-		span(prefix, { fg: CATHEDRAL_TOKENS.colors.states.thinking, dim: true }),
-		span(row, { fg: CATHEDRAL_TOKENS.colors.states.thinking, italic: true, dim: true }),
+		span(prefix, { fg: activeThemeColors().states.thinking, dim: true }),
+		span(row, { fg: activeThemeColors().states.thinking, italic: true, dim: true }),
 	]), { width }));
 }
 

--- a/src/sumo-tui/widgets/modal-layer.ts
+++ b/src/sumo-tui/widgets/modal-layer.ts
@@ -2,7 +2,7 @@ import { truncateToWidth, visibleWidth, type Component } from "@mariozechner/pi-
 import { SumoNode } from "../layout/node.js";
 import type { YogaNode } from "../layout/yoga.js";
 import type { CellBuffer, Rect } from "../render/buffer.js";
-import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { activeThemeColors } from "../../themes/index.js";
 import { ModalManager, type ModalManagerOptions } from "./modal.js";
 import { cathedralBackdropCell } from "../cathedral/theme-bridge.js";
 
@@ -43,7 +43,7 @@ function padVisible(text: string, width: number): string {
 }
 
 function centerRows(rows: readonly string[], width: number, height: number): string[] {
-	const blank = `${bg(CATHEDRAL_TOKENS.colors.surfaceRecess)}${" ".repeat(width)}${RESET}`;
+	const blank = `${bg(activeThemeColors().surfaceRecess)}${" ".repeat(width)}${RESET}`;
 	const out = Array.from({ length: height }, () => blank);
 	if (rows.length === 0) return [];
 	const top = Math.max(0, Math.floor((height - rows.length) / 2));
@@ -51,7 +51,7 @@ function centerRows(rows: readonly string[], width: number, height: number): str
 		const row = rows[index] ?? "";
 		const left = Math.max(0, Math.floor((width - visibleWidth(row)) / 2));
 		const right = Math.max(0, width - left - visibleWidth(row));
-		out[top + index] = `${bg(CATHEDRAL_TOKENS.colors.surfaceRecess)}${" ".repeat(left)}${row}${" ".repeat(right)}${RESET}`;
+		out[top + index] = `${bg(activeThemeColors().surfaceRecess)}${" ".repeat(left)}${row}${" ".repeat(right)}${RESET}`;
 	}
 	return out;
 }
@@ -73,8 +73,8 @@ export class ModalSurfaceComponent implements Component {
 	public render(width: number): string[] {
 		const outerWidth = Math.max(12, width);
 		const innerWidth = Math.max(1, outerWidth - 2);
-		const border = fg(CATHEDRAL_TOKENS.colors.divider);
-		const surface = bg(CATHEDRAL_TOKENS.colors.surfaceLifted);
+		const border = fg(activeThemeColors().divider);
+		const surface = bg(activeThemeColors().surfaceLifted);
 		const childRows = this.inner.render(innerWidth);
 		if (childRows.length === 0) return [];
 		const lines: string[] = [];

--- a/src/sumo-tui/widgets/scrolled-up-banner.ts
+++ b/src/sumo-tui/widgets/scrolled-up-banner.ts
@@ -1,4 +1,4 @@
-import { CATHEDRAL_TOKENS } from "../../tokens.js";
+import { activeThemeColors } from "../../themes/index.js";
 import { SumoNode } from "../layout/node.js";
 import type { Yoga, YogaNode } from "../layout/yoga.js";
 import type { MouseEvent } from "../input/mouse.js";
@@ -49,7 +49,7 @@ export class ScrolledUpBanner extends SumoNode {
 		const unread = this.getUnreadCount();
 		const noun = unread === 1 ? "message" : "messages";
 		const label = `↓ ${unread} new ${noun} — Press ${chatScrollHintLabel("jump-bottom")} to jump`;
-		const styled = `\x1b[2m${fg(CATHEDRAL_TOKENS.colors.foregroundDim)}${label}\x1b[0m`;
+		const styled = `\x1b[2m${fg(activeThemeColors().foregroundDim)}${label}\x1b[0m`;
 		buffer.paintRow(rect.top, styled, rect.left, rect.width);
 	}
 

--- a/src/themes/cathedral.ts
+++ b/src/themes/cathedral.ts
@@ -1,0 +1,39 @@
+import type { Theme } from "./types.js";
+
+/**
+ * Cathedral spinner frames — a hand-crafted flower-pulse that shares the
+ * design DNA with Claude Code's spinner (transforming dingbats, not a rotor)
+ * but has zero glyph overlap with their `· ✻ ✽ ✶ ✳ ✢` set.
+ */
+export const CATHEDRAL_INDICATOR_FRAMES = ["◌", "✦", "❖", "✺", "❋", "❉"] as const;
+
+export const CATHEDRAL_INDICATOR_INTERVAL_MS = 150;
+
+export const CATHEDRAL_THEME: Theme = {
+	name: "cathedral",
+	displayName: "Cathedral",
+	description: "19th-century scriptorium: warm walnut, parchment foreground, burnt-orange accents.",
+	tokens: {
+		colors: {
+			background: "#1A1511",
+			surface: "#241D17",
+			surfaceRecess: "#120D0A",
+			surfaceLifted: "#3D3024",
+			foreground: "#F5E6C8",
+			foregroundDim: "#8B7A63",
+			divider: "#5A4D3C",
+			accent: "#D97706",
+			states: {
+				idle: "#7FB069",
+				thinking: "#E8B339",
+				tool: "#5B9BD5",
+				approval: "#C1443E",
+				learning: "#8E7AB5",
+			},
+		},
+	},
+	workingIndicator: {
+		frames: CATHEDRAL_INDICATOR_FRAMES,
+		intervalMs: CATHEDRAL_INDICATOR_INTERVAL_MS,
+	},
+};

--- a/src/themes/index.ts
+++ b/src/themes/index.ts
@@ -1,0 +1,15 @@
+export { CATHEDRAL_INDICATOR_FRAMES, CATHEDRAL_INDICATOR_INTERVAL_MS, CATHEDRAL_THEME } from "./cathedral.js";
+export {
+	activeThemeColors,
+	activeThemeTokens,
+	getActiveTheme,
+	getTheme,
+	getThemeVersion,
+	listThemes,
+	onThemeChanged,
+	resetThemeRegistryForTests,
+	setActiveTheme,
+	type SetThemeResult,
+	type ThemeChangedListener,
+} from "./registry.js";
+export { SUMOCODE_STATE_NAMES, type SumoCodeState, type Theme, type ThemeColors, type ThemeTokens, type ThemeWorkingIndicator } from "./types.js";

--- a/src/themes/registry.test.ts
+++ b/src/themes/registry.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { CATHEDRAL_THEME, activeThemeColors, getActiveTheme, getTheme, getThemeVersion, listThemes, onThemeChanged, resetThemeRegistryForTests, setActiveTheme } from "./index.js";
+
+describe("theme registry", () => {
+	afterEach(() => resetThemeRegistryForTests());
+
+	it("registers Cathedral as the default and first theme", () => {
+		expect(listThemes().map((theme) => theme.name)).toEqual(["cathedral"]);
+		expect(getTheme("cathedral")).toBe(CATHEDRAL_THEME);
+		expect(getTheme(" Cathedral ")).toBe(CATHEDRAL_THEME);
+		expect(getActiveTheme()).toBe(CATHEDRAL_THEME);
+		expect(activeThemeColors().accent).toBe("#D97706");
+	});
+
+	it("sets the active theme and notifies subscribers", () => {
+		const seen: string[] = [];
+		const unsubscribe = onThemeChanged((theme) => seen.push(theme.name));
+		const before = getThemeVersion();
+
+		const result = setActiveTheme("cathedral");
+		unsubscribe();
+		setActiveTheme("cathedral");
+
+		expect(result).toEqual({ success: true, theme: CATHEDRAL_THEME });
+		expect(getThemeVersion()).toBe(before + 2);
+		expect(seen).toEqual(["cathedral"]);
+	});
+
+	it("rejects unknown themes without changing the active theme", () => {
+		const before = getThemeVersion();
+		const result = setActiveTheme("amber-crt");
+
+		expect(result.success).toBe(false);
+		if (!result.success) expect(result.error).toContain("Unknown SumoCode theme");
+		expect(getActiveTheme()).toBe(CATHEDRAL_THEME);
+		expect(getThemeVersion()).toBe(before);
+	});
+});

--- a/src/themes/registry.ts
+++ b/src/themes/registry.ts
@@ -1,0 +1,59 @@
+import { CATHEDRAL_THEME } from "./cathedral.js";
+import type { Theme, ThemeColors, ThemeTokens } from "./types.js";
+
+export type ThemeChangedListener = (theme: Theme) => void;
+export type SetThemeResult = { success: true; theme: Theme } | { success: false; error: string };
+
+function normalizeThemeName(name: string): string {
+	return name.trim().toLowerCase();
+}
+
+const registry = new Map<string, Theme>([[CATHEDRAL_THEME.name, CATHEDRAL_THEME]]);
+const listeners = new Set<ThemeChangedListener>();
+
+let activeThemeName = CATHEDRAL_THEME.name;
+let themeVersion = 0;
+
+export function listThemes(): Theme[] {
+	return [...registry.values()];
+}
+
+export function getTheme(name: string): Theme | undefined {
+	return registry.get(normalizeThemeName(name));
+}
+
+export function getActiveTheme(): Theme {
+	return registry.get(activeThemeName) ?? CATHEDRAL_THEME;
+}
+
+export function activeThemeTokens(): ThemeTokens {
+	return getActiveTheme().tokens;
+}
+
+export function activeThemeColors(): ThemeColors {
+	return getActiveTheme().tokens.colors;
+}
+
+export function getThemeVersion(): number {
+	return themeVersion;
+}
+
+export function setActiveTheme(name: string): SetThemeResult {
+	const theme = getTheme(name);
+	if (!theme) return { success: false, error: `Unknown SumoCode theme: ${name}` };
+	activeThemeName = theme.name;
+	themeVersion += 1;
+	for (const listener of listeners) listener(theme);
+	return { success: true, theme };
+}
+
+export function onThemeChanged(listener: ThemeChangedListener): () => void {
+	listeners.add(listener);
+	return () => listeners.delete(listener);
+}
+
+export function resetThemeRegistryForTests(): void {
+	activeThemeName = CATHEDRAL_THEME.name;
+	themeVersion = 0;
+	listeners.clear();
+}

--- a/src/themes/types.ts
+++ b/src/themes/types.ts
@@ -1,0 +1,34 @@
+export const SUMOCODE_STATE_NAMES = ["idle", "thinking", "tool", "approval", "learning"] as const;
+
+export type SumoCodeState = (typeof SUMOCODE_STATE_NAMES)[number];
+
+export type ThemeStateColors = Record<SumoCodeState, string>;
+
+export interface ThemeColors {
+	background: string;
+	surface: string;
+	surfaceRecess: string;
+	surfaceLifted: string;
+	foreground: string;
+	foregroundDim: string;
+	divider: string;
+	accent: string;
+	states: ThemeStateColors;
+}
+
+export interface ThemeTokens {
+	colors: ThemeColors;
+}
+
+export interface ThemeWorkingIndicator {
+	frames: readonly string[];
+	intervalMs: number;
+}
+
+export interface Theme {
+	name: string;
+	displayName: string;
+	description: string;
+	tokens: ThemeTokens;
+	workingIndicator: ThemeWorkingIndicator;
+}

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -1,23 +1,7 @@
-export const CATHEDRAL_TOKENS = {
-	colors: {
-		background: "#1A1511",
-		surface: "#241D17",
-		surfaceRecess: "#120D0A",
-		surfaceLifted: "#3D3024",
-		foreground: "#F5E6C8",
-		foregroundDim: "#8B7A63",
-		divider: "#5A4D3C",
-		accent: "#D97706",
-		states: {
-			idle: "#7FB069",
-			thinking: "#E8B339",
-			tool: "#5B9BD5",
-			approval: "#C1443E",
-			learning: "#8E7AB5",
-		},
-	},
-} as const;
+import { CATHEDRAL_THEME, SUMOCODE_STATE_NAMES, type SumoCodeState } from "./themes/index.js";
 
-export type SumoCodeState = keyof typeof CATHEDRAL_TOKENS.colors.states;
+export const CATHEDRAL_TOKENS = CATHEDRAL_THEME.tokens;
 
-export const SUMOCODE_STATES = Object.keys(CATHEDRAL_TOKENS.colors.states) as SumoCodeState[];
+export type { SumoCodeState };
+
+export const SUMOCODE_STATES = [...SUMOCODE_STATE_NAMES] as SumoCodeState[];

--- a/src/top-chrome.ts
+++ b/src/top-chrome.ts
@@ -24,7 +24,7 @@ import type { Component } from "@mariozechner/pi-tui";
 import { isTopChromeHidden } from "./commands/tabs.js";
 import { sessionHasMessages as cachedSessionHasMessages } from "./session-cache.js";
 import { getActiveSumoRuntime } from "./sumo-tui/pi-compat/sumo-interactive-mode.js";
-import { CATHEDRAL_TOKENS, type SumoCodeState } from "./tokens.js";
+import { activeThemeColors, type SumoCodeState } from "./themes/index.js";
 
 const RESET = "\u001b[0m";
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
@@ -83,33 +83,33 @@ const DOT_GLYPHS: Record<TopChromeDotSize, string> = {
  */
 function activeSegment(active: TopChromeSnapshot["activeSession"], maxLabel: number, dotSize: TopChromeDotSize): string {
 	const label = ellipsize(active.label, maxLabel);
-	const dot = color(DOT_GLYPHS[dotSize], CATHEDRAL_TOKENS.colors.accent);
-	const dim = (ch: string): string => color(ch, CATHEDRAL_TOKENS.colors.foregroundDim);
+	const dot = color(DOT_GLYPHS[dotSize], activeThemeColors().accent);
+	const dim = (ch: string): string => color(ch, activeThemeColors().foregroundDim);
 	return `${dim("║" + " ")}${dot}${dim(" " + label + " " + "║")}`;
 }
 
 const ACTIVE_OVERHEAD = 6; // chars consumed by `║ ● ` + ` ║`
 
 function recentSegment(label: string): string {
-	const sep = color("│", CATHEDRAL_TOKENS.colors.foregroundDim);
-	const text = color(label, CATHEDRAL_TOKENS.colors.foregroundDim);
+	const sep = color("│", activeThemeColors().foregroundDim);
+	const text = color(label, activeThemeColors().foregroundDim);
 	return `   ${sep} ${text}`;
 }
 
 function archiveSegment(): string {
-	const sep = color("│", CATHEDRAL_TOKENS.colors.foregroundDim);
-	const text = color(ARCHIVE_LABEL, CATHEDRAL_TOKENS.colors.foregroundDim);
+	const sep = color("│", activeThemeColors().foregroundDim);
+	const text = color(ARCHIVE_LABEL, activeThemeColors().foregroundDim);
 	return `   ${sep} ${text}`;
 }
 
 function iconsSegment(): string {
-	const term = color(ICON_TERMINAL, CATHEDRAL_TOKENS.colors.foreground);
-	const gear = color(ICON_SETTINGS, CATHEDRAL_TOKENS.colors.foreground);
+	const term = color(ICON_TERMINAL, activeThemeColors().foreground);
+	const gear = color(ICON_SETTINGS, activeThemeColors().foreground);
 	return `${term}${ICON_GAP}${gear}`;
 }
 
 function brandSegment(): string {
-	return color(TOP_CHROME_BRAND, CATHEDRAL_TOKENS.colors.accent);
+	return color(TOP_CHROME_BRAND, activeThemeColors().accent);
 }
 
 function padToWidth(text: string, width: number): string {
@@ -158,7 +158,7 @@ export function renderTopChrome(snapshot: TopChromeSnapshot, width: number): str
 		const maxActiveLabel = Math.max(1, innerWidth - brandLen - BRAND_ACTIVE_GAP - ACTIVE_OVERHEAD);
 		active = activeSegment(snapshot.activeSession, maxActiveLabel, dotSize);
 	}
-	const brandGap = color(" ".repeat(BRAND_ACTIVE_GAP), CATHEDRAL_TOKENS.colors.foregroundDim);
+	const brandGap = color(" ".repeat(BRAND_ACTIVE_GAP), activeThemeColors().foregroundDim);
 	let consumed = brandLen + BRAND_ACTIVE_GAP + visibleLength(active);
 	let line = `${brand}${brandGap}${active}`;
 	const compact = innerWidth < COMPACT_TOP_CHROME_WIDTH;

--- a/src/working-indicator.ts
+++ b/src/working-indicator.ts
@@ -14,7 +14,7 @@
  */
 
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { CATHEDRAL_TOKENS } from "./tokens.js";
+import { CATHEDRAL_INDICATOR_FRAMES as THEME_CATHEDRAL_INDICATOR_FRAMES, CATHEDRAL_INDICATOR_INTERVAL_MS as THEME_CATHEDRAL_INDICATOR_INTERVAL_MS, getActiveTheme } from "./themes/index.js";
 
 /**
  * Cathedral spinner frames — a hand-crafted flower-pulse that shares the
@@ -33,7 +33,10 @@ import { CATHEDRAL_TOKENS } from "./tokens.js";
  *   ❋ — heavy propeller, work-in-progress
  *   ❉ — balloon-spoked pinwheel, settled medallion
  */
-export const CATHEDRAL_INDICATOR_FRAMES = ["◌", "✦", "❖", "✺", "❋", "❉"] as const;
+
+export const CATHEDRAL_INDICATOR_FRAMES = THEME_CATHEDRAL_INDICATOR_FRAMES;
+
+export const CATHEDRAL_INDICATOR_INTERVAL_MS = THEME_CATHEDRAL_INDICATOR_INTERVAL_MS;
 
 const RESET = "\u001b[0m";
 
@@ -71,15 +74,20 @@ export function renderIndicator(
  * deliberately slower than ora (80ms) and Claude Code (~100ms) so the bloom
  * reads as scriptorium brushwork rather than a frantic CLI spinner.
  */
-export const CATHEDRAL_INDICATOR_INTERVAL_MS = 150;
+export const WORKING_INDICATOR_INTERVAL_MS = THEME_CATHEDRAL_INDICATOR_INTERVAL_MS;
 export const WORKING_INDICATOR_MIN_WIDTH = 80;
 
 /**
  * Pre-colorize each Cathedral frame with the accent token so Pi can render the
  * array verbatim. Pi handles cycling itself.
  */
-export function buildCathedralIndicatorFrames(hex: string = CATHEDRAL_TOKENS.colors.accent): string[] {
+export function buildCathedralIndicatorFrames(hex: string = getActiveTheme().tokens.colors.accent): string[] {
 	return CATHEDRAL_INDICATOR_FRAMES.map((_, i) => renderIndicator(i, CATHEDRAL_INDICATOR_FRAMES, hex));
+}
+
+export function buildActiveThemeIndicatorFrames(): string[] {
+	const theme = getActiveTheme();
+	return theme.workingIndicator.frames.map((_, i) => renderIndicator(i, theme.workingIndicator.frames, theme.tokens.colors.accent));
 }
 
 /**
@@ -133,9 +141,10 @@ export function installWorkingIndicator(pi: ExtensionAPI): void {
 		if (!ctx.hasUI) return;
 		if (!shouldInstallWorkingIndicator()) return;
 
+		const theme = getActiveTheme();
 		ctx.ui.setWorkingIndicator({
-			frames: buildCathedralIndicatorFrames(),
-			intervalMs: CATHEDRAL_INDICATOR_INTERVAL_MS,
+			frames: buildActiveThemeIndicatorFrames(),
+			intervalMs: theme.workingIndicator.intervalMs,
 		});
 	});
 }


### PR DESCRIPTION
## Summary

Closes #212.

Introduces the typed SumoCode theme registry while preserving Cathedral visual parity:

- Adds `src/themes/` with `Theme`, `ThemeColors`, `ThemeTokens`, `SumoCodeState`.
- Moves Cathedral tokens and working-indicator frames into `src/themes/cathedral.ts`.
- Adds registry helpers: `getActiveTheme`, `setActiveTheme`, `listThemes`, subscribers, test reset.
- Keeps `src/tokens.ts` as a compatibility shim for legacy/test imports.
- Updates production render surfaces to use `activeThemeColors()` instead of hardcoded `CATHEDRAL_TOKENS.colors`.
- Updates working indicator to render from active theme frames/accent.

## Verification

- `pnpm exec tsc --noEmit` ✅
- `pnpm build` ✅
- `pnpm test` ✅ — 100 files / 719 tests
- `pnpm test:integration` ✅ — 15 files / 21 tests
- `pnpm visual:ci` ✅ completed, existing review-lane statuses only
- SumoCode diff review via scribe ✅ GREEN

## Notes

No Amber CRT or Obsidian Temple values are added in this PR. This is intentionally a pure registry refactor so Cathedral remains the visual baseline before the new theme bundles land.