### PR TITLE
Scrub SumoCode debug env in integration test spawn

### DIFF
--- a/test/integration/spawn-pi-pty.test.ts
+++ b/test/integration/spawn-pi-pty.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { buildSpawnEnv } from "./spawn-pi-pty.js";
+
+describe("buildSpawnEnv", () => {
+	it("scrubs inherited SumoCode debug env vars", () => {
+		const env = buildSpawnEnv(
+			{
+				PATH: "/usr/bin",
+				HOME: "/Users/test",
+				SUMO_TUI: "1",
+				SUMO_TUI_DEBUG: "1",
+				SUMO_TUI_DIAG_FILE: "/tmp/sumocode-manual.jsonl",
+				SUMO_TUI_MODULE: "file:///tmp/fake.js",
+				SUMO_TUI_HIDE_PI_NOISE: "1",
+				SUMOCODE_REDUCED_MOTION: "1",
+				SUMOCODE_DEBUG_BRANCH: "feature/x",
+				SUMOCODE_DEBUG_COMMIT: "abc123",
+			},
+			undefined,
+		);
+
+		expect(env.SUMO_TUI).toBeUndefined();
+		expect(env.SUMO_TUI_DEBUG).toBeUndefined();
+		expect(env.SUMO_TUI_DIAG_FILE).toBeUndefined();
+		expect(env.SUMO_TUI_MODULE).toBeUndefined();
+		expect(env.SUMO_TUI_HIDE_PI_NOISE).toBeUndefined();
+		expect(env.SUMOCODE_REDUCED_MOTION).toBeUndefined();
+		expect(env.SUMOCODE_DEBUG_BRANCH).toBeUndefined();
+		expect(env.SUMOCODE_DEBUG_COMMIT).toBeUndefined();
+		expect(env.PATH).toBe("/usr/bin");
+		expect(env.HOME).toBe("/Users/test");
+	});
+
+	it("applies pi-friendly defaults", () => {
+		const env = buildSpawnEnv({}, undefined);
+		expect(env.PI_OFFLINE).toBe("1");
+		expect(env.TERM).toBe("xterm-256color");
+	});
+
+	it("lets per-test overrides reintroduce scrubbed keys", () => {
+		const env = buildSpawnEnv(
+			{ SUMO_TUI: "1" },
+			{ SUMO_TUI: "1", SUMO_TUI_MODULE: "file:///opt/explicit.js" },
+		);
+		expect(env.SUMO_TUI).toBe("1");
+		expect(env.SUMO_TUI_MODULE).toBe("file:///opt/explicit.js");
+	});
+
+	it("lets overrides win over scrub when intentionally setting the same key", () => {
+		const env = buildSpawnEnv(
+			{ SUMO_TUI_DEBUG: "1" },
+			{ SUMO_TUI_DEBUG: "0" },
+		);
+		expect(env.SUMO_TUI_DEBUG).toBe("0");
+	});
+
+	it("preserves overrides for unrelated env vars", () => {
+		const env = buildSpawnEnv({ HOME: "/Users/parent" }, { PI_CODING_AGENT_DIR: "/tmp/foo" });
+		expect(env.HOME).toBe("/Users/parent");
+		expect(env.PI_CODING_AGENT_DIR).toBe("/tmp/foo");
+	});
+});

--- a/test/integration/spawn-pi-pty.ts
+++ b/test/integration/spawn-pi-pty.ts
@@ -70,6 +70,34 @@ function parseTerminalState(buffer: string): TerminalStateProbe {
 	};
 }
 
+/**
+ * SumoCode debug env vars that leak retained-mode wiring or diagnostics into
+ * spawned tests when set in the developer's shell (e.g. `sumocode -d`). They
+ * must NOT be inherited by integration child processes unless a test
+ * explicitly opts in via `options.env`. See #187.
+ */
+const SUMO_DEBUG_ENV_KEYS = [
+	"SUMO_TUI",
+	"SUMO_TUI_DEBUG",
+	"SUMO_TUI_DIAG_FILE",
+	"SUMO_TUI_MODULE",
+	"SUMO_TUI_HIDE_PI_NOISE",
+	"SUMOCODE_REDUCED_MOTION",
+	"SUMOCODE_DEBUG_BRANCH",
+	"SUMOCODE_DEBUG_COMMIT",
+] as const;
+
+export function buildSpawnEnv(parent: NodeJS.ProcessEnv, overrides: NodeJS.ProcessEnv | undefined): NodeJS.ProcessEnv {
+	const scrubbed: NodeJS.ProcessEnv = { ...parent };
+	for (const key of SUMO_DEBUG_ENV_KEYS) delete scrubbed[key];
+	return {
+		...scrubbed,
+		...(overrides ?? {}),
+		PI_OFFLINE: "1",
+		TERM: "xterm-256color",
+	};
+}
+
 export function spawnPiPty(options: SpawnPiPtyOptions = {}): SpawnedPiPty {
 	ensureNodePtySpawnHelperExecutable();
 
@@ -79,12 +107,7 @@ export function spawnPiPty(options: SpawnPiPtyOptions = {}): SpawnedPiPty {
 		cols: options.cols ?? 100,
 		rows: options.rows ?? 30,
 		cwd,
-		env: {
-			...process.env,
-			...options.env,
-			PI_OFFLINE: "1",
-			TERM: "xterm-256color",
-		},
+		env: buildSpawnEnv(process.env, options.env),
 	});
 
 	let output = "";


### PR DESCRIPTION
## Summary

Fixes #187. Local integration tests fail when the developer shell has `sumocode -d` debug env vars exported (`SUMO_TUI=1`, `SUMO_TUI_DEBUG=1`, `SUMO_TUI_DIAG_FILE`, `SUMO_TUI_MODULE`, etc.) because `spawnPiPty` blindly inherited `process.env`, leaking retained-mode wiring + diagnostics into PTY children.

## What changed

`test/integration/spawn-pi-pty.ts`:

- new `buildSpawnEnv(parent, overrides)` helper that:
  - copies parent env
  - deletes a known set of SumoCode debug keys (`SUMO_TUI`, `SUMO_TUI_DEBUG`, `SUMO_TUI_DIAG_FILE`, `SUMO_TUI_MODULE`, `SUMO_TUI_HIDE_PI_NOISE`, `SUMOCODE_REDUCED_MOTION`, `SUMOCODE_DEBUG_BRANCH`, `SUMOCODE_DEBUG_COMMIT`)
  - applies per-test `options.env` overrides last so opting in stays explicit
  - sets `PI_OFFLINE=1` and `TERM=xterm-256color`
- `spawnPiPty` now uses `buildSpawnEnv(process.env, options.env)`

## Tests

- new `test/integration/spawn-pi-pty.test.ts` covers:
  - debug keys are scrubbed when not overridden
  - defaults are applied (`PI_OFFLINE`, `TERM`)
  - per-test overrides reintroduce scrubbed keys
  - per-test overrides win over inherited values
  - unrelated env keys pass through

## Verification

Passed locally:

```txt
pnpm exec tsc --noEmit
pnpm test
pnpm test:integration
SUMO_TUI=1 SUMO_TUI_DEBUG=1 SUMO_TUI_DIAG_FILE=/tmp/sumocode-manual.jsonl SUMO_TUI_MODULE=file:///tmp/fake pnpm test:integration
```

All 18 integration files / 29 tests pass in both clean and contaminated parent shells.

Closes #187
