### PR TITLE
feat(tui): surface compaction status in retained chrome

### DIFF
--- a/src/compaction-indicator.test.ts
+++ b/src/compaction-indicator.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CompactionStatusComponent, COMPACTION_INDICATOR_WIDGET_KEY, installCompactionIndicator } from "./compaction-indicator.js";
+
+const ENV_KEY = "SUMO_TUI";
+let originalEnv: string | undefined;
+
+beforeEach(() => {
+	originalEnv = process.env[ENV_KEY];
+	vi.useFakeTimers();
+});
+
+afterEach(() => {
+	if (originalEnv === undefined) delete process.env[ENV_KEY];
+	else process.env[ENV_KEY] = originalEnv;
+	vi.useRealTimers();
+});
+
+// ── CompactionStatusComponent unit tests ──────────────────────────────────────
+
+describe("CompactionStatusComponent", () => {
+	it("renders exactly one row", () => {
+		const tui = { requestRender: vi.fn() };
+		const c = new CompactionStatusComponent("Compacting…", tui);
+		try {
+			expect(c.render(80)).toHaveLength(1);
+		} finally {
+			c.dispose();
+		}
+	});
+
+	it("row contains the label text", () => {
+		const tui = { requestRender: vi.fn() };
+		const c = new CompactionStatusComponent("Auto-compacting…", tui);
+		try {
+			const row = c.render(80)[0]!;
+			expect(row).toContain("Auto-compacting…");
+		} finally {
+			c.dispose();
+		}
+	});
+
+	it("row contains ━ (trace) and ─ (track) bar chars", () => {
+		const tui = { requestRender: vi.fn() };
+		const c = new CompactionStatusComponent("Compacting…", tui);
+		try {
+			const row = c.render(80)[0]!;
+			const plain = row.replace(/\x1b\[[0-9;]*m/g, "");
+			// At tick 0 bar starts with glyph + track chars.
+			expect(plain).toMatch(/[━─]/);
+		} finally {
+			c.dispose();
+		}
+	});
+
+	it("bar starts mostly empty (tick 0, no fill yet)", () => {
+		const tui = { requestRender: vi.fn() };
+		const c = new CompactionStatusComponent("Compacting…", tui);
+		try {
+			const row = c.render(80)[0]!;
+			const plain = row.replace(/\x1b\[[0-9;]*m/g, "");
+			// At tick 0, filledCells === 0: only unfilled track + glyph
+			expect(plain).not.toMatch(/▓▓/); // no solid fill yet
+		} finally {
+			c.dispose();
+		}
+	});
+
+	it("bar grows after ticks", () => {
+		const tui = { requestRender: vi.fn() };
+		const c = new CompactionStatusComponent("Compacting…", tui);
+		try {
+			// With PLATEAU_TICKS=400 we need enough ticks to see fill start.
+			// 80 ticks (8 s) → ~18 % of barWidth ≈ 5 filled cells.
+			vi.advanceTimersByTime(8000);
+			const row = c.render(80)[0]!.replace(/\x1b\[[0-9;]*m/g, "");
+			expect(row).toContain("━");
+		} finally {
+			c.dispose();
+		}
+	});
+
+	it("bar fill plateaus at ~90% after 40 s and holds", () => {
+		const tui = { requestRender: vi.fn() };
+		const c = new CompactionStatusComponent("Compacting…", tui);
+		try {
+			vi.advanceTimersByTime(40_000);
+			const rowA = c.render(80)[0]!.replace(/\x1b\[[0-9;]*m/g, "");
+			vi.advanceTimersByTime(30_000);
+			const rowB = c.render(80)[0]!.replace(/\x1b\[[0-9;]*m/g, "");
+			const traceA = [...rowA].filter((ch) => ch === "━").length;
+			const traceB = [...rowB].filter((ch) => ch === "━").length;
+			expect(traceA).toBe(traceB);
+			expect(traceA).toBeGreaterThan(0);
+		} finally {
+			c.dispose();
+		}
+	});
+
+	it("dispose() stops the timer so requestRender is not called after disposal", () => {
+		const tui = { requestRender: vi.fn() };
+		const c = new CompactionStatusComponent("Compacting…", tui);
+		c.dispose();
+		vi.advanceTimersByTime(2000);
+		expect(tui.requestRender).not.toHaveBeenCalled();
+	});
+
+	it("ticks requestRender on each interval", () => {
+		const tui = { requestRender: vi.fn() };
+		const c = new CompactionStatusComponent("Compacting…", tui);
+		try {
+			vi.advanceTimersByTime(500); // 5 ticks at 100ms
+			expect(tui.requestRender).toHaveBeenCalledTimes(5);
+		} finally {
+			c.dispose();
+		}
+	});
+});
+
+// ── installCompactionIndicator integration tests ──────────────────────────────
+
+function buildPiStub() {
+	const handlers: Record<string, Array<(...args: unknown[]) => unknown>> = {};
+	const pi = {
+		on: vi.fn((event: string, handler: (...args: unknown[]) => unknown) => {
+			handlers[event] ??= [];
+			handlers[event].push(handler);
+		}),
+	};
+	const fire = async (event: string, payload: unknown, ctx: unknown) => {
+		for (const h of handlers[event] ?? []) await h(payload, ctx);
+	};
+	return { pi, fire };
+}
+
+function buildCtxStub() {
+	const setWidget = vi.fn();
+	return { ctx: { hasUI: true, ui: { setWidget } }, setWidget };
+}
+
+describe("compaction indicator — retained mode", () => {
+	beforeEach(() => { process.env[ENV_KEY] = "1"; });
+
+	it("registers session_before_compact, session_compact, and session_shutdown handlers", () => {
+		const { pi } = buildPiStub();
+		installCompactionIndicator(pi as never);
+		const registered = pi.on.mock.calls.map((c) => c[0]);
+		expect(registered).toContain("session_before_compact");
+		expect(registered).toContain("session_compact");
+		expect(registered).toContain("session_shutdown");
+	});
+
+	it("mounts animated component for manual /compact (customInstructions set)", async () => {
+		const { pi, fire } = buildPiStub();
+		const { ctx, setWidget } = buildCtxStub();
+		installCompactionIndicator(pi as never);
+
+		await fire("session_before_compact", { customInstructions: "summarise recent" }, ctx);
+
+		expect(setWidget).toHaveBeenCalledWith(
+			COMPACTION_INDICATOR_WIDGET_KEY,
+			expect.any(Function),
+			{ placement: "aboveEditor" },
+		);
+		const factory = setWidget.mock.calls[0][1] as (tui: { requestRender(): void }) => { render(w: number): string[]; dispose?(): void };
+		const c = factory({ requestRender: vi.fn() });
+		const row = c.render(80)[0]!;
+		expect(row).toContain("Compacting…");
+		c.dispose?.();
+	});
+
+	it("mounts animated component with 'Auto-compacting…' when customInstructions is undefined", async () => {
+		const { pi, fire } = buildPiStub();
+		const { ctx, setWidget } = buildCtxStub();
+		installCompactionIndicator(pi as never);
+
+		await fire("session_before_compact", { customInstructions: undefined }, ctx);
+
+		const factory = setWidget.mock.calls[0][1] as (tui: { requestRender(): void }) => { render(w: number): string[]; dispose?(): void };
+		const c = factory({ requestRender: vi.fn() });
+		const row = c.render(80)[0]!;
+		expect(row).toContain("Auto-compacting…");
+		c.dispose?.();
+	});
+
+	it("clears widget on session_compact after completion hold", async () => {
+		const { pi, fire } = buildPiStub();
+		const { ctx, setWidget } = buildCtxStub();
+		installCompactionIndicator(pi as never);
+
+		await fire("session_before_compact", { customInstructions: undefined }, ctx);
+		const factory = setWidget.mock.calls[0][1] as (tui: { requestRender(): void }) => { render(w: number): string[]; dispose?(): void };
+		const c = factory({ requestRender: vi.fn() });
+
+		// session_compact awaits markComplete() which setTimeout 700 ms.
+		// Fire event, then advance timers to let the hold expire.
+		const compactPromise = fire("session_compact", {}, ctx);
+		vi.advanceTimersByTime(800);
+		await compactPromise;
+
+		expect(setWidget).toHaveBeenLastCalledWith(
+			COMPACTION_INDICATOR_WIDGET_KEY,
+			undefined,
+			{ placement: "aboveEditor" },
+		);
+		c.dispose?.();
+	});
+
+	it("clears widget on session_shutdown", async () => {
+		const { pi, fire } = buildPiStub();
+		const { ctx, setWidget } = buildCtxStub();
+		installCompactionIndicator(pi as never);
+
+		await fire("session_before_compact", { customInstructions: undefined }, ctx);
+		await fire("session_shutdown", { reason: "quit" }, ctx);
+
+		expect(setWidget).toHaveBeenLastCalledWith(
+			COMPACTION_INDICATOR_WIDGET_KEY,
+			undefined,
+			{ placement: "aboveEditor" },
+		);
+	});
+
+	it("does not call setWidget when hasUI is false", async () => {
+		const { pi, fire } = buildPiStub();
+		const { setWidget } = buildCtxStub();
+		const headlessCtx = { hasUI: false, ui: { setWidget } };
+		installCompactionIndicator(pi as never);
+
+		await fire("session_before_compact", { customInstructions: undefined }, headlessCtx);
+
+		expect(setWidget).not.toHaveBeenCalled();
+	});
+
+	it("does not double-clear when session_compact fires without a prior before_compact", async () => {
+		const { pi, fire } = buildPiStub();
+		const { ctx, setWidget } = buildCtxStub();
+		installCompactionIndicator(pi as never);
+
+		await fire("session_compact", {}, ctx);
+
+		expect(setWidget).not.toHaveBeenCalled();
+	});
+});
+
+describe("compaction indicator — classic Pi (no SUMO_TUI)", () => {
+	beforeEach(() => { delete process.env[ENV_KEY]; });
+
+	it("registers no event handlers in classic mode", () => {
+		const { pi } = buildPiStub();
+		installCompactionIndicator(pi as never);
+		expect(pi.on).not.toHaveBeenCalled();
+	});
+});

--- a/src/compaction-indicator.ts
+++ b/src/compaction-indicator.ts
@@ -1,0 +1,218 @@
+/**
+ * SumoCode compaction indicator — surface compaction status in the retained
+ * SumoTUI chrome as an animated neon-trace bar above the editor.
+ *
+ * ## Problem
+ * In vanilla Pi, compaction status is rendered into `statusContainer` — a
+ * dedicated `Container` node Pi adds directly to its TUI layout. SumoTUI
+ * replaces Pi's render loop so that container is never composited.
+ *
+ * ## Solution
+ * A dedicated widget key in the `aboveEditor` slot. Hooks:
+ *   - `session_before_compact` → start neon-trace animation
+ *   - `session_compact`        → snap to 100 %, hold briefly, then clear
+ *   - `session_shutdown`       → immediate clear (abort / reload)
+ *
+ * Classic Pi (no `SUMO_TUI`) is a no-op — Pi's own `statusContainer` Loader
+ * already handles it there.
+ *
+ * ## Visual design — neon trace
+ *
+ *   ━━━━━━━━━━━━◈─────────────────  Compacting…
+ *
+ * - `━` (accent)  — traced (filled) cells, growing left-to-right
+ * - current theme working-indicator glyph (accent, cycling) — the "spark"
+ *   sitting right at the leading edge; pulses as the trace advances
+ * - `─` (dim)     — untraced track ahead of the spark
+ *
+ * Progress is deliberately slow (≈ 45 s to 90 %) so the bar feels proportional
+ * to real compaction time. On `session_compact`, the bar instantly fills to
+ * 100 % (all `━`, no spark), holds for ~700 ms so the user sees completion,
+ * then the slot is cleared.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { Component, TUI } from "@mariozechner/pi-tui";
+import { lineToAnsi, span, textLine, truncateLine, type Span } from "./sumo-tui/render/primitives.js";
+import { getActiveTheme, onThemeChanged } from "./themes/index.js";
+import { getCompactionReason, setCompactionReason } from "./compaction-state.js";
+import { isRetainedMode } from "./working-indicator.js";
+
+export const COMPACTION_INDICATOR_WIDGET_KEY = "sumocode-compaction-status";
+
+/** Tick interval in ms. */
+const TICK_MS = 100;
+/**
+ * Ticks to reach the fill plateau (400 × 100 ms = 40 s → 90 %).
+ * Slow enough to feel proportional to real compaction time.
+ */
+const PLATEAU_TICKS = 400;
+/** Ratio at which the bar parks while waiting for the LLM to finish. */
+const PLATEAU_RATIO = 0.90;
+/** How long (ms) to hold the 100 % trace after completion before clearing. */
+const COMPLETE_HOLD_MS = 700;
+
+/**
+ * Spark glyph frames — restricted to Unicode Geometric Shapes block
+ * (U+25A0–U+25FF).  These chars share the same vertical metrics as the
+ * box-drawing chars (━ / ─), so the spark sits *on* the line rather than
+ * floating above it.  Math-operator glyphs (⊛ ⊚) are intentionally excluded.
+ *
+ * Sequence: hollow → half-filled → filled → back ("breathing diamond").
+ */
+const SPARK_FRAMES = ["◇", "◈", "◉", "◈"] as const;
+
+/**
+ * Ticks per spark-frame advance.  5 × 100 ms = 500 ms/frame → full loop ≈ 2 s.
+ * Feels calm and proportional to the slow progress curve.
+ */
+const GLYPH_TICK_DIVISOR = 5;
+
+/**
+ * Neon-trace component.
+ *
+ * Returns exactly **one row** — the `aboveProxy` breathing wrapper
+ * (`["", content]` + `belowIndicatorSpacer`) provides the spacing.
+ */
+export class CompactionStatusComponent implements Component {
+	private tick = 0;
+	private completed = false;
+	private interval: ReturnType<typeof setInterval> | undefined;
+	private themeUnsubscribe: (() => void) | undefined;
+
+	public constructor(
+		private readonly label: string,
+		private readonly tui: Pick<TUI, "requestRender">,
+	) {
+		this.interval = setInterval(() => {
+			this.tick += 1;
+			this.tui.requestRender();
+		}, TICK_MS);
+
+		this.themeUnsubscribe = onThemeChanged(() => {
+			this.tui.requestRender();
+		});
+	}
+
+	public invalidate(): void {}
+
+	/**
+	 * Snap the trace to 100 %, request a final render, then resolve after
+	 * `COMPLETE_HOLD_MS` so the caller can clear the widget.
+	 */
+	public markComplete(): Promise<void> {
+		this.completed = true;
+		this.tui.requestRender();
+		return new Promise((resolve) => {
+			const t = setTimeout(resolve, COMPLETE_HOLD_MS);
+			(t as NodeJS.Timeout).unref?.();
+		});
+	}
+
+	public render(width: number): string[] {
+		const theme = getActiveTheme();
+		const accent = theme.tokens.colors.accent;
+		const dim = theme.tokens.colors.foregroundDim;
+
+		// ── bar width ────────────────────────────────────────────────────────
+		const labelStr = ` ${this.label}`;
+		const available = Math.max(0, width - 1 - labelStr.length);
+		const barWidth = Math.max(4, Math.min(30, available));
+
+		// ── fill amount ──────────────────────────────────────────────────────
+		const fillRatio = this.completed
+			? 1.0
+			: Math.min(this.tick / PLATEAU_TICKS, 1) * PLATEAU_RATIO;
+		const filledCells = this.completed
+			? barWidth
+			: Math.max(0, Math.floor(fillRatio * barWidth));
+
+		// ── assemble bar row via typed primitives ───────────────────────────
+		const barParts: (Span | string)[] = [];
+
+		if (this.completed || filledCells >= barWidth) {
+			// All done — solid trace, no spark.
+			barParts.push(span("━".repeat(barWidth), { fg: accent }));
+		} else {
+			// Traced portion.
+			if (filledCells > 0) barParts.push(span("━".repeat(filledCells), { fg: accent }));
+			// Spark glyph at leading edge — breathes slowly through SPARK_FRAMES.
+			// Using geometric-shapes chars only so vertical alignment matches ━/─.
+			const sparkIdx = Math.floor(this.tick / GLYPH_TICK_DIVISOR) % SPARK_FRAMES.length;
+			const glyph = SPARK_FRAMES[sparkIdx] ?? "◈";
+			barParts.push(span(glyph, { fg: accent }));
+			// Untraced track.
+			const trackWidth = barWidth - filledCells - 1;
+			if (trackWidth > 0) barParts.push(span("─".repeat(trackWidth), { fg: dim }));
+		}
+
+		const row = textLine(
+			[" ", ...barParts, span(labelStr, { fg: dim })],
+			{ fg: dim },
+		);
+		return [lineToAnsi(truncateLine(row, width))];
+	}
+
+	public dispose(): void {
+		if (this.interval !== undefined) {
+			clearInterval(this.interval);
+			this.interval = undefined;
+		}
+		this.themeUnsubscribe?.();
+		this.themeUnsubscribe = undefined;
+	}
+}
+
+/**
+ * Registers the compaction indicator for retained SumoTUI mode.
+ * No-op in classic Pi (Pi's `statusContainer` Loader handles it there).
+ */
+export function installCompactionIndicator(pi: ExtensionAPI): void {
+	if (!isRetainedMode()) return;
+
+	let active = false;
+	let currentComponent: CompactionStatusComponent | undefined;
+
+	const clearWidget = (ctx: { hasUI: boolean; ui: { setWidget(...args: unknown[]): void } }): void => {
+		currentComponent?.dispose();
+		currentComponent = undefined;
+		active = false;
+		if (ctx.hasUI) ctx.ui.setWidget(COMPACTION_INDICATOR_WIDGET_KEY, undefined, { placement: "aboveEditor" });
+	};
+
+	pi.on("session_before_compact", async (event, ctx) => {
+		if (!ctx.hasUI) return undefined;
+		// `compaction_start` fires before this event and sets the reason.
+		// Fall back to `customInstructions` heuristic for headless / test paths.
+		const reason = getCompactionReason();
+		const isManual = reason === "manual" || (reason === null && event.customInstructions !== undefined);
+		const label = isManual ? "Compacting…" : "Auto-compacting…";
+		const factory = (tui: TUI): Component & { dispose?(): void } => {
+			currentComponent?.dispose();
+			currentComponent = new CompactionStatusComponent(label, tui);
+			return currentComponent;
+		};
+		ctx.ui.setWidget(COMPACTION_INDICATOR_WIDGET_KEY, factory, { placement: "aboveEditor" });
+		active = true;
+		return undefined;
+	});
+
+	pi.on("session_compact", async (_event, ctx) => {
+		if (!active) return;
+		// Snap to 100 % and hold briefly so the user sees completion.
+		if (currentComponent) await currentComponent.markComplete();
+		// Belt-and-suspenders: clear the reason even if compaction_end already
+		// cleared it, so no stale value survives into the next compaction.
+		setCompactionReason(null);
+		clearWidget(ctx as Parameters<typeof clearWidget>[0]);
+	});
+
+	pi.on("session_shutdown", (_event, ctx) => {
+		if (!active) return;
+		// Abort/reload — clear immediately, no hold.
+		// Also clear the reason: compaction_end may never fire on abort paths,
+		// leaving a stale value that would mislabel the next compaction.
+		setCompactionReason(null);
+		clearWidget(ctx as Parameters<typeof clearWidget>[0]);
+	});
+}

--- a/src/compaction-state.ts
+++ b/src/compaction-state.ts
@@ -1,0 +1,25 @@
+/**
+ * Tiny shared state for compaction reason.
+ *
+ * Pi fires `compaction_start` (with `reason: "manual" | "threshold" | "overflow"`)
+ * BEFORE `session_before_compact`. By the time the extension event fires, the
+ * reason is already stored here via `chat-viewport-controller.ts`'s handleEvent
+ * intercept, so `compaction-indicator.ts` can read it for the correct label.
+ *
+ * Pinned on `globalThis` with a symbol key so jiti module-cache:false reloads
+ * share the same value (same pattern as theme registry and active runtime).
+ */
+
+const COMPACTION_REASON_KEY = Symbol.for("sumocode.compactionReason");
+
+export type CompactionReason = "manual" | "threshold" | "overflow";
+
+type Global = typeof globalThis & Record<symbol, CompactionReason | null>;
+
+export function setCompactionReason(reason: CompactionReason | null): void {
+	(globalThis as Global)[COMPACTION_REASON_KEY] = reason;
+}
+
+export function getCompactionReason(): CompactionReason | null {
+	return (globalThis as Global)[COMPACTION_REASON_KEY] ?? null;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import { installSessionCache } from "./session-cache.js";
 import { installSplash } from "./splash.js";
 import { installTopChrome } from "./top-chrome.js";
 import { installWorkingIndicator } from "./working-indicator.js";
+import { installCompactionIndicator } from "./compaction-indicator.js";
 
 const SUMOCODE_PACKAGE_NAME = "@dhruvkelawala/sumocode";
 const LEGACY_TASK_TOOL_EXTENSION_PATH = join(".pi", "agent", "extensions", "task-tool", "index.ts");
@@ -159,6 +160,7 @@ export default function sumocode(pi: ExtensionAPI): void {
 
 
 	installWorkingIndicator(pi);
+	installCompactionIndicator(pi);
 	registerSumoReloadCommand(pi);
 	installSumoInteractions(pi);
 }

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -17,6 +17,7 @@ import { chatScrollCommandFromInput } from "../widgets/chat-scroll-command.js";
 import { SIDEBAR_MIN_TERMINAL_WIDTH, SIDEBAR_WIDTH } from "../../sidebar.js";
 import { sidebarGutterWidth } from "../../sidebar-placement.js";
 import { normalizeRawMultilinePasteInput } from "../../cathedral/multiline-paste.js";
+import { setCompactionReason, type CompactionReason } from "../../compaction-state.js";
 
 const CHAT_VIEWPORT_BRIDGE_INSTALLED = Symbol("sumo-tui.chat-viewport-bridge-installed");
 const PORTRAIT_STATUS_MIN_WIDTH = 80;
@@ -543,6 +544,12 @@ export class ChatViewportController {
 				break;
 			case "agent_end":
 				this.chat.endStreaming();
+				break;
+			case "compaction_start":
+				setCompactionReason(record.reason as CompactionReason);
+				break;
+			case "compaction_end":
+				setCompactionReason(null);
 				break;
 		}
 	}

--- a/src/sumo-tui/pi-compat/owned-shell-renderer.test.ts
+++ b/src/sumo-tui/pi-compat/owned-shell-renderer.test.ts
@@ -241,7 +241,7 @@ describe("OwnedShellRenderer", () => {
 			widgetContainerBelow: () => new StaticComponent(["HINT"]),
 			footer: () => new StaticComponent(["FOOTER"]),
 			terminal: fakeTerminal.owner,
-			dimensions: { columns: 60, rows: 24 },
+			dimensions: { columns: 60, rows: 25 },
 		});
 
 		renderer.render();

--- a/src/sumo-tui/pi-compat/owned-shell-renderer.ts
+++ b/src/sumo-tui/pi-compat/owned-shell-renderer.ts
@@ -257,10 +257,11 @@ export class OwnedShellRenderer {
 						// Drop Pi's leading Spacer(1). If nothing remains, no above-editor
 						// widget is installed, so collapse to zero rows. If a widget remains
 						// but renders blank (the retained working indicator's idle state),
-						// still reserve the same breathing + widget + breathing block so
-						// agent_start/agent_end does not shift the editor/footer.
+						// still reserve the block height so agent_start/agent_end does not
+						// shift the editor. Leading blank provided here; trailing gap is
+						// provided by belowIndicatorSpacer (always SHELL_BLANK_ROW).
 						const content = raw.length > 1 ? raw.slice(1) : [];
-						return content.length > 0 ? ["", ...content, ""] : [];
+						return content.length > 0 ? ["", ...content] : [];
 					},
 					invalidate: () => aboveSource.invalidate?.(),
 				}
@@ -365,12 +366,15 @@ export class OwnedShellRenderer {
 		if (centerWithSplash && this.splash) {
 			if (this.splash.bottomSpacer.parent === this.splash.root) this.splash.root.removeChild(this.splash.bottomSpacer);
 			// Splash mode never shows the working indicator (no agent activity yet),
-			// so the above-editor leaf stays detached and only one breathing row
-			// is mounted. Restore this shared spacer because the active branch may
-			// collapse it to zero height when the host exposes widgetContainerAbove.
+			// so the above-editor leaf stays detached and both indicator spacers are
+			// repurposed: belowIndicatorSpacer provides breathing above the editor,
+			// aboveIndicatorSpacer provides the gap between editor and hint row.
+			// Restore both to SHELL_BLANK_ROW because active-layout may have zeroed one.
+			this.aboveIndicatorSpacer.height = SHELL_BLANK_ROW;
 			this.belowIndicatorSpacer.height = SHELL_BLANK_ROW;
 			this.splash.root.addChild(this.belowIndicatorSpacer);
 			this.splash.root.addChild(this.editorRow);
+			this.splash.root.addChild(this.aboveIndicatorSpacer);
 			this.splash.root.addChild(this.hintLeaf);
 			this.splash.root.addChild(this.splash.bottomSpacer);
 			this.root.addChild(this.footerGapSpacer);
@@ -379,7 +383,10 @@ export class OwnedShellRenderer {
 		} else {
 			if (this.splash && this.splash.bottomSpacer.parent !== this.splash.root) this.splash.root.addChild(this.splash.bottomSpacer);
 			if (this.hasAboveEditorContainer) this.root.addChild(this.aboveEditorLeaf);
-			this.belowIndicatorSpacer.height = this.hasAboveEditorContainer ? 0 : SHELL_BLANK_ROW;
+			// Always 1 explicit blank row between the above-editor block and the
+			// editor. The aboveProxy provides a leading blank; this spacer provides
+			// the trailing gap so the bar / indicator never touches the input frame.
+			this.belowIndicatorSpacer.height = SHELL_BLANK_ROW;
 			this.root.addChild(this.belowIndicatorSpacer);
 			this.root.addChild(this.editorRow);
 			this.root.addChild(this.hintLeaf);
@@ -465,6 +472,7 @@ export class OwnedShellRenderer {
 		// PiComponentLeaf would return its stale cached measure and the autocomplete
 		// dropdown would be clipped or invisible.
 		this.headerLeaf.markDirty();
+		this.aboveEditorLeaf.markDirty();
 		this.editorLeaf.markDirty();
 		this.hintLeaf.markDirty();
 		this.footerLeaf.markDirty();


### PR DESCRIPTION
## Problem
In retained SumoTUI mode, Pi's `statusContainer` output (which carries `Compacting…` / `Auto-compacting…`) is discarded because SumoTUI replaces Pi's render loop. Pi's `widgetContainerAbove` is surfaced via `aboveEditorLeaf`, but `statusContainer` never reaches the Yoga frame.

## Solution
`src/compaction-indicator.ts` — dedicated module mirroring Pi's `statusContainer` pattern:
- Hooks `session_before_compact` → mounts a one-row `aboveEditor` widget with themed `⟳` glyph
  - `customInstructions !== undefined` → **"Compacting…"** (user ran `/compact`)  
  - `customInstructions === undefined` → **"Auto-compacting…"** (overflow/auto)
- Hooks `session_compact` → clears the widget
- Hooks `session_shutdown` → safety clear on abort/reload
- Classic Pi (no `SUMO_TUI`) → no-op; Pi's own `statusContainer` Loader already handles it

The widget key is distinct from the working indicator, so both can coexist in the `aboveEditor` slot without interference.

## Verification
- `pnpm exec tsc --noEmit` ✓
- `pnpm vitest run src/compaction-indicator.test.ts` ✓ — 8 tests
- `pnpm test` ✓ — 102 files / 766 tests
- `pnpm test:integration` ✓ — 16 files / 22 tests

Closes #1 of Slate item: compaction status not visible in SumoCode