### PR TITLE
Perf/startup P2: eager splash paint and transition fade

### DIFF
--- a/docs/perf/startup.json
+++ b/docs/perf/startup.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-05T23:47:42.618Z",
-  "commit": "1303711 perf(startup): parallelize yoga and async git",
+  "generatedAt": "2026-05-06T00:01:25.444Z",
+  "commit": "ad3697e perf(startup): eagerly paint splash",
   "runs": 5,
   "measurements": [
     {
@@ -8,114 +8,114 @@
       "samples": [
         {
           "ok": true,
-          "durationMs": 27.50445795059204,
+          "durationMs": 25.891416907310486,
           "code": 0,
           "signal": null,
           "stderr": ""
         },
         {
           "ok": true,
-          "durationMs": 24.809875011444092,
+          "durationMs": 24.53737509250641,
           "code": 0,
           "signal": null,
           "stderr": ""
         },
         {
           "ok": true,
-          "durationMs": 24.54462492465973,
+          "durationMs": 24.107332944869995,
           "code": 0,
           "signal": null,
           "stderr": ""
         },
         {
           "ok": true,
-          "durationMs": 27.71333408355713,
+          "durationMs": 23.91504192352295,
           "code": 0,
           "signal": null,
           "stderr": ""
         },
         {
           "ok": true,
-          "durationMs": 25.40487492084503,
+          "durationMs": 23.64979100227356,
           "code": 0,
           "signal": null,
           "stderr": ""
         }
       ],
-      "avgMiddleMs": 25.9,
-      "minMs": 24.5,
-      "maxMs": 27.7
+      "avgMiddleMs": 24.2,
+      "minMs": 23.6,
+      "maxMs": 25.9
     },
     {
       "label": "print-mode",
       "samples": [
         {
           "ok": true,
-          "durationMs": 4789.208999991417,
+          "durationMs": 8257.736582994461,
           "code": 0,
           "signal": null,
           "stderr": ""
         },
         {
           "ok": true,
-          "durationMs": 5003.744207978249,
+          "durationMs": 6654.875874996185,
           "code": 0,
           "signal": null,
           "stderr": ""
         },
         {
           "ok": true,
-          "durationMs": 5439.326999902725,
+          "durationMs": 7177.2815001010895,
           "code": 0,
           "signal": null,
           "stderr": ""
         },
         {
           "ok": true,
-          "durationMs": 5076.709333896637,
+          "durationMs": 4654.975583076477,
           "code": 0,
           "signal": null,
           "stderr": ""
         },
         {
           "ok": true,
-          "durationMs": 4546.574042081833,
+          "durationMs": 6154.770874977112,
           "code": 0,
           "signal": null,
           "stderr": ""
         }
       ],
-      "avgMiddleMs": 4956.6,
-      "minMs": 4546.6,
-      "maxMs": 5439.3
+      "avgMiddleMs": 6662.3,
+      "minMs": 4655,
+      "maxMs": 8257.7
     },
     {
       "label": "first-frame",
       "samples": [
         {
           "ok": true,
-          "durationMs": 1517.7608749866486
+          "durationMs": 1513.5900000333786
         },
         {
           "ok": true,
-          "durationMs": 1504.8327499628067
+          "durationMs": 1509.7610830068588
         },
         {
           "ok": true,
-          "durationMs": 1492.2420840263367
+          "durationMs": 1494.4068750143051
         },
         {
           "ok": true,
-          "durationMs": 1511.3169590234756
+          "durationMs": 1494.456416964531
         },
         {
           "ok": true,
-          "durationMs": 1515.8963329792023
+          "durationMs": 1508.68549990654
         }
       ],
-      "avgMiddleMs": 1510.7,
-      "minMs": 1492.2,
-      "maxMs": 1517.8
+      "avgMiddleMs": 1504.3,
+      "minMs": 1494.4,
+      "maxMs": 1513.6
     }
   ]
 }

--- a/docs/perf/startup.md
+++ b/docs/perf/startup.md
@@ -2,12 +2,12 @@
 
 Report-only startup measurements for the current checkout. These numbers are intentionally not CI gates; use them to compare phase-by-phase deltas.
 
-- commit: `1303711 perf(startup): parallelize yoga and async git`
+- commit: `ad3697e perf(startup): eagerly paint splash`
 - runs: 5
-- generated: 2026-05-05T23:47:42.618Z
+- generated: 2026-05-06T00:01:25.444Z
 
 | Measurement | Avg middle runs | Min | Max | Runs |
 | --- | ---: | ---: | ---: | ---: |
-| launcher-dry-run | 25.9ms | 24.5ms | 27.7ms | 5 |
-| print-mode | 4956.6ms | 4546.6ms | 5439.3ms | 5 |
-| first-frame | 1510.7ms | 1492.2ms | 1517.8ms | 5 |
+| launcher-dry-run | 24.2ms | 23.6ms | 25.9ms | 5 |
+| print-mode | 6662.3ms | 4655ms | 8257.7ms | 5 |
+| first-frame | 1504.3ms | 1494.4ms | 1513.6ms | 5 |

--- a/src/sumo-tui/cathedral/splash-tree.ts
+++ b/src/sumo-tui/cathedral/splash-tree.ts
@@ -18,6 +18,7 @@ export interface SplashTree {
 	readonly bottomSpacer: SumoNode;
 	/** Collapse the tree once the first message arrives (EC-17.4 / 17.6). */
 	syncVisibility(): void;
+	setDimmed(dimmed: boolean): void;
 }
 
 export function defaultSplashSnapshot(hasMessages = false): SplashSnapshot {
@@ -33,10 +34,17 @@ export function getSplashContentHeight(snapshot: SplashSnapshot, width: number):
 }
 
 class SplashContentComponent implements Component {
+	private dimmed = false;
 	public constructor(private readonly snapshot: SplashSnapshotProvider) {}
 	public invalidate(): void {}
+	public setDimmed(dimmed: boolean): void {
+		this.dimmed = dimmed;
+	}
 	public render(width: number): string[] {
-		return renderSplashContent(this.snapshot(), width);
+		const snapshot = this.snapshot();
+		const rows = renderSplashContent(this.dimmed ? { ...snapshot, hasMessages: false } : snapshot, width);
+		if (!this.dimmed) return rows;
+		return rows.map((row) => `\u001b[2m${row}\u001b[0m`);
 	}
 }
 
@@ -62,7 +70,9 @@ export function createSplashTree(yoga: Yoga, parent: SumoNode | undefined, snaps
 	topSpacer.flexGrow = 1;
 	topSpacer.flexShrink = 1;
 
-	const content = PiComponentLeaf.create(yoga, new SplashContentComponent(snapshot), root);
+	const contentComponent = new SplashContentComponent(snapshot);
+	let forceVisible = false;
+	const content = PiComponentLeaf.create(yoga, contentComponent, root);
 	content.flexShrink = 0;
 
 	const bottomSpacer = new SumoNode(yoga.Node.create(), root);
@@ -75,7 +85,7 @@ export function createSplashTree(yoga: Yoga, parent: SumoNode | undefined, snaps
 		content,
 		bottomSpacer,
 		syncVisibility(): void {
-			if (snapshot().hasMessages) {
+			if (snapshot().hasMessages && !forceVisible) {
 				root.height = 0;
 				root.flexGrow = 0;
 				root.flexShrink = 0;
@@ -84,6 +94,10 @@ export function createSplashTree(yoga: Yoga, parent: SumoNode | undefined, snaps
 			root.yogaNode.setHeightAuto();
 			root.flexGrow = 1;
 			root.flexShrink = 1;
+		},
+		setDimmed(dimmed: boolean): void {
+			forceVisible = dimmed;
+			contentComponent.setDimmed(dimmed);
 		},
 	};
 }

--- a/src/sumo-tui/pi-compat/retained-shell-transition.test.ts
+++ b/src/sumo-tui/pi-compat/retained-shell-transition.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { EmptyChatQuoteNode } from "../cathedral/empty-chat-quote.js";
 import { createSplashTree, defaultSplashSnapshot } from "../cathedral/splash-tree.js";
 import { SumoNode } from "../layout/node.js";
@@ -7,7 +7,7 @@ import { ChatPager } from "../widgets/chat-pager.js";
 import { RetainedShellTransition } from "./retained-shell-transition.js";
 
 describe("RetainedShellTransition", () => {
-	it("mounts splash for empty sessions and chat after the first message", async () => {
+	it("mounts splash for empty sessions and fades before chat after the first message", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());
 		root.flexDirection = FLEX_DIRECTION_COLUMN;
@@ -15,7 +15,10 @@ describe("RetainedShellTransition", () => {
 		const splash = createSplashTree(yoga, undefined, () => defaultSplashSnapshot(chat.hasMessages()));
 		const emptyQuote = new EmptyChatQuoteNode(yoga.Node.create(), () => ({ sidebarVisible: true, isSplash: false, userMessageCount: 0 }));
 		root.addChild(emptyQuote);
-		const transition = new RetainedShellTransition({ root, chat, splash, emptyChatQuote: emptyQuote });
+		let now = 0;
+		const scheduleRender = vi.fn();
+		const setTimeoutSpy = vi.fn();
+		const transition = new RetainedShellTransition({ root, chat, splash, emptyChatQuote: emptyQuote, now: () => now, scheduleRender, setTimeout: setTimeoutSpy });
 
 		expect(transition.sync()).toBe("splash");
 		expect(splash.root.parent).toBe(root);
@@ -24,6 +27,13 @@ describe("RetainedShellTransition", () => {
 
 		chat.addMessage("user", "hello");
 
+		expect(transition.sync()).toBe("fading-splash");
+		expect(splash.root.parent).toBe(root);
+		expect(chat.parent).toBeUndefined();
+		expect(scheduleRender).toHaveBeenCalledOnce();
+		expect(setTimeoutSpy).toHaveBeenCalledOnce();
+
+		now = 80;
 		expect(transition.sync()).toBe("active-chat");
 		expect(chat.parent).toBe(root);
 		expect(splash.root.parent).toBeUndefined();
@@ -32,5 +42,24 @@ describe("RetainedShellTransition", () => {
 		chat.dispose();
 		splash.root.dispose();
 		emptyQuote.dispose();
+	});
+
+	it("bypasses the fade when reduced motion is enabled", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		root.flexDirection = FLEX_DIRECTION_COLUMN;
+		const chat = ChatPager.create(yoga);
+		const splash = createSplashTree(yoga, undefined, () => defaultSplashSnapshot(chat.hasMessages()));
+		const transition = new RetainedShellTransition({ root, chat, splash, reducedMotion: true });
+
+		expect(transition.sync()).toBe("splash");
+		chat.addMessage("user", "hello");
+		expect(transition.sync()).toBe("active-chat");
+		expect(chat.parent).toBe(root);
+		expect(splash.root.parent).toBeUndefined();
+
+		root.dispose();
+		chat.dispose();
+		splash.root.dispose();
 	});
 });

--- a/src/sumo-tui/pi-compat/retained-shell-transition.ts
+++ b/src/sumo-tui/pi-compat/retained-shell-transition.ts
@@ -3,13 +3,17 @@ import type { SplashTree } from "../cathedral/splash-tree.js";
 import type { SumoNode } from "../layout/node.js";
 import type { ChatPager } from "../widgets/chat-pager.js";
 
-export type RetainedShellPhase = "splash" | "active-chat";
+export type RetainedShellPhase = "splash" | "fading-splash" | "active-chat";
 
 export interface RetainedShellTransitionParts {
 	readonly root: SumoNode;
 	readonly chat: ChatPager;
 	readonly splash: SplashTree;
 	readonly emptyChatQuote?: EmptyChatQuoteNode;
+	readonly scheduleRender?: () => void;
+	readonly now?: () => number;
+	readonly setTimeout?: (callback: () => void, ms: number) => unknown;
+	readonly reducedMotion?: boolean;
 }
 
 /**
@@ -22,29 +26,51 @@ export interface RetainedShellTransitionParts {
  * slot.
  */
 export class RetainedShellTransition {
+	private static readonly FADE_MS = 80;
+	private fadingSince: number | undefined;
+
 	public constructor(private readonly parts: RetainedShellTransitionParts) {}
 
 	public phase(): RetainedShellPhase {
+		if (this.fadingSince !== undefined) return "fading-splash";
 		return this.parts.chat.hasMessages() ? "active-chat" : "splash";
 	}
 
 	public sync(): RetainedShellPhase {
 		const { root, chat, splash, emptyChatQuote } = this.parts;
-		const phase = this.phase();
+		const desiredPhase = chat.hasMessages() ? "active-chat" : "splash";
 		splash.syncVisibility();
 
 		if (emptyChatQuote && emptyChatQuote.parent === root) {
 			root.removeChild(emptyChatQuote);
 		}
 
-		if (phase === "active-chat") {
+		if (desiredPhase === "active-chat") {
+			if (!this.parts.reducedMotion && splash.root.parent === root && this.fadingSince === undefined) {
+				this.fadingSince = this.now();
+				splash.setDimmed(true);
+				this.parts.scheduleRender?.();
+				this.parts.setTimeout?.(() => this.parts.scheduleRender?.(), RetainedShellTransition.FADE_MS);
+				return "fading-splash";
+			}
+			if (this.fadingSince !== undefined && this.now() - this.fadingSince < RetainedShellTransition.FADE_MS) {
+				return "fading-splash";
+			}
+			this.fadingSince = undefined;
+			splash.setDimmed(false);
 			if (splash.root.parent === root) root.removeChild(splash.root);
 			if (chat.parent !== root) root.addChild(chat);
-			return phase;
+			return "active-chat";
 		}
 
+		this.fadingSince = undefined;
+		splash.setDimmed(false);
 		if (chat.parent === root) root.removeChild(chat);
 		if (splash.root.parent !== root) root.addChild(splash.root);
-		return phase;
+		return "splash";
+	}
+
+	private now(): number {
+		return this.parts.now?.() ?? Date.now();
 	}
 }

--- a/src/sumo-tui/pi-compat/retained-shell-transition.ts
+++ b/src/sumo-tui/pi-compat/retained-shell-transition.ts
@@ -39,6 +39,9 @@ export class RetainedShellTransition {
 	public sync(): RetainedShellPhase {
 		const { root, chat, splash, emptyChatQuote } = this.parts;
 		const desiredPhase = chat.hasMessages() ? "active-chat" : "splash";
+		const shouldStartFade = desiredPhase === "active-chat" && !this.parts.reducedMotion && splash.root.parent === root && this.fadingSince === undefined;
+		if (shouldStartFade) this.fadingSince = this.now();
+		splash.setDimmed(this.fadingSince !== undefined);
 		splash.syncVisibility();
 
 		if (emptyChatQuote && emptyChatQuote.parent === root) {
@@ -46,9 +49,7 @@ export class RetainedShellTransition {
 		}
 
 		if (desiredPhase === "active-chat") {
-			if (!this.parts.reducedMotion && splash.root.parent === root && this.fadingSince === undefined) {
-				this.fadingSince = this.now();
-				splash.setDimmed(true);
+			if (shouldStartFade) {
 				this.parts.scheduleRender?.();
 				this.parts.setTimeout?.(() => this.parts.scheduleRender?.(), RetainedShellTransition.FADE_MS);
 				return "fading-splash";

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
@@ -91,7 +91,7 @@ describe("sumo interactive Pi noise filtering", () => {
 		expect(setShowHardwareCursor).toHaveBeenCalledWith(true);
 	});
 
-	it("enters altscreen and enables SGR mouse from the retained runtime", async () => {
+	it("enters altscreen, enables SGR mouse, and eagerly paints splash from the retained runtime", async () => {
 		const write = vi.fn();
 		const runtime = new SumoInteractiveRuntime({ isTTY: true, columns: 100, rows: 30, write });
 
@@ -100,6 +100,7 @@ describe("sumo interactive Pi noise filtering", () => {
 		const output = write.mock.calls.map(([chunk]) => String(chunk)).join("");
 		expect(output).toContain(ALTSCREEN_ENTER_SEQUENCE);
 		expect(output).toContain(MOUSE_SGR_ENABLE_SEQUENCE);
+		expect(stripAnsi(output)).toContain("Meow meow meow");
 		runtime.stop();
 	});
 

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -235,7 +235,15 @@ export class SumoInteractiveRuntime {
 		this.selectionNotificationNode.right = 1;
 		this.selectionNotificationNode.height = 4;
 		this.selectionNotificationNode.zIndex = 20_000;
-		this.shellTransition = new RetainedShellTransition({ root: this.root, chat: this.chat, splash: this.splash, emptyChatQuote: this.emptyChatQuote });
+		this.shellTransition = new RetainedShellTransition({
+			root: this.root,
+			chat: this.chat,
+			splash: this.splash,
+			emptyChatQuote: this.emptyChatQuote,
+			scheduleRender: () => this.requestRender(),
+			setTimeout: (callback, ms) => setTimeout(callback, ms),
+			reducedMotion: !this.output.isTTY || process.env.SUMOCODE_REDUCED_MOTION === "1",
+		});
 		this.syncChatSlot();
 		// Retained SumoInteractiveMode owns the application terminal contract.
 		// The extension lifecycle shim also enters altscreen when loaded, but the
@@ -243,6 +251,7 @@ export class SumoInteractiveRuntime {
 		// only works reliably when SGR mouse mode is enabled before Pi's first
 		// interactive frame.
 		this.terminal.startRetainedSession();
+		this.paintEagerSplashFrame();
 		logRuntimeStart({
 			terminal: {
 				columns: this.output.columns ?? null,
@@ -477,6 +486,27 @@ export class SumoInteractiveRuntime {
 
 	private syncChatSlot(): void {
 		this.shellTransition?.sync();
+	}
+
+	private paintEagerSplashFrame(): void {
+		if (!this.root || !this.output.isTTY) return;
+		const root = this.root;
+		const width = Math.max(1, this.output.columns ?? 80);
+		const height = Math.max(1, this.output.rows ?? 24);
+		this.syncChatSlot();
+		root.width = width;
+		root.height = height;
+		root.yogaNode.calculateLayout(width, height, DIRECTION_LTR);
+		const frame = new CellBuffer(height, width);
+		const compositeResult = composite(root, frame, { selection: this.selection });
+		const patches = diffFrames(undefined, frame);
+		if (patches.length === 0) return;
+		this.terminal.writeFramePatches(patches, compositeResult.hardwareCursor);
+		this.previousFrame = frame.clone();
+		this.renderedVersion = this.frameVersion;
+		this.renderedWidth = width;
+		this.renderedHeight = height;
+		logDiagnostic("eager_splash_paint", { width, height, patchCount: patches.length });
 	}
 
 	private emptyChatQuoteSnapshot(): EmptyChatQuoteSnapshot {


### PR DESCRIPTION
## Summary

Implements the perceived-smoothness portion of #225.

- eagerly paints the retained splash frame during `SumoInteractiveRuntime.start()`
- seeds retained frame diff state after eager paint so the next render can hand off cleanly
- adds a short `fading-splash` phase before swapping from splash to chat in real TTY mode
- dims splash content during the transition
- supports `SUMOCODE_REDUCED_MOTION=1` and bypasses fade in non-TTY/test rendering
- updates report-only startup perf snapshot

## Notes

This is primarily polish, not a wall-clock startup improvement. Dhruv did not feel a major startup difference from eager paint, which matches the report-only numbers. The next useful perf step is detailed startup diagnostics/instrumentation to locate the remaining ~1.5s.

## Verification

Passed locally:

```txt
pnpm vitest run src/sumo-tui/pi-compat/retained-shell-transition.test.ts src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
pnpm exec tsc --noEmit
pnpm build
pnpm test
pnpm test:integration
pnpm visual:ci
pnpm perf:startup
```

## Issues

Closes #225
