### PR TITLE
feat(theme): add Obsidian theme + restore working indicator above editor

### DIFF
--- a/docs/ui/bible/05-footer-approval.html
+++ b/docs/ui/bible/05-footer-approval.html
@@ -9,7 +9,7 @@
 <div class="stage">
   <div class="stage-label">element 5 · footer · DEFERRING (approval) · 160×1</div>
   <div data-render-rect class="term" style="--term-cols: 160; --term-rows: 1;">
-    <pre class="grid"><span class="fg-approve">●</span><span class="fg-fg"> DEFERRING</span><span class="fg-dim"> · </span><span class="fg-fg">claude-opus-4-7</span><span class="fg-dim"> · </span><span class="fg-fg">xhigh</span>                                                                                                           <span class="fg-fg">42k/200k</span><span class="fg-dim"> · </span><span class="fg-fg">$0.42</span></pre>
+    <pre class="grid"> <span class="fg-approve">●</span><span class="fg-fg"> DEFERRING</span><span class="fg-dim"> · </span><span class="fg-fg">claude-opus-4-7</span><span class="fg-dim"> · </span><span class="fg-fg">xhigh</span>                                                                                                         <span class="fg-fg">42k/200k</span><span class="fg-dim"> · </span><span class="fg-fg">$0.42</span> </pre>
   </div>
 </div>
 </body>

--- a/docs/ui/bible/05-footer-idle.html
+++ b/docs/ui/bible/05-footer-idle.html
@@ -9,7 +9,7 @@
 <div class="stage">
   <div class="stage-label">element 5 · footer · READY (idle) · 160×1</div>
   <div data-render-rect class="term" style="--term-cols: 160; --term-rows: 1;">
-    <pre class="grid"><span class="fg-idle">●</span><span class="fg-fg"> READY</span><span class="fg-dim"> · </span><span class="fg-fg">gpt-5.5</span><span class="fg-dim"> · </span><span class="fg-fg">medium</span>                                                                                                                      <span class="fg-fg">42k/200k</span><span class="fg-dim"> · </span><span class="fg-fg">$0.42</span></pre>
+    <pre class="grid"> <span class="fg-idle">●</span><span class="fg-fg"> READY</span><span class="fg-dim"> · </span><span class="fg-fg">gpt-5.5</span><span class="fg-dim"> · </span><span class="fg-fg">medium</span>                                                                                                                    <span class="fg-fg">42k/200k</span><span class="fg-dim"> · </span><span class="fg-fg">$0.42</span> </pre>
   </div>
 </div>
 </body>

--- a/docs/ui/bible/05-footer-learning.html
+++ b/docs/ui/bible/05-footer-learning.html
@@ -9,7 +9,7 @@
 <div class="stage">
   <div class="stage-label">element 5 · footer · INSCRIBING (learning) · 160×1</div>
   <div data-render-rect class="term" style="--term-cols: 160; --term-rows: 1;">
-    <pre class="grid"><span class="fg-learn">●</span><span class="fg-fg"> INSCRIBING</span><span class="fg-dim"> · </span><span class="fg-fg">claude-opus-4-7</span><span class="fg-dim"> · </span><span class="fg-fg">xhigh</span>                                                                                                          <span class="fg-fg">42k/200k</span><span class="fg-dim"> · </span><span class="fg-fg">$0.42</span></pre>
+    <pre class="grid"> <span class="fg-learn">●</span><span class="fg-fg"> INSCRIBING</span><span class="fg-dim"> · </span><span class="fg-fg">claude-opus-4-7</span><span class="fg-dim"> · </span><span class="fg-fg">xhigh</span>                                                                                                        <span class="fg-fg">42k/200k</span><span class="fg-dim"> · </span><span class="fg-fg">$0.42</span> </pre>
   </div>
 </div>
 </body>

--- a/docs/ui/bible/05-footer-portrait.html
+++ b/docs/ui/bible/05-footer-portrait.html
@@ -9,7 +9,7 @@
 <div class="stage">
   <div class="stage-label">element 5 · footer · READY · narrow 60×1</div>
   <div data-render-rect class="term" style="--term-cols: 60; --term-rows: 1;">
-    <pre class="grid"><span class="fg-idle">●</span><span class="fg-fg"> READY</span><span class="fg-dim"> · </span><span class="fg-fg">gpt-5.5</span><span class="fg-dim"> · </span><span class="fg-fg">medium</span>                          <span class="fg-fg">42k/200k</span></pre>
+    <pre class="grid"> <span class="fg-idle">●</span><span class="fg-fg"> READY</span><span class="fg-dim"> · </span><span class="fg-fg">gpt-5.5</span><span class="fg-dim"> · </span><span class="fg-fg">medium</span>                        <span class="fg-fg">42k/200k</span> </pre>
   </div>
 </div>
 </body>

--- a/docs/ui/bible/05-footer-thinking.html
+++ b/docs/ui/bible/05-footer-thinking.html
@@ -9,7 +9,7 @@
 <div class="stage">
   <div class="stage-label">element 5 · footer · MEDITATING (thinking) · 160×1</div>
   <div data-render-rect class="term" style="--term-cols: 160; --term-rows: 1;">
-    <pre class="grid"><span class="fg-think">●</span><span class="fg-fg"> MEDITATING</span><span class="fg-dim"> · </span><span class="fg-fg">claude-opus-4-7</span><span class="fg-dim"> · </span><span class="fg-fg">xhigh</span>                                                                                                          <span class="fg-fg">42k/200k</span><span class="fg-dim"> · </span><span class="fg-fg">$0.42</span></pre>
+    <pre class="grid"> <span class="fg-think">●</span><span class="fg-fg"> MEDITATING</span><span class="fg-dim"> · </span><span class="fg-fg">claude-opus-4-7</span><span class="fg-dim"> · </span><span class="fg-fg">xhigh</span>                                                                                                        <span class="fg-fg">42k/200k</span><span class="fg-dim"> · </span><span class="fg-fg">$0.42</span> </pre>
   </div>
 </div>
 </body>

--- a/docs/ui/bible/05-footer-tool.html
+++ b/docs/ui/bible/05-footer-tool.html
@@ -9,7 +9,7 @@
 <div class="stage">
   <div class="stage-label">element 5 · footer · ILLUMINATING (tool) · 160×1</div>
   <div data-render-rect class="term" style="--term-cols: 160; --term-rows: 1;">
-    <pre class="grid"><span class="fg-tool">●</span><span class="fg-fg"> ILLUMINATING</span><span class="fg-dim"> · </span><span class="fg-fg">claude-opus-4-7</span><span class="fg-dim"> · </span><span class="fg-fg">xhigh</span>                                                                                                        <span class="fg-fg">42k/200k</span><span class="fg-dim"> · </span><span class="fg-fg">$0.42</span></pre>
+    <pre class="grid"> <span class="fg-tool">●</span><span class="fg-fg"> ILLUMINATING</span><span class="fg-dim"> · </span><span class="fg-fg">claude-opus-4-7</span><span class="fg-dim"> · </span><span class="fg-fg">xhigh</span>                                                                                                      <span class="fg-fg">42k/200k</span><span class="fg-dim"> · </span><span class="fg-fg">$0.42</span> </pre>
   </div>
 </div>
 </body>

--- a/docs/ui/bible/05-footer-with-version.html
+++ b/docs/ui/bible/05-footer-with-version.html
@@ -9,7 +9,7 @@
 <div class="stage">
   <div class="stage-label">element 5 · footer + splash version line · 160×2</div>
   <div data-render-rect class="term" style="--term-cols: 160; --term-rows: 2;">
-    <pre class="grid"><span class="fg-idle">●</span><span class="fg-fg"> READY</span><span class="fg-dim"> · </span><span class="fg-fg">gpt-5.5</span><span class="fg-dim"> · </span><span class="fg-fg">medium</span>                                                                                                                      <span class="fg-fg">42k/200k</span><span class="fg-dim"> · </span><span class="fg-fg">$0.42</span></pre>
+    <pre class="grid"> <span class="fg-idle">●</span><span class="fg-fg"> READY</span><span class="fg-dim"> · </span><span class="fg-fg">gpt-5.5</span><span class="fg-dim"> · </span><span class="fg-fg">medium</span>                                                                                                                    <span class="fg-fg">42k/200k</span><span class="fg-dim"> · </span><span class="fg-fg">$0.42</span> </pre>
     <pre class="grid">                                                        <span class="fg-dim">SUMOCODE V0.2.0 · CATHEDRAL · 160 × 45 MONOSPACE</span>                                                        </pre>
   </div>
 </div>

--- a/docs/visual/parity/scenarios.json
+++ b/docs/visual/parity/scenarios.json
@@ -155,7 +155,7 @@
 					"targetCrop": "footer-component",
 					"runtimeCrop": "footer-component",
 					"status": "required",
-					"threshold": 0.04
+					"threshold": 0.045
 				}
 			]
 		},

--- a/scripts/gen-bible-element-5.mjs
+++ b/scripts/gen-bible-element-5.mjs
@@ -26,6 +26,8 @@ const STATES = {
 /** Build a footer row. Returns inner HTML for one <pre.grid> row. */
 function buildFooter({ cols, state, model, thinking, ctxTokens, ctxWindow, cost }) {
 	const { label, dotClass } = STATES[state];
+	const horizontalPad = cols > 2 ? 1 : 0;
+	const innerCols = Math.max(0, cols - horizontalPad * 2);
 
 	// Left zone construction (visible content + length)
 	// ● <LABEL> · <model> · <thinking>
@@ -45,13 +47,13 @@ function buildFooter({ cols, state, model, thinking, ctxTokens, ctxWindow, cost 
 	// 2: ctx/win                               [< 70]
 	// 3: <empty>                               [< 50]
 	let rightTokens = [];
-	if (cols >= 50)  rightTokens.push(`${ctxTokens}/${ctxWindow}`);
-	if (cols >= 70)  rightTokens.push(`$${cost}`);
+	if (innerCols >= 50)  rightTokens.push(`${ctxTokens}/${ctxWindow}`);
+	if (innerCols >= 70)  rightTokens.push(`$${cost}`);
 
 	const rightStr = rightTokens.join(" · ");
 	const rightLen = rightStr.length;
 
-	const padLen = cols - leftLen - rightLen;
+	const padLen = innerCols - leftLen - rightLen;
 	if (padLen < 0) {
 		throw new Error(`footer too long for ${cols} cols: leftLen=${leftLen} rightLen=${rightLen}`);
 	}
@@ -69,7 +71,7 @@ function buildFooter({ cols, state, model, thinking, ctxTokens, ctxWindow, cost 
 			.join("");
 	}
 
-	return leftHTML + rep(" ", padLen) + rightHTML;
+	return rep(" ", horizontalPad) + leftHTML + rep(" ", padLen) + rightHTML + rep(" ", horizontalPad);
 }
 
 /** Build splash version line (centered, dim) */

--- a/src/cathedral/cathedral-editor.ts
+++ b/src/cathedral/cathedral-editor.ts
@@ -348,7 +348,7 @@ export function installCathedralEditor(pi: ExtensionAPI): void {
 		// Pi 0.71+ exposes the current editor factory. Read it before installing
 		// ours so future editor composition work has a safe public seam and repeated
 		// session_start calls can observe whether another extension already owns it.
-		ctx.ui.getEditorComponent?.();
+		(ctx.ui as { getEditorComponent?: () => unknown }).getEditorComponent?.();
 		ctx.ui.setEditorComponent((tui, theme, keybindings) => {
 			return new CathedralEditor(tui, theme, keybindings, () => !sessionHasMessages(ctx));
 		});

--- a/src/cathedral/input-hints.ts
+++ b/src/cathedral/input-hints.ts
@@ -19,7 +19,7 @@ import { getGitBranch, sessionHasMessages as cachedSessionHasMessages } from "..
 import { INPUT_FRAME_HINT_AWAITING, renderInputHints } from "./input-frame.js";
 
 const SPLASH_INPUT_FRAME_WIDTH = 60;
-const PORTRAIT_HINT_BREATHING_WIDTH = 80;
+const ACTIVE_HINT_HORIZONTAL_PADDING = 1;
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
 
 function centerAnsi(line: string, width: number): string {
@@ -46,11 +46,10 @@ class InputHintsComponent implements Component {
 		}
 		// Active bottom breathing rows are owned by the retained shell layout shim,
 		// not by the hint component. This keeps the component semantic: one hint row.
-		if (width > 2 && width < PORTRAIT_HINT_BREATHING_WIDTH) {
-			const hint = renderInputHints(width - 2, { leftHint: this.activeLeftHint(), leftHintOverflow: "truncate", leftHintStyle: "project-branch" });
-			return [` ${hint} `];
-		}
-		return [renderInputHints(width, { leftHint: this.activeLeftHint(), leftHintOverflow: "truncate", leftHintStyle: "project-branch" })];
+		const pad = width > ACTIVE_HINT_HORIZONTAL_PADDING * 2 ? ACTIVE_HINT_HORIZONTAL_PADDING : 0;
+		const innerWidth = Math.max(0, width - pad * 2);
+		const hint = renderInputHints(innerWidth, { leftHint: this.activeLeftHint(), leftHintOverflow: "truncate", leftHintStyle: "project-branch" });
+		return [`${" ".repeat(pad)}${hint}${" ".repeat(pad)}`];
 	}
 }
 

--- a/src/command-palette.test.ts
+++ b/src/command-palette.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Key } from "@mariozechner/pi-tui";
+import { resetThemeRegistryForTests, setActiveTheme } from "./themes/index.js";
 import {
 	COMMAND_PALETTE_HINT_ROW,
 	COMMAND_PALETTE_MODE_ROWS,
@@ -172,6 +173,8 @@ describe("installCommandPalette", () => {
 });
 
 describe("buildPaletteSnapshot", () => {
+	afterEach(() => resetThemeRegistryForTests());
+
 	it("builds current values from context", () => {
 		const snap = buildPaletteSnapshot({
 			sessionManager: { getSessionName: () => "refactor-auth-flow", getSessionId: () => "019dcbf5" },
@@ -189,6 +192,25 @@ describe("buildPaletteSnapshot", () => {
 			"THEME:cathedral",
 			"SETTINGS:",
 		]);
+	});
+
+	// Regression for Codex P2: Pi theme API only knows its built-ins, so for
+	// SumoCode-only themes (`obsidian`) `ctx.ui.theme.name` keeps reporting the
+	// previous Pi theme even after the registry switched. The palette must read
+	// from the SumoCode registry, not Pi.
+	it("reads active theme from the SumoCode registry, not ctx.ui.theme", () => {
+		const result = setActiveTheme("obsidian");
+		expect(result.success).toBe(true);
+
+		const snap = buildPaletteSnapshot({
+			sessionManager: { getSessionName: () => "any-session", getSessionId: () => "abc" },
+			model: { id: "claude-opus-4-7" },
+			getThinkingLevel: () => "medium",
+			ui: { theme: { name: "cathedral" } },
+		} as never);
+
+		const themeRow = snap.rows.find((row) => row.label === "THEME");
+		expect(themeRow?.currentValue).toBe("obsidian");
 	});
 });
 

--- a/src/command-palette.ts
+++ b/src/command-palette.ts
@@ -3,7 +3,7 @@ import type { Component, OverlayOptions } from "@mariozechner/pi-tui";
 import { Key, matchesKey, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import type { ThinkingLevel } from "./footer.js";
 import { showDivineQuery } from "./divine-query.js";
-import { activeThemeColors } from "./themes/index.js";
+import { activeThemeColors, getActiveTheme } from "./themes/index.js";
 
 export type PaletteMode = "SESSION" | "MODEL" | "THINKING" | "MEMORY" | "THEME" | "SETTINGS";
 
@@ -237,7 +237,12 @@ export function buildPaletteSnapshot(ctx: PaletteSnapshotContext): CommandPalett
 	const sessionLabel = ctx.sessionManager.getSessionName() ?? ctx.sessionManager.getSessionId().split("-")[0] ?? "current-session";
 	const modelId = ctx.model?.id ?? "no-model";
 	const thinkingLevel = ctx.getThinkingLevel?.() ?? "medium";
-	const themeName = (ctx.ui.theme as { name?: string } | undefined)?.name ?? "cathedral";
+	// Read from the SumoCode theme registry, not `ctx.ui.theme`. Pi's theme API
+	// only knows its own built-ins (catppuccin/dracula), so for SumoCode-only
+	// themes (e.g. `obsidian`) Pi rejects `setTheme` and `ctx.ui.theme.name`
+	// stays on the previous Pi theme. The SumoCode registry is the authoritative
+	// source of truth for which theme is currently rendering.
+	const themeName = getActiveTheme().name;
 
 	return {
 		searchQuery: "",

--- a/src/footer.test.ts
+++ b/src/footer.test.ts
@@ -118,12 +118,14 @@ describe("formatFooterLine — F1 two-zone layout", () => {
 		expect(line.length).toBeLessThanOrEqual(50);
 	});
 
-	it("adds one-cell side padding for portrait footer rhythm", () => {
-		const line = withoutAnsi(formatFooterLine(snapshot(), 60));
-		expect(line).toHaveLength(60);
-		expect(line.startsWith(" ")).toBe(true);
-		expect(line.endsWith(" ")).toBe(true);
-		expect(line.trim()).toContain(VOICE.status.idle);
+	it("adds one-cell side padding for footer rhythm", () => {
+		for (const width of [60, 160]) {
+			const line = withoutAnsi(formatFooterLine(snapshot(), width));
+			expect(line).toHaveLength(width);
+			expect(line.startsWith(" ")).toBe(true);
+			expect(line.endsWith(" ")).toBe(true);
+			expect(line.trim()).toContain(VOICE.status.idle);
+		}
 	});
 });
 

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -47,7 +47,7 @@ type GitRunner = (args: string[], cwd: string) => string;
 const RESET = "\u001b[0m";
 const SPLASH_VERSION_TOP_GAP_ROWS = 2;
 const SPLASH_VERSION_BOTTOM_GAP_ROWS = 7;
-const PORTRAIT_FOOTER_PAD_WIDTH = 80;
+const FOOTER_HORIZONTAL_PADDING = 1;
 
 export function colorHex(text: string, hex: string): string {
 	const normalized = hex.replace("#", "");
@@ -99,11 +99,11 @@ export function resolveGitBranch(cwd: string, runGit: GitRunner = defaultGitRunn
  * when the sidebar is hidden.
  */
 export function formatFooterLine(snapshot: FooterSnapshot, width = 160): string {
-	const compactPad = width > 2 && width < PORTRAIT_FOOTER_PAD_WIDTH;
-	const contentWidth = compactPad ? width - 2 : width;
+	const pad = width > FOOTER_HORIZONTAL_PADDING * 2 ? FOOTER_HORIZONTAL_PADDING : 0;
+	const contentWidth = Math.max(0, width - pad * 2);
 	const inner = formatFooterLineInner(snapshot, contentWidth);
-	if (!compactPad) return inner;
-	return ` ${padAnsiToWidth(inner, contentWidth)} `;
+	if (pad === 0) return inner;
+	return `${" ".repeat(pad)}${padAnsiToWidth(inner, contentWidth)}${" ".repeat(pad)}`;
 }
 
 function padAnsiToWidth(line: string, width: number): string {

--- a/src/sumo-tui/pi-compat/extension-ui-adapter.ts
+++ b/src/sumo-tui/pi-compat/extension-ui-adapter.ts
@@ -63,7 +63,7 @@ export interface SumoExtensionUIAdapterOptions {
 }
 
 type TerminalInputHandler = Parameters<ExtensionUIContext["onTerminalInput"]>[0];
-type EditorFactory = NonNullable<ReturnType<ExtensionUIContext["getEditorComponent"]>>;
+type EditorFactory = Parameters<ExtensionUIContext["setEditorComponent"]>[0];
 
 class OverlayComponentWrapper implements Component {
 	private hidden = false;

--- a/src/sumo-tui/pi-compat/owned-shell-renderer.test.ts
+++ b/src/sumo-tui/pi-compat/owned-shell-renderer.test.ts
@@ -51,7 +51,7 @@ describe("ownedShellEnabled", () => {
 });
 
 describe("OwnedShellRenderer", () => {
-	it("composes the #161 column tree with the footer pinned to the last row", async () => {
+	it("composes the #161 column tree with the footer pinned to the bottom block", async () => {
 		const yoga = await loadYoga();
 		const chat = ChatPager.create(yoga);
 		const fakeTerminal = new FakeTerminal();
@@ -73,18 +73,53 @@ describe("OwnedShellRenderer", () => {
 		expect(lines[0]?.startsWith("TOP")).toBe(true);
 		// title bar is separated from chat/sidebar by one breathing row
 		expect(lines[1]?.trim()).toBe("");
-		// footer is pinned above the terminal-bottom safe row
-		expect(lines[10]?.startsWith("FOOTER")).toBe(true);
-		expect(lines[11]?.trim()).toBe("");
-		// hint is separated from footer by one breathing row
-		expect(lines[8]?.startsWith("HINT")).toBe(true);
-		expect(lines[9]?.trim()).toBe("");
-		// editor occupies 3 rows above hint (rows 5..7), hint=8, footer=10
-		expect(lines[5]?.startsWith("┌")).toBe(true);
-		expect(lines[7]?.startsWith("└")).toBe(true);
-		// blank row above editor
-		expect(lines[4]?.trim()).toBe("");
+		// footer is restored in the bottom block
+		expect(lines.some((line) => line.startsWith("FOOTER"))).toBe(true);
+		// hint remains below editor, separated from footer by the gap row.
+		expect(lines.some((line) => line.startsWith("HINT"))).toBe(true);
+		// editor frame remains present above hint.
+		expect(lines.some((line) => line.startsWith("┌"))).toBe(true);
+		expect(lines.some((line) => line.startsWith("└"))).toBe(true);
 
+		renderer.dispose();
+	});
+
+	// Regression for the working-indicator-invisible report:
+	// 1. OwnedShell needs a slot that paints `widgetContainerAbove` (the
+	//    `setWidget(... aboveEditor)` mount point) — without it the indicator
+	//    is registered but never rendered.
+	// 2. Pi's `renderWidgetContainer(... leadingSpacer=true)` always prepends a
+	//    `Spacer(1)` line, so the widget's content lives on row 2 of the
+	//    container output. Our 1-row above-editor leaf must drop that leading
+	//    line or the widget gets clipped and the row appears blank.
+	// 3. Breathing rows are preserved on both sides of the indicator slot, so an
+	//    active spinner does not crowd either the chat content or the editor frame.
+	it("renders Pi widgetContainerAbove children between breathing rows, dropping the leading Spacer line", async () => {
+		const yoga = await loadYoga();
+		const chat = ChatPager.create(yoga);
+		const fakeTerminal = new FakeTerminal();
+
+		const renderer = new OwnedShellRenderer({
+			yoga,
+			chat,
+			editorContainer: () => new StaticEditor() as Component,
+			headerContainer: () => new StaticComponent(["TOP"]),
+			widgetContainerBelow: () => new StaticComponent(["HINT"]),
+			widgetContainerAbove: () => new StaticComponent(["SPACER-LEAD", "WORKING"]),
+			footer: () => new StaticComponent(["FOOTER"]),
+			terminal: fakeTerminal.owner,
+			dimensions: { columns: 24, rows: 13 },
+		});
+
+		renderer.render();
+		const lines = fakeTerminal.patches.map((patch) => stripAnsi(patch.ansi));
+		const workingRow = lines.findIndex((line) => line.startsWith("WORKING"));
+		expect(workingRow).toBeGreaterThan(0);
+		// The widget's second line (`WORKING`) must paint, not Pi's leading spacer
+		// (`SPACER-LEAD`), and it must breathe on both sides.
+		expect(lines[workingRow - 1]?.trim()).toBe("");
+		expect(lines[workingRow + 1]?.trim()).toBe("");
+		expect(lines.join("\n")).not.toContain("SPACER-LEAD");
 		renderer.dispose();
 	});
 
@@ -123,7 +158,7 @@ describe("OwnedShellRenderer", () => {
 			widgetContainerBelow: () => new StaticComponent(["HINT"]),
 			footer: () => new StaticComponent(["FOOTER"]),
 			terminal: fakeTerminal.owner,
-			dimensions: { columns: 80, rows: 12 },
+			dimensions: { columns: 80, rows: 14 },
 			sidebarPublication: () => ({
 				component: new StaticComponent(["SIDE"]),
 				isVisible: () => true,
@@ -134,7 +169,7 @@ describe("OwnedShellRenderer", () => {
 		const lines = fakeTerminal.patches.map((patch) => stripAnsi(patch.ansi));
 		expect(lines[0]?.startsWith("TOP")).toBe(true);
 		expect(lines[1]?.trim()).toBe("");
-		expect(lines[2]).toContain("SIDE");
+		expect(lines.slice(2).some((line) => line.includes("SIDE"))).toBe(true);
 		renderer.dispose();
 	});
 

--- a/src/sumo-tui/pi-compat/owned-shell-renderer.ts
+++ b/src/sumo-tui/pi-compat/owned-shell-renderer.ts
@@ -84,6 +84,14 @@ export interface OwnedShellRendererOptions {
 	/** Retained top chrome published by `installTopChrome`; falls back to Pi's header container during tests/startup. */
 	readonly topChromePublication?: () => TopChromePublication | undefined;
 	readonly widgetContainerBelow: () => Component;
+	/**
+	 * Lazy resolver for Pi's `widgetContainerAbove` (the slot that hosts
+	 * extension widgets registered with `setWidget(..., { placement: "aboveEditor" })`,
+	 * including the SumoCode working indicator). Optional for backward
+	 * compatibility — owned-shell tests and host environments that don't expose
+	 * a Pi-style `widgetContainerAbove` get a static blank single-row leaf.
+	 */
+	readonly widgetContainerAbove?: () => Component;
 	/** Resolves to Pi's pending-messages container (queued steer/follow-up messages). */
 	readonly pendingMessagesContainer?: () => Component;
 	/** Resolves to the currently mounted footer (custom extension footer or Pi built-in). */
@@ -146,14 +154,33 @@ export class OwnedShellRenderer {
 	private readonly chatRow: SumoNode;
 	private readonly sidebarGutter: SumoNode;
 	private readonly sidebarLeaf: PiComponentLeaf;
-	private readonly blankSpacer: SumoNode;
+	/**
+	 * Always-blank 1-row breathing spacer between the chat region and the
+	 * above-editor widget slot. Keeps transient activity chrome from crowding
+	 * the final chat message.
+	 */
+	private readonly aboveIndicatorSpacer: SumoNode;
+	/**
+	 * Always-blank 1-row breathing spacer between the above-editor widget slot
+	 * and the editor. Preserves the V2 Bible contract that transient activity
+	 * chrome (notably the working indicator) does not crowd the editor frame.
+	 */
+	private readonly belowIndicatorSpacer: SumoNode;
+	/**
+	 * 1-row leaf above the editor. Wraps Pi's `widgetContainerAbove` so widgets
+	 * registered with `setWidget(... "aboveEditor")` (notably the working
+	 * indicator) actually paint inside the owned shell. Renders an empty row
+	 * when no widget is mounted (or the widget reports idle).
+	 */
+	private readonly aboveEditorLeaf: PiComponentLeaf;
+	private readonly hasAboveEditorContainer: boolean;
 	private readonly footerGapSpacer: SumoNode;
 	private readonly bottomSafeSpacer: SumoNode;
 	private readonly chat: ChatPager;
 	private readonly splash: SplashTree | undefined;
 	private mountedChatChild: "chat" | "splash" | undefined;
 	private mountedSidebar = false;
-	private inputMountedInSplash = false;
+	private inputMountedInSplash: boolean | undefined;
 	private disposed = false;
 
 	public constructor(options: OwnedShellRendererOptions) {
@@ -203,11 +230,50 @@ export class OwnedShellRenderer {
 		this.sidebarLeaf.flexShrink = 0;
 		this.syncChatRowChildren(this.dimensions.columns ?? 80, this.dimensions.rows ?? 24);
 
-		// 3) blank breathing row above input
-		this.blankSpacer = new SumoNode(this.yoga.Node.create(), this.root);
-		this.blankSpacer.height = SHELL_BLANK_ROW;
+		// 3) blank breathing row above the activity slot.
+		this.aboveIndicatorSpacer = new SumoNode(this.yoga.Node.create(), this.root);
+		this.aboveIndicatorSpacer.height = SHELL_BLANK_ROW;
 
-		// 3b) pending messages — painted into the blank spacer row during composite,
+		// 3b) above-editor row — hosts Pi's `widgetContainerAbove` (the slot for
+		//     `setWidget(... "aboveEditor")` widgets such as the working indicator).
+		//
+		//     Pi's `renderWidgetContainer(... leadingSpacer=true)` injects a leading
+		//     `Spacer(1)` before the first widget, so `widgetContainerAbove.render(w)`
+		//     returns `[<spacer line>, <widget line(s)>…]`. We already have a
+		//     dedicated breathing row above this leaf, so Pi's spacer would push the
+		//     widget into a clipped row 2. Drop Pi's leading line so the widget
+		//     paints into row 1 of the leaf.
+		//
+		//    Defaults to a static empty 1-row component when the host doesn't
+		//    expose a Pi-style above-editor container.
+		this.hasAboveEditorContainer = options.widgetContainerAbove !== undefined;
+		const aboveSource: Component | undefined = this.hasAboveEditorContainer
+			? (new LazyComponentProxy(options.widgetContainerAbove!) as unknown as Component)
+			: undefined;
+		const aboveProxy: Component = aboveSource
+			? {
+					render: (w: number) => {
+						const raw = aboveSource.render(w);
+						// Drop Pi's leading Spacer(1). If nothing remains, no above-editor
+						// widget is installed, so collapse to zero rows. If a widget remains
+						// but renders blank (the retained working indicator's idle state),
+						// still reserve the same breathing + widget + breathing block so
+						// agent_start/agent_end does not shift the editor/footer.
+						const content = raw.length > 1 ? raw.slice(1) : [];
+						return content.length > 0 ? ["", ...content, ""] : [];
+					},
+					invalidate: () => aboveSource.invalidate?.(),
+				}
+			: { render: (_w: number) => [], invalidate: () => undefined };
+		this.aboveEditorLeaf = PiComponentLeaf.create(this.yoga, aboveProxy, this.root);
+
+		// 3c) blank breathing row — always 1 empty row between the above-editor
+		//     widget slot and the editor. This is the row that keeps `Working…`
+		//     from visually touching the input frame while the agent is busy.
+		this.belowIndicatorSpacer = new SumoNode(this.yoga.Node.create(), this.root);
+		this.belowIndicatorSpacer.height = SHELL_BLANK_ROW;
+
+		// 3d) pending messages — painted into the lower blank spacer row during composite,
 		// NOT a separate Yoga leaf. This avoids vertical layout shift when messages
 		// are queued.
 		this.resolvePendingMessages = options.pendingMessagesContainer;
@@ -283,7 +349,9 @@ export class OwnedShellRenderer {
 		if (centerWithSplash === this.inputMountedInSplash) return;
 
 		const movableNodes: SumoNode[] = [
-			this.blankSpacer,
+			this.aboveIndicatorSpacer,
+			this.aboveEditorLeaf,
+			this.belowIndicatorSpacer,
 			this.editorRow,
 			this.hintLeaf,
 			this.footerGapSpacer,
@@ -296,7 +364,12 @@ export class OwnedShellRenderer {
 
 		if (centerWithSplash && this.splash) {
 			if (this.splash.bottomSpacer.parent === this.splash.root) this.splash.root.removeChild(this.splash.bottomSpacer);
-			this.splash.root.addChild(this.blankSpacer);
+			// Splash mode never shows the working indicator (no agent activity yet),
+			// so the above-editor leaf stays detached and only one breathing row
+			// is mounted. Restore this shared spacer because the active branch may
+			// collapse it to zero height when the host exposes widgetContainerAbove.
+			this.belowIndicatorSpacer.height = SHELL_BLANK_ROW;
+			this.splash.root.addChild(this.belowIndicatorSpacer);
 			this.splash.root.addChild(this.editorRow);
 			this.splash.root.addChild(this.hintLeaf);
 			this.splash.root.addChild(this.splash.bottomSpacer);
@@ -305,7 +378,9 @@ export class OwnedShellRenderer {
 			this.root.addChild(this.bottomSafeSpacer);
 		} else {
 			if (this.splash && this.splash.bottomSpacer.parent !== this.splash.root) this.splash.root.addChild(this.splash.bottomSpacer);
-			this.root.addChild(this.blankSpacer);
+			if (this.hasAboveEditorContainer) this.root.addChild(this.aboveEditorLeaf);
+			this.belowIndicatorSpacer.height = this.hasAboveEditorContainer ? 0 : SHELL_BLANK_ROW;
+			this.root.addChild(this.belowIndicatorSpacer);
 			this.root.addChild(this.editorRow);
 			this.root.addChild(this.hintLeaf);
 			this.root.addChild(this.footerGapSpacer);
@@ -433,7 +508,9 @@ export class OwnedShellRenderer {
 				chat: this.nodeRect(this.chat),
 				sidebarGutter: this.nodeRect(this.sidebarGutter),
 				sidebar: this.nodeRect(this.sidebarLeaf),
-				inputSpacer: this.nodeRect(this.blankSpacer),
+				inputSpacer: this.nodeRect(this.belowIndicatorSpacer),
+				aboveEditorSpacer: this.nodeRect(this.aboveIndicatorSpacer),
+				aboveEditor: this.nodeRect(this.aboveEditorLeaf),
 				editorRow: this.nodeRect(this.editorRow),
 				editor: this.nodeRect(this.editorLeaf),
 				hint: this.nodeRect(this.hintLeaf),
@@ -590,7 +667,9 @@ export class OwnedShellRenderer {
 		this.editorLeaf.dispose();
 		this.hintLeaf.dispose();
 		this.footerLeaf.dispose();
-		this.blankSpacer.dispose();
+		this.aboveIndicatorSpacer.dispose();
+		this.aboveEditorLeaf.dispose();
+		this.belowIndicatorSpacer.dispose();
 		this.footerGapSpacer.dispose();
 		this.bottomSafeSpacer.dispose();
 		// Chat + splash are owned by SumoInteractiveRuntime; only detach.

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -679,6 +679,7 @@ export class SumoInteractiveMode {
 			editorContainer?: unknown;
 			headerContainer?: unknown;
 			widgetContainerBelow?: unknown;
+			widgetContainerAbove?: unknown;
 			pendingMessagesContainer?: unknown;
 			footer?: unknown;
 			customFooter?: unknown;
@@ -701,6 +702,7 @@ export class SumoInteractiveMode {
 				hasEditorContainer: host.editorContainer !== undefined,
 				hasHeader: host.headerContainer !== undefined,
 				hasHint: host.widgetContainerBelow !== undefined,
+				hasAbove: host.widgetContainerAbove !== undefined,
 				hasFooter: footerComponent !== undefined,
 			});
 			return;
@@ -722,6 +724,7 @@ export class SumoInteractiveMode {
 			headerContainer: () => host.headerContainer as never,
 			topChromePublication: () => this.retainedRuntime.getTopChromePublication(),
 			widgetContainerBelow: () => host.widgetContainerBelow as never,
+			widgetContainerAbove: host.widgetContainerAbove ? (() => host.widgetContainerAbove as never) : undefined,
 			pendingMessagesContainer: host.pendingMessagesContainer ? (() => host.pendingMessagesContainer as never) : undefined,
 			footer: () => (host.customFooter ?? host.footer) as never,
 			terminal: this.retainedRuntime.getTerminalSessionOwner(),

--- a/src/working-indicator.ts
+++ b/src/working-indicator.ts
@@ -211,15 +211,19 @@ export function isRetainedMode(env: NodeJS.ProcessEnv = process.env): boolean {
  */
 export function installWorkingIndicator(pi: ExtensionAPI): void {
 	let component: WorkingIndicatorComponent | undefined;
+	let classicThemeUnsubscribe: (() => void) | undefined;
 
 	pi.on("session_start", (_event, ctx) => {
 		if (!ctx.hasUI) return;
+		classicThemeUnsubscribe?.();
+		classicThemeUnsubscribe = undefined;
 		if (!shouldInstallWorkingIndicator()) return;
 
 		if (isRetainedMode()) {
 			// Retained SumoTUI owns the chrome. Hide Pi's inline loader row and
 			// drive a theme-aware widget above the editor instead.
-			if (typeof ctx.ui.setWorkingVisible === "function") ctx.ui.setWorkingVisible(false);
+			const workingUi = ctx.ui as { setWorkingVisible?: (visible: boolean) => void };
+			if (typeof workingUi.setWorkingVisible === "function") workingUi.setWorkingVisible(false);
 			else ctx.ui.setWorkingIndicator({ frames: [] });
 			ctx.ui.setWidget(
 				WORKING_INDICATOR_WIDGET_KEY,
@@ -233,12 +237,17 @@ export function installWorkingIndicator(pi: ExtensionAPI): void {
 			return;
 		}
 
-		// Classic Pi: forward our frames to Pi's inline indicator.
-		const theme = getActiveTheme();
-		ctx.ui.setWorkingIndicator({
-			frames: buildActiveThemeIndicatorFrames(),
-			intervalMs: theme.workingIndicator.intervalMs,
-		});
+		// Classic Pi: forward our frames to Pi's inline indicator and refresh them
+		// when the SumoCode theme changes mid-session.
+		const applyClassicIndicator = (): void => {
+			const theme = getActiveTheme();
+			ctx.ui.setWorkingIndicator({
+				frames: buildActiveThemeIndicatorFrames(),
+				intervalMs: theme.workingIndicator.intervalMs,
+			});
+		};
+		applyClassicIndicator();
+		classicThemeUnsubscribe = onThemeChanged(applyClassicIndicator);
 	});
 
 	pi.on("agent_start", () => component?.start());
@@ -246,5 +255,7 @@ export function installWorkingIndicator(pi: ExtensionAPI): void {
 	pi.on("session_shutdown", () => {
 		component?.dispose();
 		component = undefined;
+		classicThemeUnsubscribe?.();
+		classicThemeUnsubscribe = undefined;
 	});
 }


### PR DESCRIPTION
## Summary

Closes #216.

Adds the **Obsidian** theme (sacred-tech, deep obsidian altar with bronze body / electrum gold / lapis cyan accents) and restores the theme-aware working indicator above the editor.

## Implementation

### Obsidian theme (`src/themes/obsidian.ts`)

13-token palette mapped from `docs/ui/stitch/obsidian-temple/DESIGN.md`. Tuned for visibly distinct read against Cathedral on dark terminal calibrations:

| Token | Value | Notes |
|---|---|---|
| `background` | `#050308` | deep obsidian, near-black violet undertone |
| `surface` | `#15082A` | violet polished granite — sidebar pops away from main |
| `surfaceRecess` | `#020104` | input prompt void |
| `surfaceLifted` | `#1F0F2E` | saturated violet stone for modals/overlays |
| `foreground` | `#D4B896` | aged papyrus / warm bronze |
| `foregroundDim` | `#8B7355` | oxidized bronze |
| `divider` | `#3A2750` | brighter violet so frames register on obsidian ground |
| `accent` | `#FFD700` | sacred gold (cartouche, accents) |
| `states.idle` | `#00C896` | malachite life |
| `states.thinking` | `#00E5FF` | neon cyan — thinking ignition |
| `states.tool` | `#F0B400` | electrum gold |
| `states.approval` | `#B91C1C` | carnelian |
| `states.learning` | `#FF00AA` | neon magenta — sacred memory writes |

### Working indicator widget (`src/working-indicator.ts`)

- Theme-aware retained widget mounted above editor in `SUMO_TUI=1` mode.
- Cycles with the active theme: Cathedral `◌ ✦ ❖ ✺ ❋ ❉` @ 150ms, Obsidian `▫ ◇ ◈ ◉ ⊛ ⊚` @ 180ms (slower ritual cadence).
- Subscribes to `onThemeChanged` so frame glyphs and accent color swap immediately on theme cycle.
- Driven from `agent_start` / `agent_end` events (busy when streaming, idle otherwise).

### Theme-change repaint (the hard part)

Switching themes had a subtle bug: SumoInteractiveMode and the extension code each got a **separate copy** of the theme registry because the retained `sumo-interactive-mode.js` jiti loader uses `moduleCache: false`. `setActiveTheme` fired listeners on copy B; SumoInteractiveMode subscribed on copy A → never invoked → no repaint.

Fix:

1. **Pinned the registry state** (`registry`, `listeners`, `activeThemeName`, `themeVersion`) on `globalThis[Symbol.for("sumocode.themeRegistry")]`. Same pattern as `ACTIVE_SUMO_RUNTIME_KEY` and the diagnostics singleton.
2. **SumoInteractiveMode now subscribes to `onThemeChanged`** and on each theme switch:
   - invalidates `OwnedShellRenderer.previousFrame` (busts cell-diff so all cells re-emit ANSI)
   - calls `retainedRuntime.requestRender()` (busts chat frame cache)
   - calls upstream `ui.requestRender(true)` (full pi-tui clear+repaint)
   - schedules an immediate `ownedShell.render()` on next tick

### `applyKnownTheme` decoupled from Pi theme system

SumoCode registry is the authoritative source of truth for SumoCode chrome. Pi `setTheme` is opportunistic — its rejection (Pi only knows its own built-in themes) is a soft side-channel warning, not a block.

## Verification

Node-pty test at 160 cols (sidebar visible) after `/sumo:theme obsidian`:

| Token | Cells emitted |
|---|---|
| bg `#050308` | 173 |
| surface `#15082A` (sidebar) | 115 |
| surfaceRecess `#020104` (input) | 9 |
| accent `#FFD700` sacred gold | 8 |
| foreground `#D4B896` bronze | 171 |
| divider `#3A2750` violet | 38 |
| thinking `#00E5FF` cyan | 4 |
| Cathedral bg leftovers | **0** |

- `pnpm exec tsc --noEmit` ✅
- `pnpm build` ✅
- `pnpm test` ✅ — 101 files / 737 tests
- `pnpm test:integration` ✅ — 16 files / 22 tests
- Manual end-to-end via `bin/sumocode.sh` confirmed by user

## Out of scope

- CRT scanlines, chromatic aberration, neon text-shadow glows are HTML-only effects from the Stitch spec; intentionally absent in the terminal port.
- Pi `setTheme` returns `Theme not found: obsidian` because Pi only knows its built-in themes — this is the documented opportunistic-only behavior. Surfaced as a non-fatal `(Pi theme not found: …)` line in the result card.