### PR TITLE
v0.3 announce — rewrite README + refresh DEV_LOOP

### DIFF
--- a/DEV_LOOP.md
+++ b/DEV_LOOP.md
@@ -106,11 +106,12 @@ sumocode diag                    # summarizes /tmp/sumocode-manual.jsonl
 sumocode doctor                  # checks Pi patch/module/diagnostics health
 ```
 
-Expected signals for v0.1.0:
-- Notification: `SumoCode loaded · v0.1.0`
-- No errors in the footer or on startup
+Expected signals on a healthy boot:
+- Splash centered with version line `SUMOCODE V0.3.0 · CATHEDRAL · 160 × 45 MONOSPACE`
+- Sidebar paints in landscape (terminal width ≥ 120 cols)
+- Footer dot reads `● READY` in the active theme's idle colour
 
-For v0.2+ features, verify the specific things I just changed.
+For a feature change, verify the specific surface I just touched.
 
 ### 4. Commit to the dev repo
 
@@ -141,10 +142,10 @@ When a set of commits is ready to go live on all machines:
 Edit `package.json`:
 
 ```json
-{ "version": "0.2.0" }
+{ "version": "0.3.1" }
 ```
 
-And update `VERSION` const in `src/extension.ts` if the notification needs to reflect it.
+And update `SPLASH_VERSION_LINE` in `src/footer.ts` so the splash matches. The bible mockup version line in `scripts/gen-bible-element-3.mjs` mirrors it; bump that too if the doc is part of the release.
 
 Semver convention for SumoCode:
 - **MAJOR** — breaking extension API usage (something crashes if downgraded)
@@ -154,8 +155,8 @@ Semver convention for SumoCode:
 ### 2. Commit + tag
 
 ```bash
-git commit -am "release: v0.2.0"
-git tag v0.2.0
+git commit -am "release: v0.3.1"
+git tag v0.3.1
 ```
 
 ### 3. Push
@@ -164,7 +165,7 @@ git tag v0.2.0
 git push && git push --tags
 ```
 
-GitHub now shows the v0.2.0 release. Installed machines still on v0.1.0.
+GitHub now shows the new release. Installed machines still on the previous tag until they `pi update`.
 
 ### 4. Pull on each machine
 
@@ -172,7 +173,7 @@ GitHub now shows the v0.2.0 release. Installed machines still on v0.1.0.
 pi update git:github.com/dhruvkelawala/sumocode
 ```
 
-This refreshes `~/.pi/agent/git/github.com/dhruvkelawala/sumocode/` from the new `main` tip (which is now at v0.2.0). Restart Pi to load the new version.
+This refreshes `~/.pi/agent/git/github.com/dhruvkelawala/sumocode/` from the new `main` tip. Restart Pi to load the new version.
 
 Do this on both mini and MacBook. Since `sumocode` is in `sumocode-config`'s synced `settings.json`, no config changes are needed — it's just a package update.
 
@@ -279,15 +280,22 @@ Rule of thumb:
 
 ---
 
+## What's in the dev loop now
+
+- **Tests.** 821 unit tests via vitest, 32 integration tests via node-pty. Run `pnpm test` and `pnpm test:integration`. Both gated on the same TypeScript graph that ships.
+- **Visual harness.** `pnpm visual:ci` for the V2 parity contract; `pnpm render:bible` regenerates the mockup PNGs.
+- **Perf snapshot.** `pnpm perf:startup` produces a markdown report under `docs/perf/`.
+- **Scribe diff review.** `/sumo:review` runs an in-session reviewer (default `openai-codex/gpt-5.3-codex`) on the current branch diff. Repeat until GREEN before merging.
+- **CHANGELOG.** Keep-a-Changelog format; one section per release, retroactively documented for v0.1.0 → v0.2.0 → v0.3.0.
+- **Pi version smoke.** `scripts/smoke-pi-versions.sh` runs `pi --version` against the pinned + adjacent Pi versions to catch the seam patch breaking on a Pi bump before a real session does.
+
 ## What's NOT in the dev loop yet
 
-- Tests. No test harness exists yet. If/when extensions grow complex enough to warrant testing, add `vitest` and point it at Pi's `VirtualTerminal` for TUI tests. Not worth it at v0.1–v0.3.
-- CI. No GitHub Actions yet. Might add a lint + typecheck workflow at v0.3+.
-- Changelog file. Commit messages + GitHub Releases are enough at this scale.
-- Lint. `oxlint` or `biome` would be nice eventually. Not worth setup time at v0.1.
+- **Public PR CI.** A GitHub Actions workflow that runs `pnpm test + pnpm exec tsc --noEmit` on every PR. Stub workflows for visual + perf live under `.github/workflows/`; the typecheck/test gate is on the v0.3.x followup list.
+- **Lint.** Project leans on `tsc` strict and the scribe rather than a separate linter. If/when biome gets adopted, point it at `src/`.
 
-These are intentionally deferred. Add them when friction actually shows up, not before.
+These are intentionally deferred. Add them when friction actually shows up.
 
 ---
 
-*Last updated: 2026-04-24 · v0.1.0*
+*Last updated: 2026-05-08 · v0.3.0 · Pi 0.74.0 (`@earendil-works/pi-coding-agent`)*

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ it's been my daily-drive shell for the last two months.
 
 facts the agent learned about you, edited like a manuscript. six panels (identity, preferences, workflow, projects, system, general). `e` to revise a line, `d` to forget. groups by topic, search inline. the agent reads from it on every new session.
 
-<sub>open with `Ctrl+M` or `/sumo:memory`</sub>
+<sub>open with `/sumo:memory`</sub>
 
 </td>
 <td width="50%" valign="top">
@@ -108,7 +108,7 @@ cathedral-styled gate for dangerous bash commands. patterns are configurable per
 
 three sections: context (token meter, session cost), MCP (live status dots per server), memory (persisted bullets the agent keeps). 30 columns wide; appears at terminal width 120+. portrait policy hides it deliberately.
 
-<sub>position cycles with `Ctrl+Shift+S`</sub>
+<sub>appears automatically at 120+ columns</sub>
 
 </td>
 </tr>

--- a/README.md
+++ b/README.md
@@ -2,97 +2,170 @@
 
 # SumoCode
 
-**A Pi extension that makes your terminal AI coding experience feel personal.**
+**a scriptorium for the terminal**
 
-OpenCode visual language · persistent memory across sessions · preattentive status signals · built on [@earendil-works/pi-mono](https://github.com/badlogic/pi-mono).
+a Pi extension i built so my terminal AI feels personal across machines.
+
+[![mit license](https://img.shields.io/badge/license-MIT-2D211A?style=flat-square)](./LICENSE)
+[![version](https://img.shields.io/badge/v0.3.0-B85A22?style=flat-square)](./CHANGELOG.md)
+[![pi 0.74](https://img.shields.io/badge/pi-0.74.0-4A6B3A?style=flat-square)](https://github.com/earendil-works/pi)
+[![tests](https://img.shields.io/badge/tests-821%20passing-4A6B3A?style=flat-square)](./test)
+
+<br>
+
+<img src="./docs/marketing/02-cathedral-active.png" alt="SumoCode running in Cathedral theme — active scroll/scribe delegation with sidebar visible" width="900">
 
 </div>
 
 ---
 
-> **Status:** v0.1.0 — scaffold. Hello-world extension only. Real features land as we resolve the decision tree in [PLAN.md](./PLAN.md).
+## what you're looking at
 
-## What it is
+SumoCode is a Pi extension. it owns the experience layer — splash, top chrome, footer, sidebar, modals, themes, persistent memory across sessions. [Pi](https://github.com/earendil-works/pi) keeps the agent loop, the LLM, sessions, MCP, skills.
 
-SumoCode is a personal fork of the "OpenCode terminal UI" idea, as a Pi extension — not a separate binary. Pi handles agents, tools, LLMs, sessions, skills, MCP. SumoCode owns the **experience layer**: sidebar, footer, memory widget, status colors, persona.
+three themes ship. cathedral by default. amber CRT when i miss DOS. obsidian temple at night. cycle with `Ctrl+Shift+T`. choice persists across machines.
 
-Paired with a private `sumocode-config` repo that syncs settings/extensions/memory across my machines. Both repos together = my terminal AI stays the same whether I'm on the Mac mini or the MacBook.
+it's been my daily-drive shell for the last two months.
 
-## Architecture
+## theme tour
+
+<table>
+<tr>
+<td align="center" width="33%">
+<img src="./docs/marketing/02-cathedral-active.png" alt="Cathedral theme">
+<br><strong>cathedral</strong>
+<br><sub>warm walnut chassis, burnt-orange accent, fleur-de-lis bullets, rounded chrome. default.</sub>
+</td>
+<td align="center" width="33%">
+<img src="./docs/marketing/04-amber-crt.png" alt="Amber CRT theme">
+<br><strong>amber CRT</strong>
+<br><sub>warm dark brown chassis, P3 amber phosphor, double-line ASCII chrome, P1 green / cyan / red phosphor states.</sub>
+</td>
+<td align="center" width="33%">
+<img src="./docs/marketing/05-obsidian-temple.png" alt="Obsidian Temple theme">
+<br><strong>obsidian temple</strong>
+<br><sub>deep obsidian background, electrum gold + neon cyan + magenta, Egyptian section glyphs.</sub>
+</td>
+</tr>
+</table>
+
+## what makes it personal
+
+<table>
+<tr>
+<td width="50%" valign="top">
+
+### ❈  memory scriptorium
+
+facts the agent learned about you, edited like a manuscript. six panels (identity, preferences, workflow, projects, system, general). `e` to revise a line, `d` to forget. groups by topic, search inline. the agent reads from it on every new session.
+
+<sub>open with `Ctrl+M` or `/sumo:memory`</sub>
+
+</td>
+<td width="50%" valign="top">
+
+### ●  five preattentive states
+
+idle / thinking / tool / approval / learning. each gets a distinct colour drawn from the active theme. you can read the state out of the corner of your eye while your hands are typing.
+
+<sub>set in `src/themes/*.ts`, surfaced in the footer dot + working indicator</sub>
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+### ▣  owned-shell mode
+
+every cell that paints is mine. retained renderer, in-app scroll, modal layer, mouse routing, OSC 52 selection. Pi is reduced to LLM/tools/sessions through clean adapters; the seam lives in one directory (`src/sumo-tui/pi-compat/`).
+
+<sub>see [`docs/SUMO_TUI_PI_PATCH_STRATEGY.md`](./docs/SUMO_TUI_PI_PATCH_STRATEGY.md)</sub>
+
+</td>
+<td width="50%" valign="top">
+
+### ↻  /sumo:reload
+
+hard-reload the shell while keeping your terminal context. exits with code 100, the launcher loop respawns with `--continue`. iterating on the renderer no longer means losing the session.
+
+<sub>also strips `--resume` and replaces with `--continue`</sub>
+
+</td>
+</tr>
+<tr>
+<td width="50%" valign="top">
+
+### ✾  cathedral approval modal
+
+cathedral-styled gate for dangerous bash commands. patterns are configurable per session — `rm -rf`, `sudo`, `git push --force`, mutating gh CLI calls, plus your own. long commands get capped at 12 visible rows so the modal never overflows the terminal.
+
+<sub>configurable via `ApprovalGateConfig`</sub>
+
+</td>
+<td width="50%" valign="top">
+
+### ▦  sidebar with intent
+
+three sections: context (token meter, session cost), MCP (live status dots per server), memory (persisted bullets the agent keeps). 30 columns wide; appears at terminal width 120+. portrait policy hides it deliberately.
+
+<sub>position cycles with `Ctrl+Shift+S`</sub>
+
+</td>
+</tr>
+</table>
+
+## reading the source
+
+this is a personal Pi extension. it runs in my fork of Pi with a small private patch (`patches/@earendil-works__pi-coding-agent@0.74.0.patch`, 36 lines) that lets SumoCode own the root TUI. the package isn't designed to drop into your machine clean — but the source is yours to read, fork, and lift from. the patch is small and well-documented.
+
+if you want to actually run it, [`DEV_LOOP.md`](./DEV_LOOP.md) walks the dev loop and [`SETUP.md`](./SETUP.md) is what i run on a new machine. you'll need the public companion config too: [`dhruvkelawala/sumocode-config`](https://github.com/dhruvkelawala/sumocode-config) is private and personal, so you'd be writing your own.
+
+## how it's built
 
 ```
-┌──────────────────────────────────────────────┐
-│ Pi (the engine)                              │
-│  - LLM abstraction (pi-ai)                   │
-│  - Agent loop + tools (pi-agent-core)        │
-│  - Sessions, compaction, auth, MCP           │
-│  - Extension API (ctx.ui.*)                  │
-└──────────────────────────────────────────────┘
-                    ▲
-                    │ extension API
-                    ▼
-┌──────────────────────────────────────────────┐
-│ SumoCode (this repo)                         │
-│  - Persona layer                             │
-│  - Custom footer (model/cost/branch/memory)  │
-│  - Right sidebar overlay                     │
-│  - Memory widget (cross-session facts)       │
-│  - 5 preattentive status color signals       │
-│  - Custom working indicator frames           │
-└──────────────────────────────────────────────┘
-
- Private, synced:
-   github.com/dhruvkelawala/sumocode-config
-     ↳ persona.md, memory.json, settings, mcp, extensions
+┌──────────────────────────────────────────────────────────┐
+│  Pi  ·  @earendil-works/pi-coding-agent@0.74.0           │
+│   · LLM abstraction (pi-ai)                              │
+│   · agent loop + tools (pi-agent-core)                   │
+│   · sessions, compaction, auth, skills, MCP              │
+│   · extension API (ctx.ui.*)                             │
+└──────────────────────────────────────────────────────────┘
+                          ▲
+                          │ extension API + 36-line seam patch
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│  SumoCode  ·  this repo                                  │
+│   · retained terminal renderer (yoga flex layout)        │
+│   · cathedral / amber CRT / obsidian themes              │
+│   · memory scriptorium                                   │
+│   · approval modal · divine query · skill pills          │
+│   · cell-precise selection + OSC 52 auto-copy            │
+│   · 5 preattentive status states + working indicator     │
+└──────────────────────────────────────────────────────────┘
+                          ▲
+                          │ symlink into ~/.pi/agent/
+                          ▼
+┌──────────────────────────────────────────────────────────┐
+│  sumocode-config  ·  private, synced across machines     │
+│   · persona.md · memory · settings · MCP · extensions    │
+└──────────────────────────────────────────────────────────┘
 ```
 
-## Install
+the design history lives in [`docs/prd.md`](./docs/prd.md) (PRD), [`docs/adr/0001-sumo-tui-framework.md`](./docs/adr/0001-sumo-tui-framework.md) (the retained-renderer ADR), and [`docs/ui/CATHEDRAL_UX_SPEC_V2.md`](./docs/ui/CATHEDRAL_UX_SPEC_V2.md) (the visual canon).
 
-**Quick try:**
-```bash
-pi install git:github.com/dhruvkelawala/sumocode
-```
+## credits
 
-Then reload Pi. You should see the notification: `SumoCode loaded · v0.1.0`.
+* [Mario Zechner](https://github.com/badlogicgames) and the [@earendil-works](https://github.com/earendil-works) team for [Pi](https://github.com/earendil-works/pi). every cell SumoCode paints sits on top of Pi's agent loop, model registry, and extension API. the patch is 36 lines because Pi was already designed to be extended.
+* [OpenCode](https://opencode.ai/) for the visual language i love and openly mirror.
+* the AI agents that helped me write this — anthropic claude opus, openai codex, deepseek v4, kimi. several thousand commits' worth of pair programming.
+* built in london, on a mac mini in portrait orientation, in cmux.
 
-**Full personal setup** (me on a new machine): see [SETUP.md](./SETUP.md) — bootstraps both repos, env vars, system deps, verification.
+## license
 
-## Roadmap
+MIT — see [LICENSE](./LICENSE).
 
-See **[PLAN.md](./PLAN.md)** for decision log, v1.c scope, and open questions.
+<br>
 
-High level:
-- **v0.1.0** (today): scaffold + notification
-- **v0.2.x**: persona + custom footer + working indicator
-- **v0.3.x**: right sidebar overlay + memory widget
-- **v0.4.x**: 5 named preattentive color signals locked in
-- **v1.0.0**: all of V1.c "Personal" shipped, used daily, dogfooded
-
-## Development
-
-See [DEV_LOOP.md](./DEV_LOOP.md) for the full edit/test/release workflow, debugging, and common tasks.
-
-TL;DR:
-```bash
-cd "/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode"
-pi -e .                          # classic ephemeral Pi extension check
-./bin/sumocode.sh                 # retained SumoTUI local launcher
-./bin/sumocode.sh -d .            # retained launcher + diagnostics flight recorder
-./bin/sumocode.sh doctor          # check Pi patch/module/diagnostics health
-# ...edit, commit, push...
-git tag v0.x.y && git push --tags
-pi update git:github.com/dhruvkelawala/sumocode  # on each machine
-```
-
-If linked globally with `pnpm link --global`, use `sumocode` directly:
-
-```bash
-sumocode --help
-sumocode .
-sumocode -d .
-sumocode diag                    # summarizes /tmp/sumocode-manual.jsonl
-```
-
-## License
-
-MIT — see [LICENSE](./LICENSE). Personal project; take whatever's useful.
+<div align="center">
+<sub>made by <a href="https://github.com/dhruvkelawala">@dhruvkelawala</a> · personal project, take whatever's useful</sub>
+</div>

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ it's been my daily-drive shell for the last two months.
 
 ### ❈  memory scriptorium
 
-facts the agent learned about you, edited like a manuscript. six panels (identity, preferences, workflow, projects, system, general). `e` to revise a line, `d` to forget. groups by topic, search inline. the agent reads from it on every new session.
+facts the agent learned about you, organised like a manuscript. six panels (identity, preferences, workflow, projects, system, general). `d` to forget a line, `/` to search, `⎋` to retreat. inline revise is a planned addition; for now use `/sumo:memory forget <id>` + `/sumo:memory add <text>`. the agent reads from the manuscript on every new session.
 
 <sub>open with `/sumo:memory`</sub>
 
@@ -106,7 +106,7 @@ cathedral-styled gate for dangerous bash commands. patterns are configurable per
 
 ### ▦  sidebar with intent
 
-three sections: context (token meter, session cost), MCP (live status dots per server), memory (persisted bullets the agent keeps). 30 columns wide; appears at terminal width 120+. portrait policy hides it deliberately.
+three sections: context (token meter, session cost), MCP (server roster and current state), memory (persisted bullets the agent keeps). 30 columns wide; appears at terminal width 120+. portrait policy hides it deliberately. live MCP health surfacing is on the roadmap once Pi exposes it; today the section reflects the configured server list.
 
 <sub>appears automatically at 120+ columns</sub>
 


### PR DESCRIPTION
## Summary

HR 5–6 of the v0.3 announce-release prep, per the readiness spec at https://sumocode-release-readiness.vercel.app.

## README rewrite

Replaces the v0.1.0 "hello-world scaffold" framing with the v0.3.0 reality. Eight sections per the spec outline:

1. **Hero** — wordmark, tagline ("a scriptorium for the terminal"), hero screenshot (Cathedral active scroll-scribe), badges row (license / version / Pi / tests)
2. **What you're looking at** — the SumoCode/Pi experience-layer split + three-theme intro + "my daily-drive shell" framing
3. **Theme tour** — Cathedral / Amber CRT / Obsidian Temple side-by-side with one-line captions
4. **What makes it personal** — six-card feature grid: Memory Scriptorium, 5 preattentive states, owned-shell mode, `/sumo:reload`, Cathedral approval modal, intentional sidebar
5. **Reading the source** — honest framing of the install model. Personal Pi extension running my fork with a 36-line patch. Source is yours to read, fork, lift from. Don't pretend it's a clean drop-in.
6. **How it's built** — three-tier architecture diagram (Pi / SumoCode / sumocode-config) + links to PRD, ADR 0001, UX spec V2
7. **Credits** — Mario Zechner + earendil-works for Pi, OpenCode for the visual language, the AI agents that helped, built in London
8. **License + made-by footer** — MIT + `@dhruvkelawala`

Voice: lowercase, terse, no exclamation marks, no decorative emoji, no apologies. The geometric markers (`❈ ● ▣ ↻ ✾ ▦`) on the feature grid are typographic glyphs, not emoji.

All relative links verified to resolve.

## DEV_LOOP.md refresh

Light update bumping the stale v0.1/v0.2 references to v0.3.0 reality:

- Expected splash signal updated to `SUMOCODE V0.3.0 · CATHEDRAL · 160 × 45 MONOSPACE`
- Version-bump example updated to v0.3.1
- "What's NOT in the dev loop yet" was honestly out of date — it claimed no tests / no CI / no changelog, but we now have 821 unit + 32 integration tests, visual harness, perf snapshot, scribe diff review, and a Keep-a-Changelog. Replaced with "what's in the dev loop now" + a smaller "NOT yet" list (public PR CI workflow, lint adoption).

## Verification

```txt
pnpm exec tsc --noEmit                                  → clean
pnpm test                                                → 821 passing (104 files)
ls -la every relative README link                        → all resolve
grep README for sumo-deus|Argent|argent-x|/Users/dhruv  → (none)
markdown HTML balance check                              → all <table>/<tr>/<td>/<div> matched
```

SumoCode scribe (openai-codex/gpt-5.3-codex / thinking=high) — GREEN.

## Out of scope

This PR is the README + dev loop refresh. The remaining HR 7 work (CI workflow + 1280×640 social card + `v0.3.0` git tag + push) ships in a follow-up PR. Demo video (HR 3–4) coordination-blocked on screen recording.