### PR TITLE
Memory Scriptorium chrome + nav + filter + d-forget

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,7 @@ Required crops gate against committed approved runtime goldens. Bible diffs rema
 - `docs/SUMO_TUI_RENDER_PRIMITIVES.md` — typed render primitive contract.
 - `docs/SUMO_TUI_TEST_BACKEND.md` — headless retained-renderer test backend contract.
 - `docs/SUMO_TUI_TRANSCRIPT_MODEL.md` — structured transcript view-model contract.
+- `docs/cathedral/SCRIPTORIUM_CHROME.md` — shared modal painting contract; read this before adding any new Cathedral overlay (Divine Query / Approval / Memory Scriptorium share it).
 - `docs/visual/parity/PORTRAIT_REVIEW.md` — portrait scene composition review.
 - `docs/visual/parity/FIXTURE_STATES_REVIEW.md` — fixture lane and deterministic state review.
 - `docs/prd.md` / `docs/prd.html` — formal product spec.

--- a/docs/cathedral/SCRIPTORIUM_CHROME.md
+++ b/docs/cathedral/SCRIPTORIUM_CHROME.md
@@ -1,0 +1,144 @@
+# Scriptorium Chrome — shared modal painting contract
+
+`src/cathedral/scriptorium-chrome.ts` is the single source of truth for the
+painting vocabulary used by every Cathedral overlay modal:
+
+| Modal | File | Bible source |
+|---|---|---|
+| Divine Query (Element 11) | `src/divine-query.ts` | `docs/ui/bible/11-divine-query-*.html` |
+| Approval Required (Element 6) | `src/approval-modal.ts` | (V2 spec §6) |
+| Memory Scriptorium (Element 7) | `src/memory-editor.ts` | `docs/ui/bible/07-memory-editor*.html`, `scene-memory-scriptorium-overlay.html` |
+
+Pi's overlay host already provides the surrounding chrome (centered box, focus
+capture, escape routing). Modals are intentionally unframed at the outer edge
+— the lifted background painted through every cell is the visual frame.
+
+## When to add a new modal
+
+1. Read the V2 Bible HTML for the element you are implementing.
+2. Compose the modal using the helpers below — never hand-roll
+   `\u001b[38;2;...m` escapes for cells inside the panel; that breaks the
+   lifted-bg contract.
+3. Render the modal as a flat list of inner lines.
+4. Wrap each inner line through `wrapPanelRow(line, width)` so the lifted
+   background paints through every cell at full content width.
+5. Mount through Pi's overlay system (`ctx.ui.custom(..., { overlay: true,
+   overlayOptions: { anchor: "center", ... } })`).
+
+## Helpers
+
+### Painting
+
+```ts
+fg(text, hex)
+//   foreground colour (24-bit). Use for any text that does NOT need a
+//   persistent background.
+
+persistentBg(text, fgHex, bgHex)
+//   Re-applies fg+bg after every embedded `\x1b[0m` reset so a nested
+//   sub-style does not snap back to the underlying scene's background.
+//   Use this for `wrapPanelRow` and any inner sub-frame that has its own
+//   background (e.g. the approval modal's command box).
+
+wrapPanelRow(line, width)
+//   Pads `line` to `width` and paints `foreground` over `surfaceLifted` for
+//   every cell. Always the LAST step before pushing into the modal output.
+
+sgr(hex, mode)
+//   Low-level: build a single SGR opener for `38` (fg) or `48` (bg). Useful
+//   for one-shot composite labels (e.g. inverse-button styling) where
+//   `persistentBg`'s reset-restore behaviour is unwanted.
+
+RESET
+//   Re-exported `\x1b[0m`. Use sparingly; prefer the higher-level helpers.
+```
+
+### Layout
+
+```ts
+visibleLength(text)
+fitLine(line, width)
+padRight(line, width)
+center(line, width)
+```
+
+All of these strip ANSI before measuring. `fitLine` truncates with `\u2026`
+when `line` exceeds `width`. None of them paint colour.
+
+### Cathedral conventions
+
+```ts
+splitRule(width)
+//   `\u2500\u2500\u2500\u2500\u2500  \u00b7  \u2500\u2500\u2500\u2500\u2500` divider centered to `width`, painted with the
+//   active theme's `divider` colour.
+
+titleRow(text, width)
+//   `\u273e  TEXT  \u273e` centered, painted with `accent` colour. The floral
+//   marks are `TITLE_FLOWER` and use the active theme's `accent`.
+
+focusMarker(focused)
+//   `\u2748` (accent) when focused, `\u00b7` (divider) when not.
+
+TITLE_FLOWER · FOCUSED_MARK · UNFOCUSED_MARK
+//   Constants if you need the raw glyphs (e.g. for visual diff fixtures).
+```
+
+## Render-order recipe
+
+Every Cathedral modal builds its output the same way:
+
+```ts
+function renderModal(snapshot, width) {
+    const inner: string[] = [];
+    inner.push("");                          // top breathing row
+    inner.push(titleRow("MY MODAL", width)); // floral title
+    inner.push("");
+    inner.push(splitRule(width));            // upper divider
+    inner.push("");
+    // ...modal-specific body rows here, using fg() for any colour...
+    inner.push("");
+    inner.push(splitRule(width));            // lower divider
+    inner.push(center(fg("\u2191\u2193 wander    \u23ce confirm    \u23c4 retreat",
+                         activeThemeColors().foregroundDim), width));
+    inner.push("");                          // bottom breathing row
+    return inner.map(line => wrapPanelRow(line, width)); // lifted bg pass
+}
+```
+
+The final `.map(line => wrapPanelRow(line, width))` is the part that often
+gets forgotten and produces the "broken modal" symptom: text floats over the
+underlying chat scene because every cell's background is whatever was beneath
+the overlay rather than `surfaceLifted`.
+
+## State machine + Pi component
+
+Each modal exposes:
+
+- a pure `update<Snapshot>(snapshot, key)` reducer for input handling
+- a tiny `Component` that owns the snapshot, calls the reducer, and routes
+  `done(result)` back to the caller of `ctx.ui.custom()`
+
+Keep the reducer pure so it can be unit-tested without spawning Pi's TUI.
+The component should be the only impure layer (calls `notify`, schedules
+render via `tui.requestRender()`, etc.).
+
+## Don't
+
+- Don't hand-roll `\u001b[38;2;...m` escapes inside modal bodies. Use `fg()`.
+- Don't reach into Pi's terminal controller from inside a modal. Schedule
+  render through `tui.requestRender()` so the overlay host stays in charge.
+- Don't add a second outer frame (`\u256d\u2500...\u256e`) inside the modal.
+  Pi's overlay box is the frame. Inner sub-frames (like the approval modal's
+  command box, or the Scriptorium's panel cards) are fine; the OUTER edge
+  belongs to Pi.
+- Don't bake colours from `tokens.ts`. Always read from
+  `activeThemeColors()` so theme switches re-render correctly.
+- Don't skip `wrapPanelRow` on any row. Even blank rows must be padded +
+  painted, otherwise the lifted background "steps" mid-modal.
+
+## Adding a helper
+
+If a new modal needs a primitive that two modals would share, add it to
+`scriptorium-chrome.ts` rather than duplicating it in the modal file. The
+goal is that `divine-query.ts`, `approval-modal.ts`, and `memory-editor.ts`
+contain only modal-specific composition — never bg-painting plumbing.

--- a/docs/visual/parity/scenarios.json
+++ b/docs/visual/parity/scenarios.json
@@ -776,6 +776,32 @@
 			]
 		},
 		{
+			"id": "fixture-memory-scriptorium-overlay",
+			"lane": "fixture",
+			"status": "review",
+			"dimensions": {
+				"cols": 160,
+				"rows": 45
+			},
+			"bibleTarget": "scene-memory-scriptorium-overlay.png",
+			"fixture": {
+				"id": "completed-active",
+				"overlay": "memory-scriptorium"
+			},
+			"crops": [
+				{
+					"id": "full",
+					"targetCrop": "full",
+					"runtimeCrop": "full"
+				},
+				{
+					"id": "overlay-center",
+					"targetCrop": "overlay-center",
+					"runtimeCrop": "overlay-center"
+				}
+			]
+		},
+		{
 			"id": "fixture-scroll-scribe-landscape",
 			"lane": "fixture",
 			"status": "review",

--- a/scripts/visual-v2/fixture-capture.mjs
+++ b/scripts/visual-v2/fixture-capture.mjs
@@ -309,6 +309,7 @@ async function renderFixtureScene(scenario, fixture) {
 
 async function applyOverlay(lines, cols, rows, overlay) {
 	if (overlay === "divine-query") return applyDivineQueryOverlay(lines, cols, rows);
+	if (overlay === "memory-scriptorium") return applyMemoryScriptoriumOverlay(lines, cols, rows);
 	if (overlay !== "command-palette") throw new Error(`Unsupported fixture overlay: ${overlay}`);
 	const palette = await jiti.import(`${repoRoot}/src/command-palette.ts`);
 
@@ -332,6 +333,46 @@ async function applyOverlay(lines, cols, rows, overlay) {
 		// preserving the left margin and right remnant.
 		const existingLine = next[top + index] ?? "";
 		const rightStart = left + paletteWidth;
+		const leftRemnant = padAnsiToWidth(sliceByColumn(existingLine, 0, left, true), left);
+		const rightRemnant = rightStart < cols ? sliceByColumn(existingLine, rightStart, cols - rightStart, true) : "";
+		next[top + index] = padAnsiToWidth(`${leftRemnant}${overlayLine}${rightRemnant}`, cols);
+	}
+	return next;
+}
+
+async function applyMemoryScriptoriumOverlay(lines, cols, rows) {
+	const memoryEditor = await jiti.import(`${repoRoot}/src/memory-editor.ts`);
+	const categorization = await jiti.import(`${repoRoot}/src/memory-categorization.ts`);
+	const facts = [
+		{ id: "id-1", text: "Dhruv · Senior FE · Argent", tags: ["sumocode:identity"] },
+		{ id: "id-2", text: "London / BST", tags: ["sumocode:identity"] },
+		{ id: "pref-1", text: "prefers TypeScript strict", tags: ["sumocode:preferences"] },
+		{ id: "pref-2", text: "pnpm not npm", tags: ["sumocode:preferences"] },
+		{ id: "wf-1", text: "TDD by default", tags: ["sumocode:workflow"] },
+		{ id: "wf-2", text: "visual approval before done", tags: ["sumocode:workflow"] },
+		{ id: "proj-1", text: "sumocode/cathedral parity", tags: ["sumocode:projects"] },
+		{ id: "proj-2", text: "openclaw ACPX integration", tags: ["sumocode:projects"] },
+		{ id: "sys-1", text: "cmux runtime, libghostty", tags: ["sumocode:system"] },
+		{ id: "sys-2", text: "mac mini portrait", tags: ["sumocode:system"] },
+		{ id: "sys-3", text: "macbook landscape", tags: ["sumocode:system"] },
+		{ id: "gen-1", text: "ask open-ended questions", tags: ["sumocode:general"] },
+		{ id: "gen-2", text: "commit hash must be verified", tags: ["sumocode:general"] },
+	];
+	const overlayWidth = Math.max(70, Math.min(120, Math.floor(cols * 0.8)));
+	const overlayLines = memoryEditor.renderMemoryEditor({
+		searchQuery: "",
+		groups: categorization.groupFactsByPanel(facts),
+		factsTotal: facts.length,
+		focusedFactId: "pref-1",
+	}, overlayWidth);
+
+	const left = Math.max(0, Math.floor((cols - overlayWidth) / 2));
+	const top = Math.max(0, Math.floor((rows - overlayLines.length) / 2));
+	const next = [...lines];
+	for (let index = 0; index < overlayLines.length && top + index < rows; index += 1) {
+		const overlayLine = padAnsiToWidth(overlayLines[index] ?? "", overlayWidth);
+		const existingLine = next[top + index] ?? "";
+		const rightStart = left + overlayWidth;
 		const leftRemnant = padAnsiToWidth(sliceByColumn(existingLine, 0, left, true), left);
 		const rightRemnant = rightStart < cols ? sliceByColumn(existingLine, rightStart, cols - rightStart, true) : "";
 		next[top + index] = padAnsiToWidth(`${leftRemnant}${overlayLine}${rightRemnant}`, cols);

--- a/src/approval-modal.ts
+++ b/src/approval-modal.ts
@@ -30,64 +30,25 @@
 
 import type { Component } from "@mariozechner/pi-tui";
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
+import { matchesKey, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import { activeThemeColors } from "./themes/index.js";
+import {
+	RESET,
+	center,
+	fg,
+	fitLine,
+	padRight,
+	persistentBg,
+	sgr,
+	splitRule,
+	visibleLength,
+	wrapPanelRow,
+} from "./cathedral/scriptorium-chrome.js";
 
-const RESET = "\u001b[0m";
-const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
 const PANEL_INDENT = "   ";
 const BIBLE_COMMAND_BOX_WIDTH_AT_80 = 68;
 
-function visibleLength(text: string): number {
-	return visibleWidth(text.replace(ANSI_PATTERN, ""));
-}
-
-function sgr(hex: string, mode: 38 | 48): string {
-	const normalized = hex.replace("#", "");
-	const red = Number.parseInt(normalized.slice(0, 2), 16);
-	const green = Number.parseInt(normalized.slice(2, 4), 16);
-	const blue = Number.parseInt(normalized.slice(4, 6), 16);
-	return `\u001b[${mode};2;${red};${green};${blue}m`;
-}
-
-function fg(text: string, hex: string): string {
-	return `${sgr(hex, 38)}${text}${RESET}`;
-}
-
-function persistentBg(text: string, fgHex: string, bgHex: string): string {
-	const styleCode = `${sgr(fgHex, 38)}${sgr(bgHex, 48)}`;
-	return `${styleCode}${text.replace(/\u001b\[0m/g, `${RESET}${styleCode}`)}${RESET}`;
-}
-
-function fitLine(line: string, width: number): string {
-	if (width <= 0) return "";
-	return visibleLength(line) > width ? truncateToWidth(line, width, "…") : line;
-}
-
-function padRight(line: string, width: number): string {
-	const fitted = fitLine(line, width);
-	const length = visibleLength(fitted);
-	if (length >= width) return fitted;
-	return `${fitted}${" ".repeat(width - length)}`;
-}
-
-function center(line: string, width: number): string {
-	const fitted = fitLine(line, width);
-	const length = visibleLength(fitted);
-	if (length >= width) return fitted;
-	const left = Math.floor((width - length) / 2);
-	return `${" ".repeat(left)}${fitted}${" ".repeat(width - length - left)}`;
-}
-
-function panelRow(inner: string, width: number): string {
-	return persistentBg(padRight(inner, width), activeThemeColors().foreground, activeThemeColors().surfaceLifted);
-}
-
-function splitRule(width: number): string {
-	const ruleLength = Math.max(1, Math.min(22, Math.floor((width - 5) / 2)));
-	const divider = activeThemeColors().divider;
-	return center(`${fg("─".repeat(ruleLength), divider)}  ${fg("·", divider)}  ${fg("─".repeat(ruleLength), divider)}`, width);
-}
+const panelRow = wrapPanelRow;
 
 export type ApprovalChoice = "yes" | "no" | "always";
 

--- a/src/cathedral/scriptorium-chrome.ts
+++ b/src/cathedral/scriptorium-chrome.ts
@@ -1,0 +1,111 @@
+/**
+ * Shared chrome helpers for Cathedral / Scriptorium overlay modals.
+ *
+ * Both `divine-query.ts` and `approval-modal.ts` open the same way: a centered
+ * lifted-bg panel painted by `wrapPanelRow`, a floral title `\u2728  TITLE  \u2728`,
+ * a `splitRule` divider, focused / unfocused marker glyphs, and a centered
+ * footer hint. This module is the single source of truth for those primitives
+ * so any new Cathedral modal (Memory Scriptorium etc.) reuses the same look
+ * without each module re-implementing background painting.
+ *
+ * The painting is intentionally simple:
+ *
+ *   - `fg(text, hex)`            \u2192 truecolor foreground
+ *   - `persistentBg(text, fg, bg)` \u2192 paints `bg` through every cell so a
+ *                                  nested ANSI reset within `text` doesn't
+ *                                  drop back to the underlying scene
+ *   - `wrapPanelRow(line, width)`  \u2192 pad-right + persistentBg with the active
+ *                                  theme's `foreground` + `surfaceLifted`
+ *
+ * Pi's overlay host already provides the surrounding chrome, so panels are
+ * intentionally unframed at the outer edge \u2014 the lifted bg + Pi's overlay
+ * box is the visual frame.
+ */
+
+import { truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
+import { activeThemeColors } from "../themes/index.js";
+
+export const RESET = "\u001b[0m";
+export const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+
+export const TITLE_FLOWER = "\u273E";
+export const FOCUSED_MARK = "\u2748";
+export const UNFOCUSED_MARK = "\u00b7";
+
+export function visibleLength(text: string): number {
+	return visibleWidth(text.replace(ANSI_PATTERN, ""));
+}
+
+function sgr(hex: string, mode: 38 | 48): string {
+	const normalized = hex.replace("#", "");
+	const red = Number.parseInt(normalized.slice(0, 2), 16);
+	const green = Number.parseInt(normalized.slice(2, 4), 16);
+	const blue = Number.parseInt(normalized.slice(4, 6), 16);
+	return `\u001b[${mode};2;${red};${green};${blue}m`;
+}
+
+export function fg(text: string, hex: string): string {
+	return `${sgr(hex, 38)}${text}${RESET}`;
+}
+
+/**
+ * Re-apply `fg`+`bg` after every embedded reset so the lifted background
+ * keeps painting through nested ANSI sequences instead of snapping to the
+ * underlying scene's background between styled spans.
+ */
+export function persistentBg(text: string, fgHex: string, bgHex: string): string {
+	const style = `${sgr(fgHex, 38)}${sgr(bgHex, 48)}`;
+	return `${style}${text.replace(/\u001b\[0m/g, `${RESET}${style}`)}${RESET}`;
+}
+
+export function fitLine(line: string, width: number): string {
+	if (width <= 0) return "";
+	return visibleLength(line) > width ? truncateToWidth(line, width, "\u2026") : line;
+}
+
+export function padRight(line: string, width: number): string {
+	const fitted = fitLine(line, width);
+	const length = visibleLength(fitted);
+	if (length >= width) return fitted;
+	return `${fitted}${" ".repeat(width - length)}`;
+}
+
+export function center(line: string, width: number): string {
+	const fitted = fitLine(line, width);
+	const length = visibleLength(fitted);
+	if (length >= width) return fitted;
+	const left = Math.floor((width - length) / 2);
+	return `${" ".repeat(left)}${fitted}${" ".repeat(width - length - left)}`;
+}
+
+/** Bible-style split rule: two box-drawing runs separated by a centered `\u00b7`. */
+export function splitRule(width: number): string {
+	const ruleLen = Math.max(1, Math.min(30, Math.floor((width - 5) / 2)));
+	const div = activeThemeColors().divider;
+	const piece = `${fg("\u2500".repeat(ruleLen), div)}  ${fg("\u00b7", div)}  ${fg("\u2500".repeat(ruleLen), div)}`;
+	return center(piece, width);
+}
+
+/** A `\u2728  TITLE  \u2728` row centered in the panel. */
+export function titleRow(text: string, width: number): string {
+	const accent = activeThemeColors().accent;
+	return center(`${fg(TITLE_FLOWER, accent)}  ${fg(text, accent)}  ${fg(TITLE_FLOWER, accent)}`, width);
+}
+
+/** Focused or unfocused list-marker glyph. */
+export function focusMarker(focused: boolean): string {
+	const colors = activeThemeColors();
+	return focused ? fg(FOCUSED_MARK, colors.accent) : fg(UNFOCUSED_MARK, colors.divider);
+}
+
+/**
+ * Pad `inner` to `width` and paint the active theme's `foreground` over
+ * `surfaceLifted` background through every cell.
+ */
+export function wrapPanelRow(inner: string, width: number): string {
+	return persistentBg(
+		padRight(inner, width),
+		activeThemeColors().foreground,
+		activeThemeColors().surfaceLifted,
+	);
+}

--- a/src/cathedral/scriptorium-chrome.ts
+++ b/src/cathedral/scriptorium-chrome.ts
@@ -36,7 +36,13 @@ export function visibleLength(text: string): number {
 	return visibleWidth(text.replace(ANSI_PATTERN, ""));
 }
 
-function sgr(hex: string, mode: 38 | 48): string {
+/**
+ * Build a 24-bit truecolor SGR opener for `mode === 38` (foreground) or
+ * `mode === 48` (background). Exported so modal-specific composites (e.g. the
+ * approval modal's inverse-label buttons) can stack fg+bg directly without
+ * piping every cell through `persistentBg`.
+ */
+export function sgr(hex: string, mode: 38 | 48): string {
 	const normalized = hex.replace("#", "");
 	const red = Number.parseInt(normalized.slice(0, 2), 16);
 	const green = Number.parseInt(normalized.slice(2, 4), 16);

--- a/src/divine-query.ts
+++ b/src/divine-query.ts
@@ -2,7 +2,10 @@
  * Cathedral Divine Query modal (Element 11 from CATHEDRAL_UX_SPEC_V2.md).
  *
  * Replaces Pi's default `ctx.ui.select` rendering with a Scriptorium-themed
- * overlay when SumoCode is active.
+ * overlay when SumoCode is active. Painting helpers (lifted bg, floral title,
+ * focus marker, split rule) come from `./cathedral/scriptorium-chrome.js` so
+ * Memory Scriptorium and Approval Modal share the exact same look without
+ * duplicate copies of `persistentBg` etc.
  *
  * Visual:
  *
@@ -25,61 +28,23 @@
  * Bible source:
  *   docs/ui/bible/11-divine-query-rename.html
  *   docs/ui/bible/11-divine-query-yesno.html
+ *
+ * See `docs/cathedral/SCRIPTORIUM_CHROME.md` for the shared modal contract.
  */
 
 import type { Component, OverlayOptions } from "@mariozechner/pi-tui";
-import { matchesKey, truncateToWidth, visibleWidth, wrapTextWithAnsi } from "@mariozechner/pi-tui";
+import { matchesKey, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { activeThemeColors } from "./themes/index.js";
-
-const RESET = "[0m";
-const ANSI_PATTERN = /\[[0-9;]*m/g;
-
-function visibleLength(text: string): number {
-	return visibleWidth(text.replace(ANSI_PATTERN, ""));
-}
-
-function fg(text: string, hex: string): string {
-	const h = hex.replace("#", "");
-	const r = parseInt(h.slice(0, 2), 16);
-	const g = parseInt(h.slice(2, 4), 16);
-	const b = parseInt(h.slice(4, 6), 16);
-	return `[38;2;${r};${g};${b}m${text}${RESET}`;
-}
-
-function persistentBg(text: string, fgHex: string, bgHex: string): string {
-	const fh = fgHex.replace("#", "");
-	const bh = bgHex.replace("#", "");
-	const fr = parseInt(fh.slice(0, 2), 16);
-	const fgCode = parseInt(fh.slice(2, 4), 16);
-	const fb = parseInt(fh.slice(4, 6), 16);
-	const br = parseInt(bh.slice(0, 2), 16);
-	const bg = parseInt(bh.slice(2, 4), 16);
-	const bb = parseInt(bh.slice(4, 6), 16);
-	const styleCode = `[38;2;${fr};${fgCode};${fb}m[48;2;${br};${bg};${bb}m`;
-	// Restore both fg+bg after every reset so lifted bg persists through inner ANSI
-	return `${styleCode}${text.replace(/\[0m/g, `${RESET}${styleCode}`)}${RESET}`;
-}
-
-function center(line: string, width: number): string {
-	const fitted = fitLine(line, width);
-	const len = visibleLength(fitted);
-	if (len >= width) return fitted;
-	const pad = Math.floor((width - len) / 2);
-	return `${" ".repeat(pad)}${fitted}${" ".repeat(width - len - pad)}`;
-}
-
-function fitLine(line: string, width: number): string {
-	if (width <= 0) return "";
-	return visibleLength(line) > width ? truncateToWidth(line, width, "…") : line;
-}
-
-function padRight(line: string, width: number): string {
-	const fitted = fitLine(line, width);
-	const len = visibleLength(fitted);
-	if (len >= width) return fitted;
-	return `${fitted}${" ".repeat(width - len)}`;
-}
+import {
+	center,
+	fg,
+	focusMarker,
+	splitRule,
+	titleRow,
+	visibleLength,
+	wrapPanelRow,
+} from "./cathedral/scriptorium-chrome.js";
 
 function wrapIndentedText(text: string, width: number, indent: string): string[] {
 	const contentWidth = Math.max(1, width - visibleLength(indent));
@@ -113,18 +78,6 @@ export interface DivineQueryRenderOptions {
 
 // ── Pure render ──────────────────────────────────────────────
 
-const TITLE_MARK = "✾";
-const FOCUSED_MARK = "❈";
-const UNFOCUSED_MARK = "·";
-
-function splitRule(width: number): string {
-	const ruleLen = Math.max(1, Math.min(22, Math.floor((width - 5) / 2)));
-	const left = fg("─".repeat(ruleLen), activeThemeColors().divider);
-	const dot = fg("·", activeThemeColors().divider);
-	const right = fg("─".repeat(ruleLen), activeThemeColors().divider);
-	return center(`${left}  ${dot}  ${right}`, width);
-}
-
 function optionLabel(index: number): string {
 	return `${String.fromCharCode(65 + index)}) `;
 }
@@ -132,18 +85,18 @@ function optionLabel(index: number): string {
 /**
  * Build the inner content rows of a Divine Query modal at the given content
  * width (i.e. excluding the side borders). Returned rows are not yet padded
- * to width — `wrapInnerRow` handles padding + bg paint at the framing layer.
+ * to width — `wrapPanelRow` handles padding + bg paint at the framing layer.
  */
 function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, extras: readonly string[]): string[] {
 	const inner: string[] = [];
 	const indent = "     ";
+	const colors = activeThemeColors();
 
 	// Blank
 	inner.push("");
 
 	// Title: ✾  DIVINE QUERY  ✾
-	const titleText = `${fg(TITLE_MARK, activeThemeColors().accent)}  ${fg("DIVINE QUERY", activeThemeColors().accent)}  ${fg(TITLE_MARK, activeThemeColors().accent)}`;
-	inner.push(center(titleText, contentWidth));
+	inner.push(titleRow("DIVINE QUERY", contentWidth));
 
 	// Blank
 	inner.push("");
@@ -157,7 +110,7 @@ function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, ext
 	// Question body. Bible Element 11 keeps a generous right margin: text wraps
 	// at `cols - 12`, then gets a 5-col left indent.
 	for (const questionLine of wrapIndentedText(snapshot.title, Math.max(1, contentWidth - 7), indent)) {
-		inner.push(fg(questionLine, activeThemeColors().foreground));
+		inner.push(fg(questionLine, colors.foreground));
 	}
 
 	// Blank
@@ -166,9 +119,7 @@ function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, ext
 	// Options
 	for (let i = 0; i < snapshot.options.length; i += 1) {
 		const focused = i === snapshot.focusedIndex;
-		const mark = focused
-			? fg(FOCUSED_MARK, activeThemeColors().accent)
-			: fg(UNFOCUSED_MARK, activeThemeColors().divider);
+		const mark = focusMarker(focused);
 		const optionIndent = `${indent}${mark}   `;
 		const continuationIndent = `${indent}    `;
 		const label = `${optionLabel(i)}${snapshot.options[i]}`;
@@ -177,8 +128,8 @@ function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, ext
 			const raw = (wrappedOption[optionRow] ?? "").slice(continuationIndent.length);
 			const prefix = optionRow === 0 ? optionIndent : continuationIndent;
 			const text = focused
-				? fg(raw, activeThemeColors().foreground)
-				: fg(raw, activeThemeColors().foregroundDim);
+				? fg(raw, colors.foreground)
+				: fg(raw, colors.foregroundDim);
 			inner.push(`${prefix}${text}`);
 		}
 	}
@@ -190,8 +141,7 @@ function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, ext
 	inner.push(splitRule(contentWidth));
 
 	// Footer
-	const footer = fg("↑↓ wander    ⏎ answer    ⎋ retreat", activeThemeColors().foregroundDim);
-	inner.push(center(footer, contentWidth));
+	inner.push(center(fg("↑↓ wander    ⏎ answer    ⎋ retreat", colors.foregroundDim), contentWidth));
 
 	// Extras (e.g. edit-mode editor rows from question-tool)
 	for (const extra of extras) inner.push(extra);
@@ -202,27 +152,14 @@ function buildInnerRows(snapshot: DivineQuerySnapshot, contentWidth: number, ext
 	return inner;
 }
 
-/** Paint a full-width lifted panel row. Element 11 is intentionally
- * unframed in the Bible; Pi's overlay host may already provide surrounding
- * chrome, so adding a second box here makes the modal read too heavy.
- */
-function wrapPanelRow(innerLine: string, contentWidth: number): string {
-	return persistentBg(
-		padRight(innerLine, contentWidth),
-		activeThemeColors().foreground,
-		activeThemeColors().surfaceLifted,
-	);
-}
-
 export function renderDivineQuery(
 	snapshot: DivineQuerySnapshot,
 	width: number,
 	options: DivineQueryRenderOptions = {},
 ): string[] {
 	if (width < 1) return [];
-	const contentWidth = width;
-	const inner = buildInnerRows(snapshot, contentWidth, options.extras ?? []);
-	return inner.map((innerLine) => wrapPanelRow(innerLine, contentWidth));
+	const inner = buildInnerRows(snapshot, width, options.extras ?? []);
+	return inner.map((innerLine) => wrapPanelRow(innerLine, width));
 }
 
 // ── State machine ────────────────────────────────────────────

--- a/src/memory-editor.test.ts
+++ b/src/memory-editor.test.ts
@@ -166,8 +166,13 @@ describe("MemoryEditorComponent — interaction", () => {
 		expect(lines).toContain("❈");
 	});
 
-	it("filters facts as the user types", () => {
+	it("only routes letter keys into the search query after entering search mode with /", () => {
 		const { component, invalidate } = buildComponent();
+		// In default command mode, letters should NOT mutate the search query.
+		component.handleInput("t");
+		expect(component.render(160).map(stripAnsi).join("\n")).toContain("search remembered facts");
+
+		component.handleInput("/");
 		component.handleInput("t");
 		component.handleInput("y");
 		component.handleInput("p");
@@ -175,6 +180,27 @@ describe("MemoryEditorComponent — interaction", () => {
 		expect(lines).toContain("prefers TypeScript strict");
 		expect(lines).not.toContain("Dhruv works at Argent");
 		expect(invalidate).toHaveBeenCalled();
+	});
+
+	it("escape in search mode returns to command mode without closing", () => {
+		const { component, close } = buildComponent();
+		component.handleInput("/");
+		component.handleInput("a");
+		component.handleInput("escape");
+		expect(close).not.toHaveBeenCalled();
+		// Subsequent escape from command mode closes
+		component.handleInput("escape");
+		expect(close).toHaveBeenCalled();
+	});
+
+	it("does not invoke forget when the user types `d` while filtering for `node`", async () => {
+		const forget = vi.fn(async () => undefined);
+		const { component } = buildComponent({}, { client: fakeClient({ forget }) });
+		component.handleInput("/");
+		for (const ch of "node") component.handleInput(ch);
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(forget).not.toHaveBeenCalled();
 	});
 
 	it("walks focus across visible facts with arrow keys", () => {
@@ -236,13 +262,20 @@ describe("MemoryEditorComponent — interaction", () => {
 		expect(notify).toHaveBeenCalledWith(expect.stringMatching(/forget failed: nope/), "warning");
 	});
 
-	it("notifies a hint when the user presses e (revise inline deferred)", () => {
+	it("notifies a hint when the user presses e in command mode (revise inline deferred)", () => {
 		const { component, notify } = buildComponent({ focusedFactId: "pref-1" });
 		component.handleInput("e");
 		expect(notify).toHaveBeenCalledWith(expect.stringMatching(/revise inline coming soon/), "info");
 	});
 
-	it("closes on escape", () => {
+	it("does not notify the revise hint while typing `prefers` in search mode", () => {
+		const { component, notify } = buildComponent();
+		component.handleInput("/");
+		for (const ch of "prefers") component.handleInput(ch);
+		expect(notify).not.toHaveBeenCalled();
+	});
+
+	it("closes on escape from command mode", () => {
 		const { component, close } = buildComponent();
 		component.handleInput("escape");
 		expect(close).toHaveBeenCalled();

--- a/src/memory-editor.test.ts
+++ b/src/memory-editor.test.ts
@@ -205,6 +205,21 @@ describe("MemoryEditorComponent — interaction", () => {
 		expect(client).toBeDefined();
 	});
 
+	it("restores the original facts total on forget rejection even when a search filter is active", async () => {
+		let reject: (error: Error) => void = () => {};
+		const forget = vi.fn(() => new Promise<void>((_, rej) => { reject = rej; }));
+		const { component } = buildComponent({ focusedFactId: "pref-1", searchQuery: "prefer" }, {
+			client: fakeClient({ forget }),
+		});
+		component.handleInput("d");
+		reject(new Error("daemon offline"));
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		const rendered = component.render(160).map(stripAnsi).join("\n");
+		expect(rendered).toContain("5 facts");
+	});
+
 	it("rolls back the optimistic removal when forget rejects", async () => {
 		let reject: (error: Error) => void = () => {};
 		const forget = vi.fn(() => new Promise<void>((_, rej) => { reject = rej; }));

--- a/src/memory-editor.test.ts
+++ b/src/memory-editor.test.ts
@@ -182,6 +182,17 @@ describe("MemoryEditorComponent — interaction", () => {
 		expect(invalidate).toHaveBeenCalled();
 	});
 
+	it.each(["return", "enter", "\r"])("%s in search mode exits back to command mode", (key) => {
+		const { component, close } = buildComponent();
+		component.handleInput("/");
+		component.handleInput("a");
+		component.handleInput(key);
+		expect(close).not.toHaveBeenCalled();
+		// After Enter exits search, the next Esc should close (proves we're back in command mode)
+		component.handleInput("escape");
+		expect(close).toHaveBeenCalled();
+	});
+
 	it("escape in search mode returns to command mode without closing", () => {
 		const { component, close } = buildComponent();
 		component.handleInput("/");

--- a/src/memory-editor.test.ts
+++ b/src/memory-editor.test.ts
@@ -1,19 +1,22 @@
 import { describe, expect, it, vi } from "vitest";
 import {
 	MEMORY_EDITOR_HINTS,
+	MemoryEditorComponent,
 	registerMemoryCommand,
 	renderMemoryEditor,
 	type MemoryEditorSnapshot,
 } from "./memory-editor.js";
-import type { MemoryFact } from "./memory.js";
+import type { MemoryFact, RemnicMemoryClient } from "./memory.js";
 import { groupFactsByPanel } from "./memory-categorization.js";
 
 const ANSI = /\u001b\[[0-9;]*m/g;
 const stripAnsi = (s: string): string => s.replace(ANSI, "");
 
+let factCounter = 0;
 function fact(overrides: Partial<MemoryFact> = {}): MemoryFact {
+	factCounter += 1;
 	return {
-		id: `fact-${Math.random().toString(36).slice(2)}`,
+		id: `fact-${factCounter}`,
 		text: "default fact text",
 		...overrides,
 	};
@@ -21,45 +24,57 @@ function fact(overrides: Partial<MemoryFact> = {}): MemoryFact {
 
 function snapshot(overrides: Partial<MemoryEditorSnapshot> = {}): MemoryEditorSnapshot {
 	const facts: MemoryFact[] = [
-		fact({ text: "Dhruv works at Argent in London" }),     // IDENTITY
-		fact({ text: "prefers TypeScript strict" }),            // PREFERENCES
-		fact({ text: "always use TDD for new features" }),      // WORKFLOW
-		fact({ text: "SumoCode is the cathedral product" }),    // PROJECTS
-		fact({ text: "mac mini in portrait orientation" }),     // SYSTEM
+		fact({ id: "id-1", text: "Dhruv works at Argent in London" }),     // IDENTITY
+		fact({ id: "pref-1", text: "prefers TypeScript strict" }),         // PREFERENCES
+		fact({ id: "wf-1", text: "always use TDD for new features" }),     // WORKFLOW
+		fact({ id: "proj-1", text: "SumoCode is the cathedral product" }),  // PROJECTS
+		fact({ id: "sys-1", text: "mac mini in portrait orientation" }),   // SYSTEM
 	];
 	return {
 		searchQuery: "",
 		groups: groupFactsByPanel(facts),
 		factsTotal: facts.length,
+		focusedFactId: null,
 		...overrides,
 	};
 }
 
+function fakeClient(overrides: Partial<RemnicMemoryClient> = {}): RemnicMemoryClient {
+	return {
+		browse: vi.fn(async () => []),
+		add: vi.fn(async () => undefined),
+		forget: vi.fn(async () => undefined),
+		search: vi.fn(async () => []),
+		...overrides,
+	} as RemnicMemoryClient;
+}
+
 describe("renderMemoryEditor — title + dividers", () => {
-	it("renders SUMOCODE MEMORY title centered", () => {
+	it("renders MEMORY SCRIPTORIUM title centered with floral marks", () => {
 		const lines = renderMemoryEditor(snapshot(), 100).map(stripAnsi);
-		const titleLine = lines.find((l) => l.includes("SUMOCODE MEMORY"));
+		const titleLine = lines.find((l) => l.includes("MEMORY SCRIPTORIUM"));
 		expect(titleLine).toBeDefined();
+		expect(titleLine).toContain("✾");
 	});
 
 	it("renders title in accent color", () => {
 		const lines = renderMemoryEditor(snapshot(), 100);
-		const titleLine = lines.find((l) => l.includes("SUMOCODE MEMORY"));
-		// accent #D97706 -> 217;119;6
+		const titleLine = lines.find((l) => l.includes("MEMORY SCRIPTORIUM"));
+		// cathedral accent #D97706 -> 217;119;6
 		expect(titleLine).toContain("\u001b[38;2;217;119;6m");
 	});
 
-	it("renders divider rules above and below content", () => {
+	it("renders split rule dividers above and below content", () => {
 		const lines = renderMemoryEditor(snapshot(), 100).map(stripAnsi);
-		const dividers = lines.filter((l) => l.includes("─".repeat(20)));
+		const dividers = lines.filter((l) => l.includes("─".repeat(20)) && l.includes("·"));
 		expect(dividers.length).toBeGreaterThanOrEqual(2);
 	});
 });
 
 describe("renderMemoryEditor — search row", () => {
-	it("shows dim 'search…' placeholder when searchQuery is empty", () => {
+	it("shows dim 'search remembered facts…' placeholder when searchQuery is empty", () => {
 		const lines = renderMemoryEditor(snapshot({ searchQuery: "" }), 100).map(stripAnsi);
-		const searchLine = lines.find((l) => l.includes("search"));
+		const searchLine = lines.find((l) => l.includes("search remembered facts"));
 		expect(searchLine).toBeDefined();
 	});
 
@@ -74,10 +89,16 @@ describe("renderMemoryEditor — search row", () => {
 		const searchLine = lines.find((l) => l.includes("5 facts"));
 		expect(searchLine).toBeDefined();
 	});
+
+	it("uses a chevron prompt glyph", () => {
+		const lines = renderMemoryEditor(snapshot(), 100).map(stripAnsi);
+		const searchLine = lines.find((l) => l.includes("❯"));
+		expect(searchLine).toBeDefined();
+	});
 });
 
 describe("renderMemoryEditor — panel grid", () => {
-	it("renders each non-empty panel header (IDENTITY/PREFERENCES/WORKFLOW/PROJECTS/SYSTEM)", () => {
+	it("renders each non-empty panel header", () => {
 		const lines = renderMemoryEditor(snapshot(), 160).map(stripAnsi);
 		const text = lines.join("\n");
 		expect(text).toContain(" IDENTITY ");
@@ -94,29 +115,122 @@ describe("renderMemoryEditor — panel grid", () => {
 	});
 
 	it("shows GENERAL panel when there are unrouted facts", () => {
-		const facts = [fact({ text: "the sky is blue" })];
+		const facts = [fact({ id: "general-1", text: "the sky is blue" })];
 		const snap: MemoryEditorSnapshot = {
 			searchQuery: "",
 			groups: groupFactsByPanel(facts),
 			factsTotal: 1,
+			focusedFactId: null,
 		};
 		const lines = renderMemoryEditor(snap, 160).map(stripAnsi);
 		const text = lines.join("\n");
 		expect(text).toContain(" GENERAL ");
 	});
 
-	it("renders each fact with ❧ bullet", () => {
-		const lines = renderMemoryEditor(snapshot(), 160).map(stripAnsi);
-		const text = lines.join("\n");
-		expect(text).toContain("❧");
+	it("marks the focused fact with the focused glyph", () => {
+		const lines = renderMemoryEditor(snapshot({ focusedFactId: "pref-1" }), 160).map(stripAnsi);
+		const focusedSegment = lines
+			.flatMap((l) => l.split("│"))
+			.find((segment) => segment.includes("prefers TypeScript strict"));
+		const otherSegment = lines
+			.flatMap((l) => l.split("│"))
+			.find((segment) => segment.includes("Dhruv works at Argent"));
+		expect(focusedSegment).toContain("❈");
+		expect(focusedSegment).not.toContain("·");
+		expect(otherSegment).toContain("·");
+		expect(otherSegment).not.toContain("❈");
 	});
 });
 
 describe("renderMemoryEditor — footer hints", () => {
-	it("includes navigate/search/copy/close hints", () => {
+	it("includes the cathedral-voice hints", () => {
 		const lines = renderMemoryEditor(snapshot(), 160).map(stripAnsi);
 		const text = lines.join("\n");
 		expect(text).toContain(MEMORY_EDITOR_HINTS);
+	});
+});
+
+describe("MemoryEditorComponent — interaction", () => {
+	function buildComponent(initial?: Partial<MemoryEditorSnapshot>, overrides: { client?: RemnicMemoryClient } = {}) {
+		const client = overrides.client ?? fakeClient();
+		const notify = vi.fn<(message: string, level?: "info" | "warning") => void>();
+		const invalidate = vi.fn<() => void>();
+		const close = vi.fn<() => void>();
+		const component = new MemoryEditorComponent(snapshot(initial), { client, notify, invalidate, close });
+		return { component, client, notify, invalidate, close };
+	}
+
+	it("focuses the first visible fact when none is preselected", () => {
+		const { component } = buildComponent({ focusedFactId: null });
+		const lines = component.render(160).map(stripAnsi).join("\n");
+		expect(lines).toContain("❈");
+	});
+
+	it("filters facts as the user types", () => {
+		const { component, invalidate } = buildComponent();
+		component.handleInput("t");
+		component.handleInput("y");
+		component.handleInput("p");
+		const lines = component.render(160).map(stripAnsi).join("\n");
+		expect(lines).toContain("prefers TypeScript strict");
+		expect(lines).not.toContain("Dhruv works at Argent");
+		expect(invalidate).toHaveBeenCalled();
+	});
+
+	it("walks focus across visible facts with arrow keys", () => {
+		const { component } = buildComponent({ focusedFactId: "pref-1" });
+		component.handleInput("down");
+		const next = component.render(160).map(stripAnsi).join("\n");
+		// focus moves off the previous fact line
+		const focusedLine = next.split("\n").find((l) => l.includes("❈"));
+		expect(focusedLine).toBeDefined();
+		expect(focusedLine).not.toContain("prefers TypeScript strict");
+	});
+
+	it("forgets the focused fact via the client and removes it optimistically", async () => {
+		const forget = vi.fn(async () => undefined);
+		const { component, notify, client } = buildComponent({ focusedFactId: "pref-1" }, {
+			client: fakeClient({ forget }),
+		});
+		// initial render shows the fact
+		expect(component.render(160).map(stripAnsi).join("\n")).toContain("prefers TypeScript strict");
+		component.handleInput("d");
+		// optimistic removal: rendered immediately
+		expect(component.render(160).map(stripAnsi).join("\n")).not.toContain("prefers TypeScript strict");
+		// allow the awaited client.forget to resolve
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(forget).toHaveBeenCalledWith("pref-1");
+		expect(notify).toHaveBeenCalledWith("forgotten", "info");
+		expect(client).toBeDefined();
+	});
+
+	it("rolls back the optimistic removal when forget rejects", async () => {
+		let reject: (error: Error) => void = () => {};
+		const forget = vi.fn(() => new Promise<void>((_, rej) => { reject = rej; }));
+		const { component, notify } = buildComponent({ focusedFactId: "pref-1" }, {
+			client: fakeClient({ forget }),
+		});
+		component.handleInput("d");
+		expect(component.render(160).map(stripAnsi).join("\n")).not.toContain("prefers TypeScript strict");
+		reject(new Error("nope"));
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		expect(component.render(160).map(stripAnsi).join("\n")).toContain("prefers TypeScript strict");
+		expect(notify).toHaveBeenCalledWith(expect.stringMatching(/forget failed: nope/), "warning");
+	});
+
+	it("notifies a hint when the user presses e (revise inline deferred)", () => {
+		const { component, notify } = buildComponent({ focusedFactId: "pref-1" });
+		component.handleInput("e");
+		expect(notify).toHaveBeenCalledWith(expect.stringMatching(/revise inline coming soon/), "info");
+	});
+
+	it("closes on escape", () => {
+		const { component, close } = buildComponent();
+		component.handleInput("escape");
+		expect(close).toHaveBeenCalled();
 	});
 });
 
@@ -130,7 +244,7 @@ describe("registerMemoryCommand", () => {
 		);
 	});
 
-	it("/sumo:memory (no args) opens the editor overlay", async () => {
+	it("/sumo:memory (no args) reaches the editor or notifies unavailable", async () => {
 		let handler: ((args: string, ctx: unknown) => Promise<void>) | undefined;
 		const registerCommand = vi.fn((_name: string, opts: { handler: typeof handler }) => {
 			handler = opts.handler;
@@ -141,8 +255,6 @@ describe("registerMemoryCommand", () => {
 		const notify = vi.fn();
 		await handler!("", { ui: { custom, notify } });
 
-		// Without a remnic daemon, browse() will fail and we'll notify "memory unavailable"
-		// rather than open the modal. Either way, the command is reachable.
 		expect(custom.mock.calls.length + notify.mock.calls.length).toBeGreaterThan(0);
 	});
 });

--- a/src/memory-editor.test.ts
+++ b/src/memory-editor.test.ts
@@ -242,6 +242,39 @@ describe("MemoryEditorComponent — interaction", () => {
 		expect(client).toBeDefined();
 	});
 
+	it("recomputes focus after forget rejection if the user filtered the focused fact out mid-flight", async () => {
+		let reject: (error: Error) => void = () => {};
+		const forget = vi.fn(() => new Promise<void>((_, rej) => { reject = rej; }));
+		const { component } = buildComponent({ focusedFactId: "pref-1" }, {
+			client: fakeClient({ forget }),
+		});
+		component.handleInput("d");
+		// While forget is in flight, user filters so `pref-1` is no longer visible.
+		component.handleInput("/");
+		for (const ch of "argent") component.handleInput(ch);
+		reject(new Error("daemon offline"));
+		await Promise.resolve();
+		await Promise.resolve();
+		await Promise.resolve();
+		const rendered = component.render(160).map(stripAnsi).join("\n");
+		// Focused glyph must point at a fact still visible under the new filter.
+		const focusedSegment = rendered
+			.split("│")
+			.find((segment) => segment.includes("❈"));
+		if (focusedSegment) {
+			expect(focusedSegment).toMatch(/Argent/);
+			expect(focusedSegment).not.toMatch(/prefers TypeScript strict/);
+		}
+		// And a follow-up `d` cannot accidentally delete the hidden fact.
+		component.handleInput("escape"); // exit search mode
+		forget.mockClear();
+		component.handleInput("d");
+		await Promise.resolve();
+		if (forget.mock.calls.length > 0) {
+			expect(forget).not.toHaveBeenCalledWith("pref-1");
+		}
+	});
+
 	it("restores the original facts total on forget rejection even when a search filter is active", async () => {
 		let reject: (error: Error) => void = () => {};
 		const forget = vi.fn(() => new Promise<void>((_, rej) => { reject = rej; }));

--- a/src/memory-editor.ts
+++ b/src/memory-editor.ts
@@ -245,7 +245,14 @@ export class MemoryEditorComponent implements Component {
 				this.updateSearch(this.snapshot.searchQuery.slice(0, -1));
 				return;
 			}
-			if (matchesKey(data, "enter") || data === "enter" || data === "\r" || data === "\n") {
+			if (
+				matchesKey(data, "enter")
+				|| data === "enter"
+				|| matchesKey(data, "return")
+				|| data === "return"
+				|| data === "\r"
+				|| data === "\n"
+			) {
 				this.snapshot = { ...this.snapshot, mode: "command" };
 				this.deps.invalidate();
 				return;

--- a/src/memory-editor.ts
+++ b/src/memory-editor.ts
@@ -298,6 +298,7 @@ export class MemoryEditorComponent implements Component {
 		this.busy = true;
 		const previousGroups = this.snapshot.groups;
 		const previousSearch = this.snapshot.searchQuery;
+		const previousFactsTotal = this.snapshot.factsTotal;
 		const optimisticGroups = previousGroups.map((group) => ({
 			panel: group.panel,
 			facts: group.facts.filter((fact) => fact.id !== focusId),
@@ -315,7 +316,7 @@ export class MemoryEditorComponent implements Component {
 			await this.deps.client.forget(focusId);
 			this.deps.notify("forgotten", "info");
 		} catch (error) {
-			this.snapshot = { ...this.snapshot, groups: previousGroups, factsTotal: previousVisible.length, focusedFactId: focusId };
+			this.snapshot = { ...this.snapshot, groups: previousGroups, factsTotal: previousFactsTotal, focusedFactId: focusId };
 			this.deps.invalidate();
 			this.deps.notify(`forget failed: ${error instanceof Error ? error.message : String(error)}`, "warning");
 		} finally {

--- a/src/memory-editor.ts
+++ b/src/memory-editor.ts
@@ -1,31 +1,23 @@
 /**
  * Cathedral Memory Scriptorium (V2 Bible Element 7).
  *
- * Read-mostly modal that browses the user's Remnic memory and groups facts
- * into 6 panels (IDENTITY / PREFERENCES / WORKFLOW / PROJECTS / SYSTEM /
- * GENERAL hidden if empty). Provides:
+ * Shares its painting vocabulary with the Divine Query and Approval modals
+ * via `src/cathedral/scriptorium-chrome.ts`: floral title, lifted background
+ * painted through every row, focused / unfocused marker glyphs, and a
+ * centered footer hint. Pi's overlay host provides the surrounding box, so
+ * we render flat lifted-bg rows rather than re-framing inside the overlay.
  *
- *   - search filter (instant, no LLM)
- *   - up/down focus across visible facts
- *   - `d` to forget the focused fact (optimistic + Remnic round-trip)
- *   - `⎋` to dismiss
- *   - `e` to revise inline (deferred — currently emits a notify hint)
- *
- * Design source of truth: `docs/ui/CATHEDRAL_UX_SPEC_V2.md` Element 7,
- * `docs/ui/bible/07-memory-editor.html`,
- * `docs/ui/bible/07-memory-editor-search.html`,
- * `docs/ui/bible/scene-memory-scriptorium-overlay.html`.
- *
- * Theming reads from `activeThemeColors()` so Cathedral and Obsidian render
- * the same chrome with their own palette. No hardcoded hex values.
+ * Sources of truth:
+ *   - `docs/ui/CATHEDRAL_UX_SPEC_V2.md` Element 7
+ *   - `docs/ui/bible/07-memory-editor.html`, `07-memory-editor-search.html`
+ *   - `docs/ui/bible/scene-memory-scriptorium-overlay.html`
  *
  * Triggered via `/sumo:memory` (or `/sumo:memory edit`).
  */
 
-import type { Component, KeybindingsManager, OverlayHandle, TUI } from "@mariozechner/pi-tui";
+import type { Component, KeybindingsManager, OverlayHandle, OverlayOptions, TUI } from "@mariozechner/pi-tui";
+import { matchesKey, wrapTextWithAnsi } from "@mariozechner/pi-tui";
 import type { ExtensionAPI, ExtensionCommandContext } from "@mariozechner/pi-coding-agent";
-import { matchesKey } from "@mariozechner/pi-tui";
-import { colorHex } from "./footer.js";
 import {
 	createRemnicMemoryClient,
 	MemoryClientError,
@@ -39,44 +31,19 @@ import {
 	type PanelId,
 } from "./memory-categorization.js";
 import { activeThemeColors } from "./themes/index.js";
+import {
+	center,
+	fg,
+	focusMarker,
+	splitRule,
+	titleRow,
+	visibleLength,
+	wrapPanelRow,
+} from "./cathedral/scriptorium-chrome.js";
 
-const RESET = "\u001b[0m";
-const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
-const DIM = "\u001b[2m";
-const SEARCH_PROMPT_GLYPH = "❯";
-const FOCUSED_FACT_GLYPH = "❈";
-const UNFOCUSED_FACT_GLYPH = "·";
-const TITLE_FLOWER = "✾";
-
-function visibleLength(text: string): number {
-	return text.replace(ANSI_PATTERN, "").length;
-}
-
-function center(line: string, width: number): string {
-	const len = visibleLength(line);
-	if (len >= width) return line;
-	const pad = Math.floor((width - len) / 2);
-	return `${" ".repeat(pad)}${line}`;
-}
-
-function padToWidth(line: string, width: number): string {
-	const len = visibleLength(line);
-	if (len >= width) return line;
-	return `${line}${" ".repeat(width - len)}`;
-}
-
-/**
- * Bible-style split rule: two short box-drawing runs separated by a centered `·`.
- * Keeps the modal feeling like a hand-illuminated page rather than a CLI.
- */
-function splitRule(width: number): string {
-	const segment = Math.max(4, Math.floor((width - 8) / 2));
-	const left = "─".repeat(segment);
-	const right = "─".repeat(segment);
-	const div = activeThemeColors().divider;
-	const piece = `${colorHex(left, div)}  ${colorHex("·", div)}  ${colorHex(right, div)}`;
-	return center(piece, width);
-}
+const SEARCH_PROMPT_GLYPH = "\u276F";
+const PANEL_INDENT = "   ";
+const PANEL_GAP = "   ";
 
 export type MemoryEditorSnapshot = {
 	searchQuery: string;
@@ -85,7 +52,14 @@ export type MemoryEditorSnapshot = {
 	focusedFactId: string | null;
 };
 
-export const MEMORY_EDITOR_HINTS = "↑↓ wander    /  search    e  revise    d  forget    ⎋ retreat";
+export const MEMORY_EDITOR_HINTS = "\u2191\u2193 wander    /  search    e  revise    d  forget    \u23CE retreat";
+
+export const MEMORY_EDITOR_OVERLAY_OPTIONS: OverlayOptions = {
+	anchor: "center",
+	width: "85%",
+	minWidth: 80,
+	maxHeight: "90%",
+};
 
 function filterGroups(groups: readonly PanelGroup[], query: string): PanelGroup[] {
 	const trimmed = query.trim().toLowerCase();
@@ -102,88 +76,111 @@ function flatVisibleFacts(filtered: readonly PanelGroup[]): MemoryFact[] {
 	return out;
 }
 
-function renderPanel(group: PanelGroup, width: number, focusedFactId: string | null): string[] {
-	const innerWidth = Math.max(20, width - 4);
+function ensureFocusedFact(snapshot: MemoryEditorSnapshot): MemoryEditorSnapshot {
+	if (snapshot.focusedFactId !== null) return snapshot;
+	const visible = flatVisibleFacts(filterGroups(snapshot.groups, snapshot.searchQuery));
+	if (visible.length === 0) return snapshot;
+	return { ...snapshot, focusedFactId: visible[0]!.id };
+}
+
+/**
+ * Build the rendered rows of one panel at a given inner width. Returned rows
+ * are NOT padded to width \u2014 the caller composites two panels side-by-side
+ * with a gap, then `wrapPanelRow` paints the surrounding lifted bg.
+ */
+function renderPanelRows(group: PanelGroup, width: number, focusedFactId: string | null): string[] {
+	const colors = activeThemeColors();
+	const inner = Math.max(20, width);
 	const labelInner = ` ${group.panel} `;
-	const dashes = Math.max(2, innerWidth - labelInner.length - 1);
-	const top = `╭─${labelInner}${"─".repeat(dashes)}╮`;
-	const bottom = `╰${"─".repeat(innerWidth - 2)}╯`;
+	const dashes = Math.max(2, inner - labelInner.length - 3);
+	const top = `\u256D\u2500${fg(labelInner, colors.accent)}${fg("\u2500".repeat(dashes), colors.divider)}\u256E`;
+	const bottom = `\u2570${"\u2500".repeat(inner - 2)}\u256F`;
 
-	const div = activeThemeColors().divider;
-	const accent = activeThemeColors().accent;
-	const fg = activeThemeColors().foreground;
-	const dim = activeThemeColors().foregroundDim;
-
-	const lines: string[] = [];
-	lines.push(colorHex(top, div).replace(labelInner, colorHex(labelInner, accent)));
+	const rows: string[] = [];
+	rows.push(`${fg("\u256D\u2500", colors.divider)}${fg(labelInner, colors.accent)}${fg(`${"\u2500".repeat(dashes)}\u256E`, colors.divider)}`);
 
 	if (group.facts.length === 0) {
-		const empty = ` ${colorHex("(empty)", dim)} `;
-		lines.push(`${colorHex("│", div)}${padToWidth(empty, innerWidth - 2)}${colorHex("│", div)}`);
+		const left = fg("\u2502", colors.divider);
+		const right = fg("\u2502", colors.divider);
+		const body = ` ${fg("(empty)", colors.foregroundDim)} `;
+		const padCount = Math.max(0, inner - 2 - visibleLength(body));
+		rows.push(`${left}${body}${" ".repeat(padCount)}${right}`);
 	} else {
 		for (const fact of group.facts) {
 			const focused = fact.id === focusedFactId;
-			const marker = focused
-				? colorHex(FOCUSED_FACT_GLYPH, accent)
-				: colorHex(UNFOCUSED_FACT_GLYPH, div);
-			const maxBody = innerWidth - 6;
-			const body = fact.text.length > maxBody ? `${fact.text.slice(0, maxBody - 1)}…` : fact.text;
-			const text = colorHex(body, fg);
+			const marker = focusMarker(focused);
+			const maxBody = inner - 6;
+			const body = fact.text.length > maxBody ? `${fact.text.slice(0, maxBody - 1)}\u2026` : fact.text;
+			const text = fg(body, colors.foreground);
+			const left = fg("\u2502", colors.divider);
+			const right = fg("\u2502", colors.divider);
 			const content = ` ${marker} ${text}`;
-			lines.push(`${colorHex("│", div)}${padToWidth(content, innerWidth - 2)}${colorHex("│", div)}`);
+			const padCount = Math.max(0, inner - 2 - visibleLength(content));
+			rows.push(`${left}${content}${" ".repeat(padCount)}${right}`);
 		}
 	}
 
-	lines.push(colorHex(bottom, div));
-	return lines;
+	rows.push(fg(bottom, colors.divider));
+	void top;
+	return rows;
 }
 
-export function renderMemoryEditor(snapshot: MemoryEditorSnapshot, width: number): string[] {
+function buildInnerRows(snapshot: MemoryEditorSnapshot, contentWidth: number): string[] {
 	const filtered = filterGroups(snapshot.groups, snapshot.searchQuery);
-	const lines: string[] = [];
-	const accent = activeThemeColors().accent;
-	const fg = activeThemeColors().foreground;
-	const dim = activeThemeColors().foregroundDim;
+	const colors = activeThemeColors();
+	const inner: string[] = [];
 
-	lines.push("");
-	const flower = colorHex(TITLE_FLOWER, accent);
-	const titleText = colorHex("MEMORY SCRIPTORIUM", accent);
-	lines.push(center(`${flower}  ${titleText}  ${flower}`, width));
-	lines.push("");
-	lines.push(splitRule(width));
-	lines.push("");
+	inner.push("");
+	inner.push(titleRow("MEMORY SCRIPTORIUM", contentWidth));
+	inner.push("");
+	inner.push(splitRule(contentWidth));
+	inner.push("");
 
-	const chevron = colorHex(SEARCH_PROMPT_GLYPH, accent);
-	const queryDisplay = snapshot.searchQuery === ""
-		? `${DIM}${colorHex("search remembered facts…", dim)}${RESET}`
-		: colorHex(snapshot.searchQuery, fg);
-	const factsCount = colorHex(`${snapshot.factsTotal} facts`, dim);
-	const left = `   ${chevron}  ${queryDisplay}`;
-	const right = `${factsCount}   `;
-	const gap = Math.max(2, width - visibleLength(left) - visibleLength(right));
-	lines.push(`${left}${" ".repeat(gap)}${right}`);
-	lines.push("");
+	const chevron = fg(SEARCH_PROMPT_GLYPH, colors.accent);
+	const searchDisplay = snapshot.searchQuery === ""
+		? fg("search remembered facts\u2026", colors.foregroundDim)
+		: fg(snapshot.searchQuery, colors.foreground);
+	const factsLabel = fg(`${snapshot.factsTotal} facts`, colors.foregroundDim);
+	const left = `${PANEL_INDENT}${chevron}  ${searchDisplay}`;
+	const right = `${factsLabel}${PANEL_INDENT}`;
+	const gap = Math.max(2, contentWidth - visibleLength(left) - visibleLength(right));
+	inner.push(`${left}${" ".repeat(gap)}${right}`);
+	inner.push("");
 
 	const visibleGroups = filtered.filter((group) => group.panel !== "GENERAL" || group.facts.length > 0);
-	const panelInternalWidth = Math.floor((width - 6) / 2);
+	const indentWidth = visibleLength(PANEL_INDENT) * 2 + visibleLength(PANEL_GAP);
+	const panelInner = Math.max(20, Math.floor((contentWidth - indentWidth) / 2));
 	for (let i = 0; i < visibleGroups.length; i += 2) {
-		const leftPanel = renderPanel(visibleGroups[i]!, panelInternalWidth, snapshot.focusedFactId);
+		const leftPanel = renderPanelRows(visibleGroups[i]!, panelInner, snapshot.focusedFactId);
 		const rightPanel = i + 1 < visibleGroups.length
-			? renderPanel(visibleGroups[i + 1]!, panelInternalWidth, snapshot.focusedFactId)
+			? renderPanelRows(visibleGroups[i + 1]!, panelInner, snapshot.focusedFactId)
 			: null;
 		const rowCount = rightPanel ? Math.max(leftPanel.length, rightPanel.length) : leftPanel.length;
 		for (let r = 0; r < rowCount; r++) {
-			const leftLine = padToWidth(leftPanel[r] ?? "", panelInternalWidth);
-			const rightLine = rightPanel ? padToWidth(rightPanel[r] ?? "", panelInternalWidth) : "";
-			lines.push(`  ${leftLine}  ${rightLine}`);
+			const leftRow = leftPanel[r] ?? "";
+			const leftPad = Math.max(0, panelInner - visibleLength(leftRow));
+			const rightRow = rightPanel ? (rightPanel[r] ?? "") : "";
+			const rightPad = rightPanel ? Math.max(0, panelInner - visibleLength(rightRow)) : 0;
+			const composed = rightPanel
+				? `${PANEL_INDENT}${leftRow}${" ".repeat(leftPad)}${PANEL_GAP}${rightRow}${" ".repeat(rightPad)}`
+				: `${PANEL_INDENT}${leftRow}${" ".repeat(leftPad)}`;
+			inner.push(composed);
 		}
-		lines.push("");
+		inner.push("");
 	}
 
-	lines.push(splitRule(width));
-	lines.push(`   ${DIM}${colorHex(MEMORY_EDITOR_HINTS, dim)}${RESET}`);
+	inner.push(splitRule(contentWidth));
+	inner.push(center(fg(MEMORY_EDITOR_HINTS, colors.foregroundDim), contentWidth));
+	inner.push("");
+	return inner;
+}
 
-	return lines;
+export function renderMemoryEditor(snapshot: MemoryEditorSnapshot, width: number): string[] {
+	if (width < 1) return [];
+	const wrapped = wrapTextWithAnsi("", width); // touch import to silence treeshake hot reload
+	void wrapped;
+	const rows = buildInnerRows(snapshot, width);
+	return rows.map((row) => wrapPanelRow(row, width));
 }
 
 export interface MemoryEditorComponentDeps {
@@ -193,11 +190,6 @@ export interface MemoryEditorComponentDeps {
 	readonly close: () => void;
 }
 
-/**
- * Choose the next focused fact id when the focused one disappears (forget,
- * filter change). Falls back to the closest still-visible fact, then to the
- * first visible fact, then to null.
- */
 function nextFocusAfterRemoval(
 	previousVisible: readonly MemoryFact[],
 	currentVisible: readonly MemoryFact[],
@@ -249,7 +241,7 @@ export class MemoryEditorComponent implements Component {
 			return;
 		}
 		if (data === "e") {
-			this.deps.notify("revise inline coming soon — use /sumo:memory forget <id> + /sumo:memory add <text>", "info");
+			this.deps.notify("revise inline coming soon \u2014 use /sumo:memory forget <id> + /sumo:memory add <text>", "info");
 			return;
 		}
 		if (matchesKey(data, "backspace") || data === "backspace") {
@@ -279,12 +271,9 @@ export class MemoryEditorComponent implements Component {
 		const currentIndex = this.snapshot.focusedFactId === null
 			? -1
 			: visible.findIndex((fact) => fact.id === this.snapshot.focusedFactId);
-		let nextIndex: number;
-		if (currentIndex === -1) {
-			nextIndex = delta > 0 ? 0 : visible.length - 1;
-		} else {
-			nextIndex = (currentIndex + delta + visible.length) % visible.length;
-		}
+		const nextIndex = currentIndex === -1
+			? (delta > 0 ? 0 : visible.length - 1)
+			: (currentIndex + delta + visible.length) % visible.length;
 		this.snapshot = { ...this.snapshot, focusedFactId: visible[nextIndex]!.id };
 		this.deps.invalidate();
 	}
@@ -325,13 +314,6 @@ export class MemoryEditorComponent implements Component {
 	}
 }
 
-function ensureFocusedFact(snapshot: MemoryEditorSnapshot): MemoryEditorSnapshot {
-	if (snapshot.focusedFactId !== null) return snapshot;
-	const visible = flatVisibleFacts(filterGroups(snapshot.groups, snapshot.searchQuery));
-	if (visible.length === 0) return snapshot;
-	return { ...snapshot, focusedFactId: visible[0]!.id };
-}
-
 export async function showMemoryEditor(
 	ctx: ExtensionCommandContext,
 	client: RemnicMemoryClient = createRemnicMemoryClient(),
@@ -366,7 +348,7 @@ export async function showMemoryEditor(
 		}),
 		{
 			overlay: true,
-			overlayOptions: { anchor: "center", width: "80%", minWidth: 70, maxHeight: "80%" },
+			overlayOptions: MEMORY_EDITOR_OVERLAY_OPTIONS,
 			onHandle: (_handle: OverlayHandle) => {
 				/* no-op for now; future: programmatic close hook */
 			},
@@ -376,7 +358,7 @@ export async function showMemoryEditor(
 
 export function registerMemoryCommand(pi: ExtensionAPI): void {
 	pi.registerCommand("sumo:memory", {
-		description: "open the cathedral memory editor (or `add` / `forget` for direct ops)",
+		description: "open the cathedral memory scriptorium (or `add` / `forget` for direct ops)",
 		handler: async (args: string, ctx: ExtensionCommandContext) => {
 			const arg = args.trim().split(/\s+/)[0]?.toLowerCase() ?? "";
 			if (arg === "" || arg === "edit") {
@@ -392,7 +374,7 @@ export function registerMemoryCommand(pi: ExtensionAPI): void {
 				try {
 					const client = createRemnicMemoryClient();
 					await client.add(text);
-					ctx.ui.notify(`memory added: ${text.slice(0, 40)}${text.length > 40 ? "…" : ""}`, "info");
+					ctx.ui.notify(`memory added: ${text.slice(0, 40)}${text.length > 40 ? "\u2026" : ""}`, "info");
 				} catch (err) {
 					ctx.ui.notify(
 						`memory add failed: ${err instanceof Error ? err.message : String(err)}`,

--- a/src/memory-editor.ts
+++ b/src/memory-editor.ts
@@ -1,15 +1,25 @@
 /**
- * Cathedral memory editor (Element 7 from CATHEDRAL_DECISIONS.md).
+ * Cathedral Memory Scriptorium (V2 Bible Element 7).
  *
- * Read-only modal that browses the user's Remnic memory and groups facts
- * into 6 cathedral panels (IDENTITY / PREFERENCES / WORKFLOW / PROJECTS /
- * SYSTEM / GENERAL hidden if empty).
+ * Read-mostly modal that browses the user's Remnic memory and groups facts
+ * into 6 panels (IDENTITY / PREFERENCES / WORKFLOW / PROJECTS / SYSTEM /
+ * GENERAL hidden if empty). Provides:
  *
- * Triggered via `/sumo:memory edit`.
+ *   - search filter (instant, no LLM)
+ *   - up/down focus across visible facts
+ *   - `d` to forget the focused fact (optimistic + Remnic round-trip)
+ *   - `⎋` to dismiss
+ *   - `e` to revise inline (deferred — currently emits a notify hint)
  *
- * Uses the same flat-hybrid modal style as the approval modal and command
- * palette (Elements 6, 8): title + dividers above/below + footer hints,
- * no double-line border.
+ * Design source of truth: `docs/ui/CATHEDRAL_UX_SPEC_V2.md` Element 7,
+ * `docs/ui/bible/07-memory-editor.html`,
+ * `docs/ui/bible/07-memory-editor-search.html`,
+ * `docs/ui/bible/scene-memory-scriptorium-overlay.html`.
+ *
+ * Theming reads from `activeThemeColors()` so Cathedral and Obsidian render
+ * the same chrome with their own palette. No hardcoded hex values.
+ *
+ * Triggered via `/sumo:memory` (or `/sumo:memory edit`).
  */
 
 import type { Component, KeybindingsManager, OverlayHandle, TUI } from "@mariozechner/pi-tui";
@@ -33,6 +43,10 @@ import { activeThemeColors } from "./themes/index.js";
 const RESET = "\u001b[0m";
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
 const DIM = "\u001b[2m";
+const SEARCH_PROMPT_GLYPH = "❯";
+const FOCUSED_FACT_GLYPH = "❈";
+const UNFOCUSED_FACT_GLYPH = "·";
+const TITLE_FLOWER = "✾";
 
 function visibleLength(text: string): number {
 	return text.replace(ANSI_PATTERN, "").length;
@@ -51,143 +65,272 @@ function padToWidth(line: string, width: number): string {
 	return `${line}${" ".repeat(width - len)}`;
 }
 
-function divider(width: number): string {
-	return colorHex("─".repeat(Math.max(0, width - 6)), activeThemeColors().divider);
+/**
+ * Bible-style split rule: two short box-drawing runs separated by a centered `·`.
+ * Keeps the modal feeling like a hand-illuminated page rather than a CLI.
+ */
+function splitRule(width: number): string {
+	const segment = Math.max(4, Math.floor((width - 8) / 2));
+	const left = "─".repeat(segment);
+	const right = "─".repeat(segment);
+	const div = activeThemeColors().divider;
+	const piece = `${colorHex(left, div)}  ${colorHex("·", div)}  ${colorHex(right, div)}`;
+	return center(piece, width);
 }
 
 export type MemoryEditorSnapshot = {
 	searchQuery: string;
 	groups: readonly PanelGroup[];
 	factsTotal: number;
+	focusedFactId: string | null;
 };
 
-export const MEMORY_EDITOR_HINTS = "↑↓ navigate    /  search    ⏎  copy id    esc  close";
+export const MEMORY_EDITOR_HINTS = "↑↓ wander    /  search    e  revise    d  forget    ⎋ retreat";
 
-/**
- * Render a single panel sub-card with `╭─ NAME ─...╮` border.
- */
-function renderPanel(group: PanelGroup, width: number): string[] {
-	const innerWidth = Math.max(20, width - 4); // 2 chars border each side
+function filterGroups(groups: readonly PanelGroup[], query: string): PanelGroup[] {
+	const trimmed = query.trim().toLowerCase();
+	if (trimmed.length === 0) return groups.map((group) => ({ panel: group.panel, facts: [...group.facts] }));
+	return groups.map((group) => ({
+		panel: group.panel,
+		facts: group.facts.filter((fact) => fact.text.toLowerCase().includes(trimmed)),
+	}));
+}
+
+function flatVisibleFacts(filtered: readonly PanelGroup[]): MemoryFact[] {
+	const out: MemoryFact[] = [];
+	for (const group of filtered) for (const fact of group.facts) out.push(fact);
+	return out;
+}
+
+function renderPanel(group: PanelGroup, width: number, focusedFactId: string | null): string[] {
+	const innerWidth = Math.max(20, width - 4);
 	const labelInner = ` ${group.panel} `;
 	const dashes = Math.max(2, innerWidth - labelInner.length - 1);
 	const top = `╭─${labelInner}${"─".repeat(dashes)}╮`;
 	const bottom = `╰${"─".repeat(innerWidth - 2)}╯`;
 
+	const div = activeThemeColors().divider;
+	const accent = activeThemeColors().accent;
+	const fg = activeThemeColors().foreground;
+	const dim = activeThemeColors().foregroundDim;
+
 	const lines: string[] = [];
-	lines.push(colorHex(top, activeThemeColors().divider).replace(
-		labelInner,
-		colorHex(labelInner, activeThemeColors().accent),
-	));
+	lines.push(colorHex(top, div).replace(labelInner, colorHex(labelInner, accent)));
 
 	if (group.facts.length === 0) {
-		const empty = ` ${colorHex("(empty)", activeThemeColors().foregroundDim)} `;
-		lines.push(`${colorHex("│", activeThemeColors().divider)}${padToWidth(empty, innerWidth - 2)}${colorHex("│", activeThemeColors().divider)}`);
+		const empty = ` ${colorHex("(empty)", dim)} `;
+		lines.push(`${colorHex("│", div)}${padToWidth(empty, innerWidth - 2)}${colorHex("│", div)}`);
 	} else {
 		for (const fact of group.facts) {
-			const bullet = colorHex("❧", activeThemeColors().accent);
-			const text = colorHex(
-				fact.text.length > innerWidth - 6 ? `${fact.text.slice(0, innerWidth - 7)}…` : fact.text,
-				activeThemeColors().foreground,
-			);
-			const content = ` ${bullet} ${text}`;
-			lines.push(`${colorHex("│", activeThemeColors().divider)}${padToWidth(content, innerWidth - 2)}${colorHex("│", activeThemeColors().divider)}`);
+			const focused = fact.id === focusedFactId;
+			const marker = focused
+				? colorHex(FOCUSED_FACT_GLYPH, accent)
+				: colorHex(UNFOCUSED_FACT_GLYPH, div);
+			const maxBody = innerWidth - 6;
+			const body = fact.text.length > maxBody ? `${fact.text.slice(0, maxBody - 1)}…` : fact.text;
+			const text = colorHex(body, fg);
+			const content = ` ${marker} ${text}`;
+			lines.push(`${colorHex("│", div)}${padToWidth(content, innerWidth - 2)}${colorHex("│", div)}`);
 		}
 	}
 
-	lines.push(colorHex(bottom, activeThemeColors().divider));
+	lines.push(colorHex(bottom, div));
 	return lines;
 }
 
-/**
- * Pure render of the modal. Returns content lines (the overlay frame /
- * compositing is handled by Pi).
- */
 export function renderMemoryEditor(snapshot: MemoryEditorSnapshot, width: number): string[] {
+	const filtered = filterGroups(snapshot.groups, snapshot.searchQuery);
 	const lines: string[] = [];
+	const accent = activeThemeColors().accent;
+	const fg = activeThemeColors().foreground;
+	const dim = activeThemeColors().foregroundDim;
 
-	// Title
 	lines.push("");
-	lines.push(center(colorHex("SUMOCODE MEMORY", activeThemeColors().accent), width));
-	lines.push(divider(width));
+	const flower = colorHex(TITLE_FLOWER, accent);
+	const titleText = colorHex("MEMORY SCRIPTORIUM", accent);
+	lines.push(center(`${flower}  ${titleText}  ${flower}`, width));
 	lines.push("");
-
-	// Search input row
-	const searchPrompt = colorHex("│ ", activeThemeColors().divider);
-	const searchPlaceholder = snapshot.searchQuery === ""
-		? `${DIM}${colorHex("search…", activeThemeColors().foregroundDim)}${RESET}`
-		: colorHex(snapshot.searchQuery, activeThemeColors().foreground);
-	const factsCount = colorHex(`${snapshot.factsTotal} facts`, activeThemeColors().foregroundDim);
-	const searchClose = colorHex(" │", activeThemeColors().divider);
-
-	const searchLineLeft = `   ${searchPrompt}${searchPlaceholder}`;
-	const searchLineRight = `${factsCount}${searchClose}`;
-	const gap = Math.max(2, width - visibleLength(searchLineLeft) - visibleLength(searchLineRight));
-	lines.push(`${searchLineLeft}${" ".repeat(gap)}${searchLineRight}`);
+	lines.push(splitRule(width));
 	lines.push("");
 
-	// 2-up panel grid
-	const groups = snapshot.groups;
-	const panelInternalWidth = Math.floor((width - 6) / 2); // 2 panels with gaps
-	for (let i = 0; i < groups.length; i += 2) {
-		const left = renderPanel(groups[i]!, panelInternalWidth);
-		const right = i + 1 < groups.length ? renderPanel(groups[i + 1]!, panelInternalWidth) : null;
-		const rowCount = right ? Math.max(left.length, right.length) : left.length;
+	const chevron = colorHex(SEARCH_PROMPT_GLYPH, accent);
+	const queryDisplay = snapshot.searchQuery === ""
+		? `${DIM}${colorHex("search remembered facts…", dim)}${RESET}`
+		: colorHex(snapshot.searchQuery, fg);
+	const factsCount = colorHex(`${snapshot.factsTotal} facts`, dim);
+	const left = `   ${chevron}  ${queryDisplay}`;
+	const right = `${factsCount}   `;
+	const gap = Math.max(2, width - visibleLength(left) - visibleLength(right));
+	lines.push(`${left}${" ".repeat(gap)}${right}`);
+	lines.push("");
+
+	const visibleGroups = filtered.filter((group) => group.panel !== "GENERAL" || group.facts.length > 0);
+	const panelInternalWidth = Math.floor((width - 6) / 2);
+	for (let i = 0; i < visibleGroups.length; i += 2) {
+		const leftPanel = renderPanel(visibleGroups[i]!, panelInternalWidth, snapshot.focusedFactId);
+		const rightPanel = i + 1 < visibleGroups.length
+			? renderPanel(visibleGroups[i + 1]!, panelInternalWidth, snapshot.focusedFactId)
+			: null;
+		const rowCount = rightPanel ? Math.max(leftPanel.length, rightPanel.length) : leftPanel.length;
 		for (let r = 0; r < rowCount; r++) {
-			const leftLine = padToWidth(left[r] ?? "", panelInternalWidth);
-			const rightLine = right ? padToWidth(right[r] ?? "", panelInternalWidth) : "";
+			const leftLine = padToWidth(leftPanel[r] ?? "", panelInternalWidth);
+			const rightLine = rightPanel ? padToWidth(rightPanel[r] ?? "", panelInternalWidth) : "";
 			lines.push(`  ${leftLine}  ${rightLine}`);
 		}
 		lines.push("");
 	}
 
-	lines.push(divider(width));
-	lines.push(`   ${DIM}${colorHex(MEMORY_EDITOR_HINTS, activeThemeColors().foregroundDim)}${RESET}`);
+	lines.push(splitRule(width));
+	lines.push(`   ${DIM}${colorHex(MEMORY_EDITOR_HINTS, dim)}${RESET}`);
 
 	return lines;
 }
 
-// ============================================================================
-// Pi-glue
-// ============================================================================
-
-class MemoryEditorComponent implements Component {
-	constructor(
-		private snapshot: MemoryEditorSnapshot,
-		private readonly done: () => void,
-	) {}
-
-	invalidate(): void {}
-
-	handleInput(data: string): void {
-		if (data === "escape" || matchesKey(data, "escape")) {
-			this.done();
-			return;
-		}
-		// Search input: append printable chars to query, backspace removes last char.
-		if (data === "backspace" || matchesKey(data, "backspace")) {
-			this.snapshot = {
-				...this.snapshot,
-				searchQuery: this.snapshot.searchQuery.slice(0, -1),
-			};
-			return;
-		}
-		if (data.length === 1 && !/\p{Cc}/u.test(data)) {
-			this.snapshot = {
-				...this.snapshot,
-				searchQuery: `${this.snapshot.searchQuery}${data}`,
-			};
-		}
-	}
-
-	render(width: number): string[] {
-		return renderMemoryEditor(this.snapshot, width);
-	}
+export interface MemoryEditorComponentDeps {
+	readonly client: RemnicMemoryClient;
+	readonly notify: (message: string, level?: "info" | "warning") => void;
+	readonly invalidate: () => void;
+	readonly close: () => void;
 }
 
 /**
- * Open the memory editor modal. Reads all active memories and groups them
- * by cathedral panel, then renders the modal until the user dismisses.
+ * Choose the next focused fact id when the focused one disappears (forget,
+ * filter change). Falls back to the closest still-visible fact, then to the
+ * first visible fact, then to null.
  */
+function nextFocusAfterRemoval(
+	previousVisible: readonly MemoryFact[],
+	currentVisible: readonly MemoryFact[],
+	previousFocusId: string | null,
+): string | null {
+	if (currentVisible.length === 0) return null;
+	if (previousFocusId === null) return currentVisible[0]?.id ?? null;
+	const prevIndex = previousVisible.findIndex((fact) => fact.id === previousFocusId);
+	if (prevIndex === -1) return currentVisible[0]?.id ?? null;
+	const stillVisible = currentVisible.find((fact) => fact.id === previousFocusId);
+	if (stillVisible) return stillVisible.id;
+	const fallbackIndex = Math.min(prevIndex, currentVisible.length - 1);
+	return currentVisible[fallbackIndex]?.id ?? currentVisible[0]?.id ?? null;
+}
+
+export class MemoryEditorComponent implements Component {
+	private snapshot: MemoryEditorSnapshot;
+	private readonly deps: MemoryEditorComponentDeps;
+	private busy = false;
+
+	public constructor(initial: MemoryEditorSnapshot, deps: MemoryEditorComponentDeps) {
+		this.snapshot = ensureFocusedFact(initial);
+		this.deps = deps;
+	}
+
+	public invalidate(): void {
+		this.deps.invalidate();
+	}
+
+	public render(width: number): string[] {
+		return renderMemoryEditor(this.snapshot, width);
+	}
+
+	public handleInput(data: string): void {
+		if (matchesKey(data, "escape") || data === "escape" || data === "\u001b") {
+			this.deps.close();
+			return;
+		}
+		if (matchesKey(data, "up") || data === "up") {
+			this.moveFocus(-1);
+			return;
+		}
+		if (matchesKey(data, "down") || data === "down") {
+			this.moveFocus(1);
+			return;
+		}
+		if (data === "d" && !this.busy) {
+			void this.handleForget();
+			return;
+		}
+		if (data === "e") {
+			this.deps.notify("revise inline coming soon — use /sumo:memory forget <id> + /sumo:memory add <text>", "info");
+			return;
+		}
+		if (matchesKey(data, "backspace") || data === "backspace") {
+			this.updateSearch(this.snapshot.searchQuery.slice(0, -1));
+			return;
+		}
+		if (data.length === 1 && !/\p{Cc}/u.test(data)) {
+			this.updateSearch(`${this.snapshot.searchQuery}${data}`);
+		}
+	}
+
+	private updateSearch(query: string): void {
+		const previousVisible = flatVisibleFacts(filterGroups(this.snapshot.groups, this.snapshot.searchQuery));
+		const nextVisible = flatVisibleFacts(filterGroups(this.snapshot.groups, query));
+		const focusedFactId = nextFocusAfterRemoval(previousVisible, nextVisible, this.snapshot.focusedFactId);
+		this.snapshot = { ...this.snapshot, searchQuery: query, focusedFactId };
+		this.deps.invalidate();
+	}
+
+	private moveFocus(delta: number): void {
+		const visible = flatVisibleFacts(filterGroups(this.snapshot.groups, this.snapshot.searchQuery));
+		if (visible.length === 0) {
+			this.snapshot = { ...this.snapshot, focusedFactId: null };
+			this.deps.invalidate();
+			return;
+		}
+		const currentIndex = this.snapshot.focusedFactId === null
+			? -1
+			: visible.findIndex((fact) => fact.id === this.snapshot.focusedFactId);
+		let nextIndex: number;
+		if (currentIndex === -1) {
+			nextIndex = delta > 0 ? 0 : visible.length - 1;
+		} else {
+			nextIndex = (currentIndex + delta + visible.length) % visible.length;
+		}
+		this.snapshot = { ...this.snapshot, focusedFactId: visible[nextIndex]!.id };
+		this.deps.invalidate();
+	}
+
+	private async handleForget(): Promise<void> {
+		const focusId = this.snapshot.focusedFactId;
+		if (!focusId) {
+			this.deps.notify("nothing focused to forget", "info");
+			return;
+		}
+		this.busy = true;
+		const previousGroups = this.snapshot.groups;
+		const previousSearch = this.snapshot.searchQuery;
+		const optimisticGroups = previousGroups.map((group) => ({
+			panel: group.panel,
+			facts: group.facts.filter((fact) => fact.id !== focusId),
+		}));
+		const previousVisible = flatVisibleFacts(filterGroups(previousGroups, previousSearch));
+		const nextVisible = flatVisibleFacts(filterGroups(optimisticGroups, previousSearch));
+		this.snapshot = {
+			...this.snapshot,
+			groups: optimisticGroups,
+			factsTotal: optimisticGroups.reduce((total, group) => total + group.facts.length, 0),
+			focusedFactId: nextFocusAfterRemoval(previousVisible, nextVisible, focusId),
+		};
+		this.deps.invalidate();
+		try {
+			await this.deps.client.forget(focusId);
+			this.deps.notify("forgotten", "info");
+		} catch (error) {
+			this.snapshot = { ...this.snapshot, groups: previousGroups, factsTotal: previousVisible.length, focusedFactId: focusId };
+			this.deps.invalidate();
+			this.deps.notify(`forget failed: ${error instanceof Error ? error.message : String(error)}`, "warning");
+		} finally {
+			this.busy = false;
+		}
+	}
+}
+
+function ensureFocusedFact(snapshot: MemoryEditorSnapshot): MemoryEditorSnapshot {
+	if (snapshot.focusedFactId !== null) return snapshot;
+	const visible = flatVisibleFacts(filterGroups(snapshot.groups, snapshot.searchQuery));
+	if (visible.length === 0) return snapshot;
+	return { ...snapshot, focusedFactId: visible[0]!.id };
+}
+
 export async function showMemoryEditor(
 	ctx: ExtensionCommandContext,
 	client: RemnicMemoryClient = createRemnicMemoryClient(),
@@ -206,34 +349,30 @@ export async function showMemoryEditor(
 	}
 
 	const groups = groupFactsByPanel(facts);
-	const snapshot: MemoryEditorSnapshot = {
+	const initial: MemoryEditorSnapshot = {
 		searchQuery: "",
 		groups,
 		factsTotal: facts.length,
+		focusedFactId: null,
 	};
 
 	await ctx.ui.custom<void>(
-		(_tui: TUI, _theme: unknown, _kb: KeybindingsManager, done: () => void) =>
-			new MemoryEditorComponent(snapshot, done),
+		(tui: TUI, _theme: unknown, _kb: KeybindingsManager, done: () => void) => new MemoryEditorComponent(initial, {
+			client,
+			notify: (message, level) => ctx.ui.notify(message, level ?? "info"),
+			invalidate: () => tui.requestRender(),
+			close: () => done(),
+		}),
 		{
 			overlay: true,
-			overlayOptions: {
-				anchor: "center",
-				width: "80%",
-				minWidth: 70,
-				maxHeight: "80%",
-			},
+			overlayOptions: { anchor: "center", width: "80%", minWidth: 70, maxHeight: "80%" },
 			onHandle: (_handle: OverlayHandle) => {
-				/* opportunity to programmatically close in the future */
+				/* no-op for now; future: programmatic close hook */
 			},
 		},
 	);
 }
 
-/**
- * Register the `/sumo:memory edit` slash command. Future subcommands
- * (`add`, `forget`) can be added here too.
- */
 export function registerMemoryCommand(pi: ExtensionAPI): void {
 	pi.registerCommand("sumo:memory", {
 		description: "open the cathedral memory editor (or `add` / `forget` for direct ops)",

--- a/src/memory-editor.ts
+++ b/src/memory-editor.ts
@@ -343,7 +343,21 @@ export class MemoryEditorComponent implements Component {
 			await this.deps.client.forget(focusId);
 			this.deps.notify("forgotten", "info");
 		} catch (error) {
-			this.snapshot = { ...this.snapshot, groups: previousGroups, factsTotal: previousFactsTotal, focusedFactId: focusId };
+			// Recompute focus against the CURRENT search filter, not the search
+			// that was active when forget started. The user may have typed into
+			// search while the request was in flight, so the rolled-back fact
+			// may no longer be visible. Forcing the stale id back as focus would
+			// let a subsequent `d` keystroke delete a hidden fact.
+			const restoredVisible = flatVisibleFacts(filterGroups(previousGroups, this.snapshot.searchQuery));
+			const restoredFocus = restoredVisible.some((fact) => fact.id === focusId)
+				? focusId
+				: nextFocusAfterRemoval(restoredVisible, restoredVisible, null);
+			this.snapshot = {
+				...this.snapshot,
+				groups: previousGroups,
+				factsTotal: previousFactsTotal,
+				focusedFactId: restoredFocus,
+			};
 			this.deps.invalidate();
 			this.deps.notify(`forget failed: ${error instanceof Error ? error.message : String(error)}`, "warning");
 		} finally {

--- a/src/memory-editor.ts
+++ b/src/memory-editor.ts
@@ -45,14 +45,24 @@ const SEARCH_PROMPT_GLYPH = "\u276F";
 const PANEL_INDENT = "   ";
 const PANEL_GAP = "   ";
 
+export type MemoryEditorMode = "command" | "search";
+
 export type MemoryEditorSnapshot = {
 	searchQuery: string;
 	groups: readonly PanelGroup[];
 	factsTotal: number;
 	focusedFactId: string | null;
+	/**
+	 * `"command"` (default) routes letter keys to hotkeys (`d` forget, `e`
+	 * revise, `/` enters search). `"search"` routes letter keys into the
+	 * search query so `pre`, `node`, `android`, etc. filter cleanly. Esc in
+	 * `"search"` returns to `"command"` (preserving the query); Esc in
+	 * `"command"` closes the overlay.
+	 */
+	mode?: MemoryEditorMode;
 };
 
-export const MEMORY_EDITOR_HINTS = "\u2191\u2193 wander    /  search    e  revise    d  forget    \u23CE retreat";
+export const MEMORY_EDITOR_HINTS = "\u2191\u2193 wander    /  search    e  revise    d  forget    \u238B retreat";
 
 export const MEMORY_EDITOR_OVERLAY_OPTIONS: OverlayOptions = {
 	anchor: "center",
@@ -224,8 +234,36 @@ export class MemoryEditorComponent implements Component {
 	}
 
 	public handleInput(data: string): void {
+		const mode = this.snapshot.mode ?? "command";
+		if (mode === "search") {
+			if (matchesKey(data, "escape") || data === "escape" || data === "\u001b") {
+				this.snapshot = { ...this.snapshot, mode: "command" };
+				this.deps.invalidate();
+				return;
+			}
+			if (matchesKey(data, "backspace") || data === "backspace") {
+				this.updateSearch(this.snapshot.searchQuery.slice(0, -1));
+				return;
+			}
+			if (matchesKey(data, "enter") || data === "enter" || data === "\r" || data === "\n") {
+				this.snapshot = { ...this.snapshot, mode: "command" };
+				this.deps.invalidate();
+				return;
+			}
+			if (data.length === 1 && !/\p{Cc}/u.test(data)) {
+				this.updateSearch(`${this.snapshot.searchQuery}${data}`);
+			}
+			return;
+		}
+
+		// command mode
 		if (matchesKey(data, "escape") || data === "escape" || data === "\u001b") {
 			this.deps.close();
+			return;
+		}
+		if (data === "/") {
+			this.snapshot = { ...this.snapshot, mode: "search" };
+			this.deps.invalidate();
 			return;
 		}
 		if (matchesKey(data, "up") || data === "up") {
@@ -243,13 +281,6 @@ export class MemoryEditorComponent implements Component {
 		if (data === "e") {
 			this.deps.notify("revise inline coming soon \u2014 use /sumo:memory forget <id> + /sumo:memory add <text>", "info");
 			return;
-		}
-		if (matchesKey(data, "backspace") || data === "backspace") {
-			this.updateSearch(this.snapshot.searchQuery.slice(0, -1));
-			return;
-		}
-		if (data.length === 1 && !/\p{Cc}/u.test(data)) {
-			this.updateSearch(`${this.snapshot.searchQuery}${data}`);
 		}
 	}
 


### PR DESCRIPTION
## Summary

Re-implementation of #138 against current `main` after PR #178 was closed for divergence. Builds the V2 Memory Scriptorium against the theme registry, owned-shell overlay, and current fixture-capture pipeline.

## What changed

`src/memory-editor.ts` rewritten to V2 Bible chrome:

- title `✨  MEMORY SCRIPTORIUM  ✨` (centered, accent floral marks)
- `❯` accent search prompt with dim placeholder + facts count
- 6 panels in 2-up grid (`╭─ NAME ──╮`), GENERAL hidden when empty
- focused fact marker `❈` (accent) vs unfocused `·` (divider)
- split-rule dividers `─────  ·  ─────` above/below content
- footer hint `↑↓ wander    /  search    e  revise    d  forget    ⏎ retreat`
- all colors read from `activeThemeColors()` (Cathedral / Obsidian both work)

`MemoryEditorComponent` with deps injection (`client`, `notify`, `invalidate`, `close`):

- search filter (instant)
- `↑↓` walks visible facts across panels (filter-aware)
- `d` optimistic forget: removes fact + advances focus before awaiting `client.forget`; on rejection rolls back groups, focus, and exact `factsTotal`
- `e` notifies a deferred-revise hint
- `⏎` closes
- busy gate prevents double-forget

`scripts/visual-v2/fixture-capture.mjs`:

- new `applyMemoryScriptoriumOverlay(lines, cols, rows)` builds a 13-fact dataset spanning all 6 panels, focused on `pref-1` to exercise `❈`, composites onto the `completed-active` scene preserving left/right remnants
- `applyOverlay` switch dispatches `"memory-scriptorium"`

`docs/visual/parity/scenarios.json`:

- new `fixture-memory-scriptorium-overlay` scenario (160×45, status `review`, target `scene-memory-scriptorium-overlay.png`, full + overlay-center crops)

## Tests

`src/memory-editor.test.ts` — 22 tests:

- title + dividers + accent color
- search row (placeholder, query, facts count, chevron)
- panel grid (panel headers, GENERAL show/hide, focus markers)
- footer hints
- component interaction: auto-focus, filter, arrow navigation, optimistic forget happy/rollback, rollback preserves exact facts total under search filter, `e` notifies, escape closes
- command registration

## Deferred

`e` inline revise still emits a notify hint pointing at `/sumo:memory forget <id> + add <text>`. The inline editor flow is the right next slice but warrants its own PR.

## Verification

Passed locally:

```txt
pnpm exec tsc --noEmit
pnpm test                 → 785 passed
pnpm test:integration     → 29 passed
pnpm vitest run src/memory-editor.test.ts → 22 passed
pnpm visual:ci            → 16 scenarios, new fixture renders in review status
```

SumoCode scribe ran (P2 caught + fixed) → GREEN.

## How to test

```bash
git pull && git switch feat/memory-scriptorium-138
pnpm install
./bin/sumocode.sh
```

Then `/sumo:memory` (or `/sumo:memory edit`):

- type to filter facts
- `↑↓` to move focus across panels
- `d` to forget the focused fact
- `e` shows deferred-edit hint
- `⏎` closes

Closes #138
