### PR TITLE
Cap approval modal command + description rows

### DIFF
--- a/src/approval-modal.test.ts
+++ b/src/approval-modal.test.ts
@@ -99,6 +99,29 @@ describe("renderApprovalModal", () => {
 		expect(plain.filter((row) => row.includes("│")).length).toBeGreaterThan(1);
 		expect(plain.join("\n")).toContain("Approval modal leaks long commands");
 	});
+
+	it("caps the command box height for very long commands and shows a truncation marker", () => {
+		// Twenty pipe-separated subcommands that each wrap once at width 80 →
+		// far more than MAX_COMMAND_ROWS = 12 once expanded into the modal.
+		const longCommand = Array.from({ length: 20 }, (_, i) => `subcmd${i} --flag-${i}=very-long-value-${i}-${i}-${i}-${i}-${i}-${i}-${i}-${i}-${i}-${i}`).join(" | ");
+		const lines = renderApprovalModal(snapshot({ command: longCommand }), 80);
+		const plain = lines.map(stripAnsi);
+		const commandRows = plain.filter((row) => row.includes("│") && !row.includes("┌") && !row.includes("└"));
+		// Cap is MAX_COMMAND_ROWS = 12, so the bash region must not blow up the modal height.
+		expect(commandRows.length).toBeLessThanOrEqual(12);
+		expect(plain.some((row) => row.includes("more lines hidden"))).toBe(true);
+		// Total modal height stays bounded.
+		expect(lines.length).toBeLessThanOrEqual(28);
+	});
+
+	it("caps the description region for verbose multi-line explanations", () => {
+		const lines = renderApprovalModal(snapshot({
+			descriptionLines: Array.from({ length: 12 }, (_, i) => `Reason ${i + 1}: this command is dangerous because of an unusual edge case.`),
+		}), 80);
+		const plain = lines.map(stripAnsi).join("\n");
+		expect(plain).toContain("more lines hidden");
+		expect(lines.length).toBeLessThanOrEqual(28);
+	});
 });
 
 describe("updateApprovalSnapshot — direct letter selection", () => {

--- a/src/approval-modal.ts
+++ b/src/approval-modal.ts
@@ -47,6 +47,15 @@ import {
 
 const PANEL_INDENT = "   ";
 const BIBLE_COMMAND_BOX_WIDTH_AT_80 = 68;
+/**
+ * Cap the visible row count of the command box. Long bash commands (e.g.
+ * a deeply piped one-liner) would otherwise wrap into dozens of rows and
+ * grow the modal beyond the terminal height. The remaining rows are
+ * collapsed into a `… N more lines` indicator so the user still sees that
+ * the command is truncated and can `⎘` to abort and copy from session.
+ */
+const MAX_COMMAND_ROWS = 12;
+const MAX_DESCRIPTION_ROWS = 4;
 
 const panelRow = wrapPanelRow;
 
@@ -81,11 +90,25 @@ function renderCommandFrame(command: string, width: number): string[] {
 	const innerWidth = Math.max(0, boxWidth - 2);
 	const commandWidth = Math.max(1, innerWidth - 2);
 	const border = activeThemeColors().divider;
-	const commandRows = wrapTextWithAnsi(command, commandWidth);
-	const safeRows = commandRows.length > 0 ? commandRows : [""];
+	const dim = activeThemeColors().foregroundDim;
+	const wrappedRows = wrapTextWithAnsi(command, commandWidth);
+	const initialRows = wrappedRows.length > 0 ? wrappedRows : [""];
+	const overflowCount = Math.max(0, initialRows.length - MAX_COMMAND_ROWS);
+	const commandRows = overflowCount > 0
+		? [
+			...initialRows.slice(0, MAX_COMMAND_ROWS - 1),
+			fitLine(`… ${overflowCount + 1} more lines hidden`, commandWidth),
+		]
+		: initialRows;
+	const commandFg = (row: string, isOverflow: boolean): string =>
+		fg(fitLine(row, commandWidth), isOverflow ? dim : activeThemeColors().foreground);
 	const boxRows = [
 		fg(`┌${"─".repeat(innerWidth)}┐`, border),
-		...safeRows.map((row) => `${fg("│", border)} ${fg(fitLine(row, commandWidth), activeThemeColors().foreground)}${" ".repeat(Math.max(0, commandWidth - visibleLength(row)))} ${fg("│", border)}`),
+		...commandRows.map((row, index) => {
+			const isOverflow = overflowCount > 0 && index === commandRows.length - 1;
+			const paddingCount = Math.max(0, commandWidth - visibleLength(row));
+			return `${fg("│", border)} ${commandFg(row, isOverflow)}${" ".repeat(paddingCount)} ${fg("│", border)}`;
+		}),
 		fg(`└${"─".repeat(innerWidth)}┘`, border),
 	];
 	return boxRows.map((row) => `${PANEL_INDENT}${persistentBg(padRight(row, boxWidth), activeThemeColors().foreground, activeThemeColors().surfaceRecess)}`);
@@ -103,7 +126,12 @@ function renderDescriptionRows(descriptionLines: readonly string[], width: numbe
 			rows.push(`${PANEL_INDENT}${fg(`${rowPrefix}${lines[rowIndex]}`, activeThemeColors().foregroundDim)}`);
 		}
 	}
-	return rows;
+	if (rows.length <= MAX_DESCRIPTION_ROWS) return rows;
+	const hidden = rows.length - (MAX_DESCRIPTION_ROWS - 1);
+	return [
+		...rows.slice(0, MAX_DESCRIPTION_ROWS - 1),
+		`${PANEL_INDENT}${fg(`  … ${hidden} more lines hidden`, activeThemeColors().foregroundDim)}`,
+	];
 }
 
 /**


### PR DESCRIPTION
## Summary

Dhruv reported the approval modal grows uncontrollably tall when the gated bash command is long (multi-piped one-liner, GitHub command with a quoted body, etc.). `wrapTextWithAnsi(command, commandWidth)` would produce N rows and every wrapped row got rendered into the lifted-bg panel, so the modal could exceed the terminal height in both portrait and landscape.

## Fix

`src/approval-modal.ts`:

- new caps `MAX_COMMAND_ROWS = 12` and `MAX_DESCRIPTION_ROWS = 4`
- `renderCommandFrame` slices wrapped command rows; on overflow the last row becomes `… N more lines hidden` rendered in `foregroundDim` (passed through `fitLine` so the marker itself can't overflow horizontally)
- `renderDescriptionRows` same pattern for verbose explanations
- short commands / short descriptions are unchanged byte-for-byte

Users can `⎘` to abort and copy the full command from the session log.

## Tests

`src/approval-modal.test.ts`:

- 20 pipe-separated subcommands at width 80 → ≤12 command rows + `more lines hidden` marker present + total modal ≤28 rows
- 12 verbose description lines → `more lines hidden` marker + total modal ≤28 rows
- existing long-command-wraps regression test still green (well within caps)

## Verification

Passed locally:

```txt
pnpm exec tsc --noEmit
pnpm vitest run src/approval-modal.test.ts  → 30 passed
pnpm test                                   → 797 passed
```

SumoCode scribe → GREEN.
