### PR TITLE
feat(theme): persist active theme

### DIFF
--- a/src/commands/theme.test.ts
+++ b/src/commands/theme.test.ts
@@ -59,13 +59,14 @@ describe("/sumo:theme", () => {
 		expect(sendMessage).toHaveBeenCalledWith(expect.anything(), { triggerTurn: false });
 	});
 
-	it("switches known themes through the registry and Pi theme API", async () => {
-		const { handler, sendMessage } = registerHarness();
+	it("switches known themes through the registry and Pi theme API and persists the preference", async () => {
+		const { handler, sendMessage, persistTheme } = registerHarness();
 		const setTheme = vi.fn(() => ({ success: true }));
 
 		await handler(" Cathedral ", uiContext({ setTheme }));
 
 		expect(setTheme).toHaveBeenCalledWith("cathedral");
+		expect(persistTheme).toHaveBeenCalledWith("cathedral");
 		expect(sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({ details: { tone: "info", lines: ["theme set: cathedral"] } }),
 			{ triggerTurn: false },
@@ -90,13 +91,14 @@ describe("/sumo:theme", () => {
 		);
 	});
 
-	it("warns for unknown themes without calling Pi theme API", async () => {
-		const { handler, sendMessage } = registerHarness();
+	it("warns for unknown themes without calling Pi theme API or persistence", async () => {
+		const { handler, sendMessage, persistTheme } = registerHarness();
 		const setTheme = vi.fn(() => ({ success: true }));
 
 		await handler("amber-crt", uiContext({ setTheme }));
 
 		expect(setTheme).not.toHaveBeenCalled();
+		expect(persistTheme).not.toHaveBeenCalled();
 		expect(sendMessage).toHaveBeenCalledWith(
 			expect.objectContaining({ details: { tone: "warning", lines: ["Unknown SumoCode theme: amber-crt"] } }),
 			{ triggerTurn: false },
@@ -109,14 +111,15 @@ describe("/sumo:theme", () => {
 			expect([...shortcuts.keys()].sort()).toEqual(["alt+t", "ctrl+shift+t"]);
 		});
 
-		it("cycles theme through Pi UI and notifies on success", async () => {
-			const { shortcuts } = registerHarness();
+		it("cycles theme through Pi UI, persists, and notifies on success", async () => {
+			const { shortcuts, persistTheme } = registerHarness();
 			const setTheme = vi.fn(() => ({ success: true }));
 			const notify = vi.fn();
 
 			await shortcuts.get("ctrl+shift+t")?.({ hasUI: true, ui: { notify, setTheme } });
 
 			expect(setTheme).toHaveBeenCalledWith("obsidian");
+			expect(persistTheme).toHaveBeenCalledWith("obsidian");
 			expect(notify).toHaveBeenCalledWith("theme: obsidian", "info");
 		});
 
@@ -140,6 +143,16 @@ describe("/sumo:theme", () => {
 
 			expect(notify).toHaveBeenCalledWith("theme: obsidian (Theme API unavailable)", "info");
 		});
+
+		it("warns when cycling succeeds but persistence fails", async () => {
+			const { shortcuts } = registerHarness({ persistTheme: vi.fn(() => ({ success: false, error: "EACCES" })) });
+			const setTheme = vi.fn(() => ({ success: true }));
+			const notify = vi.fn();
+
+			await shortcuts.get("ctrl+shift+t")?.({ hasUI: true, ui: { notify, setTheme } });
+
+			expect(notify).toHaveBeenCalledWith("theme: obsidian (EACCES)", "warning");
+		});
 	});
 });
 
@@ -148,9 +161,10 @@ interface RegisteredHarness {
 	shortcuts: Map<string, (ctx: any) => void | Promise<void>>;
 	sendMessage: ReturnType<typeof vi.fn>;
 	registerMessageRenderer: ReturnType<typeof vi.fn>;
+	persistTheme: ReturnType<typeof vi.fn>;
 }
 
-function registerHarness(): RegisteredHarness {
+function registerHarness(options: { persistTheme?: any } = {}): RegisteredHarness {
 	let handler: ((args: string, ctx: any) => Promise<void>) | undefined;
 	const shortcuts = new Map<string, (ctx: any) => void | Promise<void>>();
 	const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
@@ -161,10 +175,11 @@ function registerHarness(): RegisteredHarness {
 	});
 	const sendMessage = vi.fn();
 	const registerMessageRenderer = vi.fn();
+	const persistTheme = options.persistTheme ?? vi.fn(() => ({ success: true }));
 
-	registerThemeCommand({ registerCommand, registerShortcut, sendMessage, registerMessageRenderer } as never);
+	registerThemeCommand({ registerCommand, registerShortcut, sendMessage, registerMessageRenderer } as never, { persistTheme });
 	if (!handler) throw new Error("handler was not registered");
-	return { handler, shortcuts, sendMessage, registerMessageRenderer };
+	return { handler, shortcuts, sendMessage, registerMessageRenderer, persistTheme };
 }
 
 function uiContext(options: { setTheme?: ReturnType<typeof vi.fn> } = {}): any {

--- a/src/commands/theme.ts
+++ b/src/commands/theme.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { truncateToWidth, visibleWidth, type Component } from "@mariozechner/pi-tui";
 import { activeThemeColors, getActiveTheme, getTheme, listThemes, nextThemeName } from "../themes/index.js";
+import { saveSumoCodeConfigPatch } from "../config/sumocode-config.js";
 import { emitCathedralThemeChanged } from "../sumo-tui/cathedral/theme-bridge.js";
 
 /**
@@ -13,11 +14,13 @@ import { emitCathedralThemeChanged } from "../sumo-tui/cathedral/theme-bridge.js
  */
 export interface ApplyThemeOutcome {
 	readonly piWarning?: string;
+	readonly persistenceWarning?: string;
 }
 
 export function applyKnownTheme(
 	theme: { name: string },
 	applyPiTheme: ((name: string) => { success: boolean; error?: string }) | undefined,
+	persistTheme: ((name: string) => { success: boolean; error?: string }) | undefined = (name) => saveSumoCodeConfigPatch({ themeName: name }),
 ): ApplyThemeOutcome {
 	let piWarning: string | undefined;
 	if (applyPiTheme) {
@@ -25,7 +28,9 @@ export function applyKnownTheme(
 		if (!result.success) piWarning = result.error ?? theme.name;
 	}
 	emitCathedralThemeChanged(theme.name);
-	return piWarning === undefined ? {} : { piWarning };
+	const persistResult = persistTheme?.(theme.name);
+	const persistenceWarning = persistResult && !persistResult.success ? persistResult.error ?? theme.name : undefined;
+	return { ...(piWarning === undefined ? {} : { piWarning }), ...(persistenceWarning === undefined ? {} : { persistenceWarning }) };
 }
 
 export const THEME_RESULT_CUSTOM_TYPE = "sumocode-theme-result";
@@ -123,8 +128,12 @@ export function formatThemeList(): string[] {
 	return listThemes().map((theme) => `${theme.name === active ? "*" : " "} ${theme.name} — ${theme.description}`);
 }
 
+interface RegisterThemeOptions {
+	readonly persistTheme?: (name: string) => { success: boolean; error?: string };
+}
+
 /** Register the `Ctrl+Shift+T` / `Alt+T` cycle shortcuts. */
-export function registerThemeCycleShortcuts(pi: ExtensionAPI): void {
+export function registerThemeCycleShortcuts(pi: ExtensionAPI, options: RegisterThemeOptions = {}): void {
 	const handler = (ctx: ExtensionContext): void => {
 		const nextName = nextThemeName();
 		const theme = getTheme(nextName);
@@ -134,9 +143,10 @@ export function registerThemeCycleShortcuts(pi: ExtensionAPI): void {
 		}
 
 		const applyPi = ctx.hasUI ? (name: string) => ctx.ui.setTheme(name) : undefined;
-		const outcome = applyKnownTheme(theme, applyPi);
+		const outcome = applyKnownTheme(theme, applyPi, options.persistTheme);
 		if (ctx.hasUI) {
-			ctx.ui.notify(outcome.piWarning ? `theme: ${theme.name} (${outcome.piWarning})` : `theme: ${theme.name}`, "info");
+			const warning = outcome.persistenceWarning ?? outcome.piWarning;
+			ctx.ui.notify(warning ? `theme: ${theme.name} (${warning})` : `theme: ${theme.name}`, outcome.persistenceWarning ? "warning" : "info");
 		}
 	};
 
@@ -145,9 +155,9 @@ export function registerThemeCycleShortcuts(pi: ExtensionAPI): void {
 }
 
 /** Register `/sumo:theme [list|name]` for SumoCode theme switching. */
-export function registerThemeCommand(pi: ExtensionAPI): void {
+export function registerThemeCommand(pi: ExtensionAPI, options: RegisterThemeOptions = {}): void {
 	registerThemeResultRenderer(pi);
-	registerThemeCycleShortcuts(pi);
+	registerThemeCycleShortcuts(pi, options);
 	pi.registerCommand("sumo:theme", {
 		description: "Show or switch the active SumoCode theme",
 		handler: async (args: string, ctx: ExtensionContext) => {
@@ -169,10 +179,11 @@ export function registerThemeCommand(pi: ExtensionAPI): void {
 			}
 
 			const applyPi = ctx.hasUI ? (name: string) => ctx.ui.setTheme(name) : undefined;
-			const outcome = applyKnownTheme(theme, applyPi);
+			const outcome = applyKnownTheme(theme, applyPi, options.persistTheme);
 			const lines = [`theme set: ${theme.name}`];
 			if (outcome.piWarning) lines.push(`(Pi theme not found: ${outcome.piWarning})`);
-			pushThemeResult(pi, ctx, lines, "info");
+			if (outcome.persistenceWarning) lines.push(`(theme preference not saved: ${outcome.persistenceWarning})`);
+			pushThemeResult(pi, ctx, lines, outcome.persistenceWarning ? "warning" : "info");
 		},
 	});
 }

--- a/src/config/sumocode-config.test.ts
+++ b/src/config/sumocode-config.test.ts
@@ -1,8 +1,8 @@
-import { existsSync, mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { DEFAULT_SUMOCODE_CONFIG, loadSumoCodeConfig, resolveSumoCodeConfigCandidates } from "./sumocode-config.js";
+import { DEFAULT_SUMOCODE_CONFIG, loadSumoCodeConfig, resolveGlobalSumoCodeConfigPath, resolveSumoCodeConfigCandidates, saveSumoCodeConfigPatch } from "./sumocode-config.js";
 
 function writeJson(path: string, value: unknown): void {
 	mkdirSync(dirname(path), { recursive: true });
@@ -41,19 +41,148 @@ describe("sumocode-config", () => {
 		}
 	});
 
-	it("skips malformed config files and validates primaryAgentName", () => {
+	it("skips malformed config files and trims optional themeName", () => {
 		const root = mkdtempSync(join(tmpdir(), "sumocode-config-invalid-"));
 		const cwd = join(root, "project");
 		const homeDir = join(root, "home");
 		mkdirSync(cwd, { recursive: true });
 		const [project, projectPi] = resolveSumoCodeConfigCandidates({ cwd, homeDir });
 		writeFileSync(project.path, "{");
-		writeJson(projectPi.path, { primaryAgentName: "  Zeus  " });
+		writeJson(projectPi.path, { primaryAgentName: "  Zeus  ", themeName: "  Obsidian  " });
+
+		try {
+			expect(loadSumoCodeConfig({ cwd, homeDir })).toMatchObject({ config: { primaryAgentName: "Zeus", themeName: "obsidian" }, source: "project-pi" });
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("accepts theme-only config files and falls back to default agent name", () => {
+		const root = mkdtempSync(join(tmpdir(), "sumocode-config-theme-only-"));
+		const cwd = join(root, "project");
+		const homeDir = join(root, "home");
+		mkdirSync(cwd, { recursive: true });
+		const [project] = resolveSumoCodeConfigCandidates({ cwd, homeDir });
+		writeJson(project.path, { themeName: "cathedral" });
+
+		try {
+			expect(loadSumoCodeConfig({ cwd, homeDir })).toMatchObject({ config: { primaryAgentName: "SUMO", themeName: "cathedral" }, source: "project" });
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("fills missing primaryAgentName from lower-priority configs", () => {
+		const root = mkdtempSync(join(tmpdir(), "sumocode-config-theme-merge-"));
+		const cwd = join(root, "project");
+		const homeDir = join(root, "home");
+		mkdirSync(cwd, { recursive: true });
+		const [project, , global] = resolveSumoCodeConfigCandidates({ cwd, homeDir });
+		writeJson(project.path, { themeName: "cathedral" });
+		writeJson(global.path, { primaryAgentName: "Zeus", themeName: "obsidian" });
+
+		try {
+			expect(loadSumoCodeConfig({ cwd, homeDir })).toMatchObject({
+				config: { primaryAgentName: "Zeus", themeName: "cathedral" },
+				source: "project",
+			});
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("skips config files without recognized SumoCode keys", () => {
+		const root = mkdtempSync(join(tmpdir(), "sumocode-config-unrecognized-"));
+		const cwd = join(root, "project");
+		const homeDir = join(root, "home");
+		mkdirSync(cwd, { recursive: true });
+		const [project, projectPi] = resolveSumoCodeConfigCandidates({ cwd, homeDir });
+		writeJson(project.path, { otherToolConfig: true });
+		writeJson(projectPi.path, { primaryAgentName: "Zeus" });
 
 		try {
 			expect(loadSumoCodeConfig({ cwd, homeDir })).toMatchObject({ config: { primaryAgentName: "Zeus" }, source: "project-pi" });
 		} finally {
 			rmSync(root, { recursive: true, force: true });
 		}
+	});
+
+	it("skips unreadable config files while loading", () => {
+		const root = mkdtempSync(join(tmpdir(), "sumocode-config-unreadable-load-"));
+		const cwd = join(root, "project");
+		const homeDir = join(root, "home");
+		mkdirSync(cwd, { recursive: true });
+		const [, projectPi] = resolveSumoCodeConfigCandidates({ cwd, homeDir });
+
+		try {
+			expect(loadSumoCodeConfig({
+				cwd,
+				homeDir,
+				readFile: (path) => {
+					if (path.endsWith(".sumocode.json")) throw new Error("EACCES");
+					if (path === projectPi.path) return JSON.stringify({ primaryAgentName: "Zeus", themeName: "cathedral" });
+					return undefined;
+				},
+			})).toMatchObject({ config: { primaryAgentName: "Zeus", themeName: "cathedral" }, source: "project-pi" });
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("fills missing themeName from lower-priority configs", () => {
+		const root = mkdtempSync(join(tmpdir(), "sumocode-config-merge-"));
+		const cwd = join(root, "project");
+		const homeDir = join(root, "home");
+		mkdirSync(cwd, { recursive: true });
+		const [project, , global] = resolveSumoCodeConfigCandidates({ cwd, homeDir });
+		writeJson(project.path, { primaryAgentName: "Project" });
+		writeJson(global.path, { primaryAgentName: "Global", themeName: "cathedral" });
+
+		try {
+			expect(loadSumoCodeConfig({ cwd, homeDir })).toMatchObject({
+				config: { primaryAgentName: "Project", themeName: "cathedral" },
+				source: "project",
+			});
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("persists themeName to the synced global config while preserving existing keys", () => {
+		const root = mkdtempSync(join(tmpdir(), "sumocode-config-save-"));
+		const homeDir = join(root, "home");
+		const globalPath = resolveGlobalSumoCodeConfigPath(homeDir);
+		writeJson(globalPath, { primaryAgentName: "Zeus", extra: true });
+
+		try {
+			expect(saveSumoCodeConfigPatch({ themeName: "obsidian" }, { homeDir })).toMatchObject({ success: true, path: globalPath });
+			expect(JSON.parse(readFileSync(globalPath, "utf8"))).toEqual({ primaryAgentName: "Zeus", extra: true, themeName: "obsidian" });
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("refuses to overwrite malformed global config", () => {
+		const root = mkdtempSync(join(tmpdir(), "sumocode-config-malformed-save-"));
+		const homeDir = join(root, "home");
+		const globalPath = resolveGlobalSumoCodeConfigPath(homeDir);
+		mkdirSync(dirname(globalPath), { recursive: true });
+		writeFileSync(globalPath, "{");
+
+		try {
+			expect(saveSumoCodeConfigPatch({ themeName: "obsidian" }, { homeDir })).toMatchObject({ success: false, path: globalPath });
+			expect(readFileSync(globalPath, "utf8")).toBe("{");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("returns a save error when the existing global config cannot be read", () => {
+		expect(saveSumoCodeConfigPatch({ themeName: "obsidian" }, {
+			homeDir: "/home/dhruv",
+			readFile: () => {
+				throw new Error("EACCES");
+			},
+		})).toMatchObject({ success: false, error: "EACCES" });
 	});
 });

--- a/src/config/sumocode-config.ts
+++ b/src/config/sumocode-config.ts
@@ -1,9 +1,15 @@
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
 export interface SumoCodeConfig {
 	readonly primaryAgentName: string;
+	readonly themeName?: string;
+}
+
+interface ParsedSumoCodeConfig {
+	readonly primaryAgentName?: string;
+	readonly themeName?: string;
 }
 
 export type SumoCodeConfigSourceKind = "project" | "project-pi" | "global" | "defaults";
@@ -25,9 +31,19 @@ export interface LoadSumoCodeConfigOptions {
 	readonly readFile?: (path: string) => string | undefined;
 }
 
+export interface SaveSumoCodeConfigOptions {
+	readonly homeDir?: string;
+	readonly readFile?: (path: string) => string | undefined;
+	readonly writeFile?: (path: string, content: string) => void;
+}
+
 export const DEFAULT_SUMOCODE_CONFIG: SumoCodeConfig = {
 	primaryAgentName: "SUMO",
 };
+
+export function resolveGlobalSumoCodeConfigPath(homeDir = homedir()): string {
+	return join(resolve(homeDir), ".pi", "agent", "sumocode.json");
+}
 
 export function resolveSumoCodeConfigCandidates(options: Pick<LoadSumoCodeConfigOptions, "cwd" | "homeDir"> = {}): SumoCodeConfigCandidate[] {
 	const cwd = resolve(options.cwd ?? process.cwd());
@@ -35,19 +51,82 @@ export function resolveSumoCodeConfigCandidates(options: Pick<LoadSumoCodeConfig
 	return [
 		{ kind: "project", path: join(cwd, ".sumocode.json") },
 		{ kind: "project-pi", path: join(cwd, ".pi", "sumocode.json") },
-		{ kind: "global", path: join(homeDir, ".pi", "agent", "sumocode.json") },
+		{ kind: "global", path: resolveGlobalSumoCodeConfigPath(homeDir) },
 	];
 }
 
 export function loadSumoCodeConfig(options: LoadSumoCodeConfigOptions = {}): SumoCodeConfigLoadResult {
 	const readFile = options.readFile ?? readConfigFile;
+	let merged: ParsedSumoCodeConfig | undefined;
+	let source: SumoCodeConfigSourceKind = "defaults";
+	let path: string | undefined;
 	for (const candidate of resolveSumoCodeConfigCandidates(options)) {
-		const raw = readFile(candidate.path);
+		let raw: string | undefined;
+		try {
+			raw = readFile(candidate.path);
+		} catch {
+			continue;
+		}
 		if (raw === undefined) continue;
 		const config = parseSumoCodeConfig(raw);
-		if (config) return { config, source: candidate.kind, path: candidate.path };
+		if (!config) continue;
+		merged = mergeMissingSumoCodeConfig(merged, config);
+		if (source === "defaults") {
+			source = candidate.kind;
+			path = candidate.path;
+		}
 	}
-	return { config: DEFAULT_SUMOCODE_CONFIG, source: "defaults" };
+	if (!merged) return { config: DEFAULT_SUMOCODE_CONFIG, source: "defaults" };
+	const config = finalizeSumoCodeConfig(merged);
+	return path === undefined ? { config, source } : { config, source, path };
+}
+
+export function saveSumoCodeConfigPatch(patch: Partial<SumoCodeConfig>, options: SaveSumoCodeConfigOptions = {}): { success: true; path: string } | { success: false; error: string; path: string } {
+	const path = resolveGlobalSumoCodeConfigPath(options.homeDir);
+	const readFile = options.readFile ?? readConfigFile;
+	const writeFile = options.writeFile ?? writeConfigFileAtomic;
+	let existing: Record<string, unknown> = {};
+	let raw: string | undefined;
+	try {
+		raw = readFile(path);
+	} catch (error) {
+		return { success: false, path, error: error instanceof Error ? error.message : String(error) };
+	}
+	if (raw !== undefined) {
+		try {
+			const parsed = JSON.parse(raw) as unknown;
+			if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return { success: false, path, error: "Existing SumoCode config is not a JSON object" };
+			existing = parsed as Record<string, unknown>;
+		} catch (error) {
+			return { success: false, path, error: error instanceof Error ? error.message : String(error) };
+		}
+	}
+
+	const next = { ...existing };
+	if (patch.primaryAgentName !== undefined) next.primaryAgentName = patch.primaryAgentName;
+	if (patch.themeName !== undefined) next.themeName = patch.themeName;
+
+	try {
+		writeFile(path, `${JSON.stringify(next, null, "\t")}\n`);
+		return { success: true, path };
+	} catch (error) {
+		return { success: false, path, error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+function mergeMissingSumoCodeConfig(primary: ParsedSumoCodeConfig | undefined, fallback: ParsedSumoCodeConfig): ParsedSumoCodeConfig {
+	if (!primary) return fallback;
+	return {
+		primaryAgentName: primary.primaryAgentName ?? fallback.primaryAgentName,
+		themeName: primary.themeName ?? fallback.themeName,
+	};
+}
+
+function finalizeSumoCodeConfig(config: ParsedSumoCodeConfig): SumoCodeConfig {
+	return {
+		primaryAgentName: config.primaryAgentName ?? DEFAULT_SUMOCODE_CONFIG.primaryAgentName,
+		...(config.themeName === undefined ? {} : { themeName: config.themeName }),
+	};
 }
 
 function readConfigFile(path: string): string | undefined {
@@ -55,7 +134,14 @@ function readConfigFile(path: string): string | undefined {
 	return readFileSync(path, "utf8");
 }
 
-function parseSumoCodeConfig(raw: string): SumoCodeConfig | undefined {
+function writeConfigFileAtomic(path: string, content: string): void {
+	mkdirSync(dirname(path), { recursive: true });
+	const tmpPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+	writeFileSync(tmpPath, content);
+	renameSync(tmpPath, path);
+}
+
+function parseSumoCodeConfig(raw: string): ParsedSumoCodeConfig | undefined {
 	let parsed: unknown;
 	try {
 		parsed = JSON.parse(raw);
@@ -63,9 +149,10 @@ function parseSumoCodeConfig(raw: string): SumoCodeConfig | undefined {
 		return undefined;
 	}
 	if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return undefined;
-	const primaryAgentName = (parsed as { primaryAgentName?: unknown }).primaryAgentName;
-	if (typeof primaryAgentName !== "string") return undefined;
-	const trimmed = primaryAgentName.trim();
-	if (trimmed.length === 0) return undefined;
-	return { primaryAgentName: trimmed };
+	const record = parsed as { primaryAgentName?: unknown; themeName?: unknown };
+	if (record.primaryAgentName === undefined && record.themeName === undefined) return undefined;
+	if (record.primaryAgentName !== undefined && (typeof record.primaryAgentName !== "string" || record.primaryAgentName.trim().length === 0)) return undefined;
+	const primaryAgentName = typeof record.primaryAgentName === "string" ? record.primaryAgentName.trim() : undefined;
+	const themeName = typeof record.themeName === "string" && record.themeName.trim().length > 0 ? record.themeName.trim().toLowerCase() : undefined;
+	return { ...(primaryAgentName === undefined ? {} : { primaryAgentName }), ...(themeName === undefined ? {} : { themeName }) };
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,8 @@ import { installApprovalGate } from "./approval-modal.js";
 import { installQuestionTool } from "./question-tool.js";
 import { taskTool } from "./native-task-tool.js";
 
-import { setActiveTheme } from "./themes/index.js";
+import { loadSumoCodeConfig } from "./config/sumocode-config.js";
+import { getTheme, setActiveTheme } from "./themes/index.js";
 import { installAltscreen } from "./cathedral/altscreen.js";
 import { installCathedralEditor } from "./cathedral/cathedral-editor.js";
 import { installSumoInteractions } from "./interaction-registry.js";
@@ -105,10 +106,11 @@ export default function sumocode(pi: ExtensionAPI): void {
 		return;
 	}
 
-	// Default runtime theme. The registry default stays Cathedral (so unit tests
-	// that don't explicitly switch themes get a stable baseline). Switching here
-	// only affects the runtime path. Persistence across sessions lands later.
-	setActiveTheme("obsidian");
+	// Restore the persisted runtime theme before installing any UI surfaces so
+	// first paint uses the chosen palette. Registry default stays Cathedral for
+	// tests and non-runtime module imports; runtime fallback stays Obsidian.
+	const configuredThemeName = loadSumoCodeConfig().config.themeName;
+	setActiveTheme(configuredThemeName && getTheme(configuredThemeName) ? configuredThemeName : "obsidian");
 
 	// Render diagnostics must install BEFORE any consumer so its `setFooter` /
 	// `setHeader` / `setEditorComponent` / `setWidget` wrappers are in place


### PR DESCRIPTION
## Summary
- persist selected SumoCode theme to the synced global config
- restore persisted theme before first UI paint, falling back to Obsidian
- cover theme-only configs, unknown-key skip behavior, persistence failures, and cycle persistence

## Verification
- pnpm exec tsc --noEmit
- pnpm vitest run src/config/sumocode-config.test.ts src/commands/theme.test.ts src/extension.test.ts
- pnpm build
- SumoCode diff review GREEN; scribe also ran pnpm test and pnpm test:integration

Closes #217