### PR TITLE
Allow text selection in input editor

### DIFF
--- a/src/sumo-tui/widgets/pi-editor-leaf.test.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.test.ts
@@ -106,7 +106,7 @@ describe("PiEditorLeaf", () => {
 			"\u2502 hello \u2502",
 			"\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256F",
 		];
-		const leaf = new PiEditorLeaf(yoga.Node.create(), asEditor(new FakeEditor(rows)), root);
+		new PiEditorLeaf(yoga.Node.create(), asEditor(new FakeEditor(rows)), root);
 		root.width = 9;
 		root.yogaNode.calculateLayout(9, undefined, DIRECTION_LTR);
 		const buffer = new CellBuffer(3, 9);

--- a/src/sumo-tui/widgets/pi-editor-leaf.test.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.test.ts
@@ -126,6 +126,27 @@ describe("PiEditorLeaf", () => {
 		root.dispose();
 	});
 
+	it("treats embedded separators inside content rows as selectable", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const rows = [
+			"\u256D\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256E",
+			"\u2502 \u2500\u2500\u2500\u2500\u2500 \u2502",
+			"\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256F",
+		];
+		new PiEditorLeaf(yoga.Node.create(), asEditor(new FakeEditor(rows)), root);
+		root.width = 9;
+		root.yogaNode.calculateLayout(9, undefined, DIRECTION_LTR);
+		const buffer = new CellBuffer(3, 9);
+		composite(root, buffer);
+
+		// the separator row still has side `│` borders, so its inner cells stay selectable
+		for (let col = 1; col <= 7; col += 1) {
+			expect(buffer.getSelectionMeta(1, col)).toEqual({ selectable: true });
+		}
+		root.dispose();
+	});
+
 	it("keeps blank rows inside multiline prompts selectable so paragraph breaks survive copy", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());

--- a/src/sumo-tui/widgets/pi-editor-leaf.test.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.test.ts
@@ -126,6 +126,30 @@ describe("PiEditorLeaf", () => {
 		root.dispose();
 	});
 
+	it("keeps blank rows inside multiline prompts selectable so paragraph breaks survive copy", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const rows = [
+			"\u256D\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256E",
+			"\u2502 line1 \u2502",
+			"\u2502       \u2502",
+			"\u2502 line3 \u2502",
+			"\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256F",
+		];
+		new PiEditorLeaf(yoga.Node.create(), asEditor(new FakeEditor(rows)), root);
+		root.width = 9;
+		root.yogaNode.calculateLayout(9, undefined, DIRECTION_LTR);
+		const buffer = new CellBuffer(5, 9);
+		composite(root, buffer);
+
+		for (const row of [1, 2, 3]) {
+			for (let col = 1; col <= 7; col += 1) {
+				expect(buffer.getSelectionMeta(row, col)).toEqual({ selectable: true });
+			}
+		}
+		root.dispose();
+	});
+
 	it("preserves ANSI underline around IME pre-edit while stripping only the marker (EC-1.5)", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());

--- a/src/sumo-tui/widgets/pi-editor-leaf.test.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.test.ts
@@ -142,6 +142,30 @@ describe("PiEditorLeaf", () => {
 		root.dispose();
 	});
 
+	it("keeps a user-typed box-drawing row in the middle of a multiline prompt selectable", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const rows = [
+			"\u256D\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256E",
+			"\u2502 hello \u2502",
+			"\u2502\u250C\u2500\u2500\u2500\u2500\u2500\u2510\u2502",
+			"\u2502 world \u2502",
+			"\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256F",
+		];
+		new PiEditorLeaf(yoga.Node.create(), asEditor(new FakeEditor(rows)), root);
+		root.width = 9;
+		root.yogaNode.calculateLayout(9, undefined, DIRECTION_LTR);
+		const buffer = new CellBuffer(5, 9);
+		composite(root, buffer);
+
+		// the middle row is box-drawing-only but sits inside the frame, so its
+		// inner cells stay selectable
+		for (let col = 1; col <= 7; col += 1) {
+			expect(buffer.getSelectionMeta(2, col)).toEqual({ selectable: true });
+		}
+		root.dispose();
+	});
+
 	it("keeps a bare horizontal-bar row selectable when no corners frame it", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());

--- a/src/sumo-tui/widgets/pi-editor-leaf.test.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.test.ts
@@ -126,6 +126,38 @@ describe("PiEditorLeaf", () => {
 		root.dispose();
 	});
 
+	it("marks every cell selectable when the editor renders without a frame (e.g. Pi resume selector)", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const rows = ["SELECT SESSION"];
+		new PiEditorLeaf(yoga.Node.create(), asEditor(new FakeEditor(rows)), root);
+		root.width = 14;
+		root.yogaNode.calculateLayout(14, undefined, DIRECTION_LTR);
+		const buffer = new CellBuffer(1, 14);
+		composite(root, buffer);
+
+		for (let col = 0; col < 14; col += 1) {
+			expect(buffer.getSelectionMeta(0, col)).toEqual({ selectable: true });
+		}
+		root.dispose();
+	});
+
+	it("keeps a bare horizontal-bar row selectable when no corners frame it", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const rows = ["\u2500\u2500\u2500\u2500\u2500"];
+		new PiEditorLeaf(yoga.Node.create(), asEditor(new FakeEditor(rows)), root);
+		root.width = 5;
+		root.yogaNode.calculateLayout(5, undefined, DIRECTION_LTR);
+		const buffer = new CellBuffer(1, 5);
+		composite(root, buffer);
+
+		for (let col = 0; col < 5; col += 1) {
+			expect(buffer.getSelectionMeta(0, col)).toEqual({ selectable: true });
+		}
+		root.dispose();
+	});
+
 	it("treats embedded separators inside content rows as selectable", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());

--- a/src/sumo-tui/widgets/pi-editor-leaf.test.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.test.ts
@@ -98,6 +98,34 @@ describe("PiEditorLeaf", () => {
 		root.dispose();
 	});
 
+	it("marks inner editor cells as selectable so drag-to-copy works (#207-style follow-up)", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const rows = [
+			"\u256D\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256E",
+			"\u2502 hello \u2502",
+			"\u2570\u2500\u2500\u2500\u2500\u2500\u2500\u2500\u256F",
+		];
+		const leaf = new PiEditorLeaf(yoga.Node.create(), asEditor(new FakeEditor(rows)), root);
+		root.width = 9;
+		root.yogaNode.calculateLayout(9, undefined, DIRECTION_LTR);
+		const buffer = new CellBuffer(3, 9);
+		composite(root, buffer);
+
+		// border rows must remain non-selectable
+		for (let col = 0; col < 9; col += 1) {
+			expect(buffer.getSelectionMeta(0, col)).toBeUndefined();
+			expect(buffer.getSelectionMeta(2, col)).toBeUndefined();
+		}
+		// content row marks inner cells but not the side border columns
+		expect(buffer.getSelectionMeta(1, 0)).toBeUndefined();
+		expect(buffer.getSelectionMeta(1, 8)).toBeUndefined();
+		for (let col = 1; col <= 7; col += 1) {
+			expect(buffer.getSelectionMeta(1, col)).toEqual({ selectable: true });
+		}
+		root.dispose();
+	});
+
 	it("preserves ANSI underline around IME pre-edit while stripping only the marker (EC-1.5)", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());

--- a/src/sumo-tui/widgets/pi-editor-leaf.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.ts
@@ -5,6 +5,19 @@ import type { Yoga, YogaNode } from "../layout/yoga.js";
 import type { CellBuffer, Rect } from "../render/buffer.js";
 import { PiComponentLeaf } from "./pi-component-leaf.js";
 
+const ANSI_PATTERN = /\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]|\x1b[()][A-Za-z0-9]/g;
+const BORDER_ONLY_PATTERN = /^[\s\u2500-\u257F]*$/;
+
+function stripAnsi(value: string): string {
+	return value.replace(ANSI_PATTERN, "");
+}
+
+function isBorderRow(rendered: string): boolean {
+	const plain = stripAnsi(rendered).replace(/[\u200B-\u200F]/g, "");
+	if (plain.length === 0) return true;
+	return BORDER_ONLY_PATTERN.test(plain);
+}
+
 export interface HardwareCursorPosition {
 	row: number;
 	col: number;
@@ -51,6 +64,16 @@ export class PiEditorLeaf extends PiComponentLeaf {
 						fallbackInverseCursor = { row: rect.top + row, col: rect.left + col };
 						break;
 					}
+				}
+			}
+			if (!isBorderRow(painted) && rect.width >= 3) {
+				// Mark inner editor cells as selectable so the user can drag-copy the
+				// prompt text. Skip the leftmost / rightmost columns: the Cathedral
+				// input frame paints `│ … │` so the outer cells are border glyphs.
+				const startCol = rect.left + 1;
+				const endCol = rect.left + rect.width - 2;
+				for (let col = startCol; col <= endCol; col += 1) {
+					buffer.setSelectionMeta(row + rect.top, col, { selectable: true });
 				}
 			}
 		}

--- a/src/sumo-tui/widgets/pi-editor-leaf.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.ts
@@ -7,6 +7,7 @@ import { PiComponentLeaf } from "./pi-component-leaf.js";
 
 const ANSI_PATTERN = /\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]|\x1b[()][A-Za-z0-9]/g;
 const HORIZONTAL_BAR_PATTERN = /[\u2500\u2501\u2504\u2505\u2508\u2509\u254C\u254D\u2550]/;
+const VERTICAL_BAR_PATTERN = /[\u2502\u2503\u2506\u2507\u250A\u250B\u254E\u254F\u2551]/;
 const NON_BORDER_PATTERN = /[^\s\u2500-\u257F]/;
 
 function stripAnsi(value: string): string {
@@ -14,15 +15,18 @@ function stripAnsi(value: string): string {
 }
 
 /**
- * A row is a frame border iff it contains at least one horizontal box-drawing
- * bar (─━═ etc) and no non-whitespace, non-box-drawing characters. Side-only
- * frame rows like `│ hello │` and `│       │` (intentional blank line in a
- * multiline prompt) are content rows so multiline selection still picks up
- * paragraph breaks during copy.
+ * Classify the editor frame's top/bottom border rows. A border row contains
+ * at least one horizontal box-drawing bar (─━═ etc), no vertical bar
+ * (│┃║ etc), and no non-box-drawing content characters. Side-bordered
+ * content rows like `│ hello │`, blank rows like `│       │`, and editor
+ * content that intentionally embeds a separator like `│ ───── │` therefore
+ * stay selectable so multiline copy preserves paragraph breaks and inline
+ * separators.
  */
 function isBorderRow(rendered: string): boolean {
 	const plain = stripAnsi(rendered).replace(/[\u200B-\u200F]/g, "");
 	if (!HORIZONTAL_BAR_PATTERN.test(plain)) return false;
+	if (VERTICAL_BAR_PATTERN.test(plain)) return false;
 	return !NON_BORDER_PATTERN.test(plain);
 }
 

--- a/src/sumo-tui/widgets/pi-editor-leaf.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.ts
@@ -6,16 +6,24 @@ import type { CellBuffer, Rect } from "../render/buffer.js";
 import { PiComponentLeaf } from "./pi-component-leaf.js";
 
 const ANSI_PATTERN = /\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]|\x1b[()][A-Za-z0-9]/g;
-const BORDER_ONLY_PATTERN = /^[\s\u2500-\u257F]*$/;
+const HORIZONTAL_BAR_PATTERN = /[\u2500\u2501\u2504\u2505\u2508\u2509\u254C\u254D\u2550]/;
+const NON_BORDER_PATTERN = /[^\s\u2500-\u257F]/;
 
 function stripAnsi(value: string): string {
 	return value.replace(ANSI_PATTERN, "");
 }
 
+/**
+ * A row is a frame border iff it contains at least one horizontal box-drawing
+ * bar (─━═ etc) and no non-whitespace, non-box-drawing characters. Side-only
+ * frame rows like `│ hello │` and `│       │` (intentional blank line in a
+ * multiline prompt) are content rows so multiline selection still picks up
+ * paragraph breaks during copy.
+ */
 function isBorderRow(rendered: string): boolean {
 	const plain = stripAnsi(rendered).replace(/[\u200B-\u200F]/g, "");
-	if (plain.length === 0) return true;
-	return BORDER_ONLY_PATTERN.test(plain);
+	if (!HORIZONTAL_BAR_PATTERN.test(plain)) return false;
+	return !NON_BORDER_PATTERN.test(plain);
 }
 
 export interface HardwareCursorPosition {

--- a/src/sumo-tui/widgets/pi-editor-leaf.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.ts
@@ -86,7 +86,13 @@ export class PiEditorLeaf extends PiComponentLeaf {
 					}
 				}
 			}
-			if (!isBorderRow(painted) && rect.width >= 1) {
+			// Cathedral input frame's top/bottom borders only ever appear at the
+			// outer edges of the editor render. Restrict the box-drawing border
+			// classification to those positions so that user-typed content rows
+			// composed only of box-drawing glyphs (e.g. `┌────┐`, `┬────┬`) in the
+			// middle of a multiline prompt remain selectable.
+			const isOuterRow = row === 0 || row === height - 1;
+			if ((!isOuterRow || !isBorderRow(painted)) && rect.width >= 1) {
 				// Mark editor content cells as selectable so the user can drag-copy
 				// the prompt text. The Cathedral input frame paints `│ … │`, so when
 				// the actual edge cells are vertical-bar glyphs we skip them; for

--- a/src/sumo-tui/widgets/pi-editor-leaf.ts
+++ b/src/sumo-tui/widgets/pi-editor-leaf.ts
@@ -8,6 +8,7 @@ import { PiComponentLeaf } from "./pi-component-leaf.js";
 const ANSI_PATTERN = /\x1b\][^\x07]*(?:\x07|\x1b\\)|\x1b\[[0-?]*[ -/]*[@-~]|\x1b[()][A-Za-z0-9]/g;
 const HORIZONTAL_BAR_PATTERN = /[\u2500\u2501\u2504\u2505\u2508\u2509\u254C\u254D\u2550]/;
 const VERTICAL_BAR_PATTERN = /[\u2502\u2503\u2506\u2507\u250A\u250B\u254E\u254F\u2551]/;
+const CORNER_PATTERN = /[\u250C-\u251B\u2552-\u255D\u256D-\u2570]/;
 const NON_BORDER_PATTERN = /[^\s\u2500-\u257F]/;
 
 function stripAnsi(value: string): string {
@@ -15,19 +16,26 @@ function stripAnsi(value: string): string {
 }
 
 /**
- * Classify the editor frame's top/bottom border rows. A border row contains
- * at least one horizontal box-drawing bar (─━═ etc), no vertical bar
- * (│┃║ etc), and no non-box-drawing content characters. Side-bordered
- * content rows like `│ hello │`, blank rows like `│       │`, and editor
- * content that intentionally embeds a separator like `│ ───── │` therefore
- * stay selectable so multiline copy preserves paragraph breaks and inline
- * separators.
+ * Classify the editor frame's top/bottom border rows. A border row needs all of:
+ *   - at least one horizontal bar (─━═ etc)
+ *   - at least one box corner glyph (┌┐└┘ / ╭╮╯╰ / ╔╗╚╝ etc)
+ *   - no vertical bars (│┃║ etc)
+ *   - no non-box-drawing content characters
+ * That keeps content rows like `│ hello │`, `│       │`, `│ ───── │`, and a
+ * user-typed bare `─────` separator selectable while still excluding the
+ * Cathedral input frame's `╭──╮` and `╰──╯` border rows.
  */
 function isBorderRow(rendered: string): boolean {
 	const plain = stripAnsi(rendered).replace(/[\u200B-\u200F]/g, "");
 	if (!HORIZONTAL_BAR_PATTERN.test(plain)) return false;
+	if (!CORNER_PATTERN.test(plain)) return false;
 	if (VERTICAL_BAR_PATTERN.test(plain)) return false;
 	return !NON_BORDER_PATTERN.test(plain);
+}
+
+function isVerticalBarChar(char: string | undefined): boolean {
+	if (!char) return false;
+	return VERTICAL_BAR_PATTERN.test(char);
 }
 
 export interface HardwareCursorPosition {
@@ -78,12 +86,21 @@ export class PiEditorLeaf extends PiComponentLeaf {
 					}
 				}
 			}
-			if (!isBorderRow(painted) && rect.width >= 3) {
-				// Mark inner editor cells as selectable so the user can drag-copy the
-				// prompt text. Skip the leftmost / rightmost columns: the Cathedral
-				// input frame paints `│ … │` so the outer cells are border glyphs.
-				const startCol = rect.left + 1;
-				const endCol = rect.left + rect.width - 2;
+			if (!isBorderRow(painted) && rect.width >= 1) {
+				// Mark editor content cells as selectable so the user can drag-copy
+				// the prompt text. The Cathedral input frame paints `│ … │`, so when
+				// the actual edge cells are vertical-bar glyphs we skip them; for
+				// non-framed rows (Pi's resume / model selector / confirm dialogs
+				// also render through this leaf flush to the rect edges) the edge
+				// cells stay selectable so first/last glyphs are not truncated on
+				// copy.
+				const lastCol = rect.width - 1;
+				const leftIsBar = isVerticalBarChar(buffer.getCell(row + rect.top, rect.left).char);
+				const rightIsBar = lastCol > 0
+					? isVerticalBarChar(buffer.getCell(row + rect.top, rect.left + lastCol).char)
+					: false;
+				const startCol = leftIsBar ? rect.left + 1 : rect.left;
+				const endCol = rightIsBar ? rect.left + lastCol - 1 : rect.left + lastCol;
 				for (let col = startCol; col <= endCol; col += 1) {
 					buffer.setSelectionMeta(row + rect.top, col, { selectable: true });
 				}


### PR DESCRIPTION
## Summary

Dhruv reported that mouse drag-selection inside the input editor doesn't work. Once chat had any selection metadata, `SelectionController` switched to *semantic* mode and rejected mouse-down on cells that weren't tagged `selectable`. Editor cells were never tagged, so the editor input frame was a dead zone for selection.

## What changed

`src/sumo-tui/widgets/pi-editor-leaf.ts`:

- after painting each editor row, mark the inner cells `selectable: true`
- skip pure box-drawing rows (top/bottom border)
- skip leftmost / rightmost columns on content rows so the Cathedral frame's `│` glyphs stay non-selectable, matching how `chat-message` excludes its frame

## Tests

- new test in `src/sumo-tui/widgets/pi-editor-leaf.test.ts` confirms:
  - top/bottom border rows are not selectable
  - inner cells `[1, width-2]` of content rows are selectable
  - side border columns (`0` and `width-1`) stay non-selectable

## Verification

Passed locally:

```txt
pnpm exec tsc --noEmit
pnpm vitest run src/sumo-tui/widgets/pi-editor-leaf.test.ts src/sumo-tui/input/selection.test.ts
pnpm test
pnpm test:integration
pnpm visual:ci
```

## How to test

```bash
git pull && git switch fix/editor-selection
pnpm install
./bin/sumocode.sh
```

Type something into the input frame, then click-and-drag with the mouse over the typed text. The selection should now highlight, and `⌘C` should put the text on the clipboard via OSC 52.
