### PR TITLE
README v2 — surface SumoTUI + the kernel + the parity contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ a Pi extension i built so my terminal AI feels personal across machines.
 [![mit license](https://img.shields.io/badge/license-MIT-2D211A?style=flat-square)](./LICENSE)
 [![version](https://img.shields.io/badge/v0.3.0-B85A22?style=flat-square)](./CHANGELOG.md)
 [![pi 0.74](https://img.shields.io/badge/pi-0.74.0-4A6B3A?style=flat-square)](https://github.com/earendil-works/pi)
-[![tests](https://img.shields.io/badge/tests-821%20passing-4A6B3A?style=flat-square)](./test)
+[![tests](https://img.shields.io/badge/tests-807%20passing-4A6B3A?style=flat-square)](./test)
 
 <br>
 
@@ -21,7 +21,7 @@ a Pi extension i built so my terminal AI feels personal across machines.
 
 ## what you're looking at
 
-SumoCode is a Pi extension. it owns the experience layer — splash, top chrome, footer, sidebar, modals, themes, persistent memory across sessions. [Pi](https://github.com/earendil-works/pi) keeps the agent loop, the LLM, sessions, MCP, skills.
+SumoCode is a Pi extension that ships its own terminal renderer. [Pi](https://github.com/earendil-works/pi) keeps the agent loop, the LLM, sessions, MCP, and skills. SumoCode owns every cell that paints — splash, top chrome, footer, sidebar, modals, themes, in-app scrollback, mouse routing. the renderer is called **SumoTUI** and lives in [`src/sumo-tui/`](./src/sumo-tui/); it's a node-native retained renderer with Yoga flex layout, a cell compositor, frame diff, modal layer, and a headless test backend.
 
 three themes ship. cathedral by default. amber CRT when i miss DOS. obsidian temple at night. cycle with `Ctrl+Shift+T`. choice persists across machines.
 
@@ -114,13 +114,68 @@ three sections: context (token meter, session cost), MCP (server roster and curr
 </tr>
 </table>
 
+## under the hood
+
+### SumoTUI — the retained renderer
+
+pi's built-in TUI is a vertical line-concatenation `Container`. no flex layout, no in-app scroll, no mouse routing, no modal layer. ten cathedral elements in, the workarounds — manual padding math for splash centering, footers floating wherever the linear renderer left them, mouse-wheel translating to arrow keys (so the user couldn't scroll chat), kitty keyboard escapes leaking into the shell on signal exit — had stopped scaling.
+
+[**SumoTUI**](./src/sumo-tui/) is the answer. node-native retained renderer that takes over altscreen, owns mouse routing, runs a Yoga flex layout tree, composites cells through a frame-diff, and wraps Pi's own `CustomEditor` as a leaf so autocomplete / IME / kill-ring / undo-stack / history all keep working. it pays for itself in surfaces that pi-tui structurally cannot do: in-app scrollback with sticky-bottom, modal overlays, sidebar dock at width ≥ 120, splash centering that holds at any terminal height, signal-clean cleanup. the full reasoning is in [ADR 0001](./docs/adr/0001-sumo-tui-framework.md).
+
+### the seam — 36 lines of patch
+
+SumoTUI has to insert itself before Pi's `InteractiveMode` is constructed. Pi's public extension API can't reach that high; it composes on top of the existing TUI rather than replacing it. so SumoCode carries a tiny pnpm patch against `@earendil-works/pi-coding-agent`'s `dist/main.js` ([`patches/@earendil-works__pi-coding-agent@0.74.0.patch`](./patches/), 36 lines) that adds:
+
+```js
+const useSumoTui = isTruthyEnvFlag(process.env.SUMO_TUI) || parsed.unknownFlags.has("sumo-tui");
+const interactiveMode = useSumoTui
+  ? await loadSumoInteractiveMode(runtime, interactiveOptions)
+  : new InteractiveMode(runtime, interactiveOptions);
+```
+
+`loadSumoInteractiveMode` dynamically imports `@dhruvkelawala/sumocode/sumo-interactive-mode` (or `$SUMO_TUI_MODULE` for dev). without `SUMO_TUI=1` set, the patch is a no-op and plain Pi loads. the maintenance contract is documented in [`docs/SUMO_TUI_PI_PATCH_STRATEGY.md`](./docs/SUMO_TUI_PI_PATCH_STRATEGY.md). the policy: revisit removal when Pi exposes a public `interactiveMode` injection API.
+
+### the kernel
+
+the consolidation epic ground a year of seam-bug churn into six contracts. each is small, each is enforced by tests:
+
+| Contract | What it owns | Code | Doc |
+|---|---|---|---|
+| **TerminalSessionOwner** | single owner of the altscreen lifecycle, mouse + cursor reporting, signal cleanup, and the stdin/raw-mode lifecycle. split across two files: terminal output ownership in `terminal-controller.ts`, stdin + raw-mode + signal handling in `lifecycle.ts` | [`src/sumo-tui/runtime/terminal-controller.ts`](./src/sumo-tui/runtime/terminal-controller.ts) + [`lifecycle.ts`](./src/sumo-tui/runtime/lifecycle.ts) | (in ADR + audit) |
+| **InteractionRegistry** | one place to register keybindings, shortcuts, slash commands, with collision detection. paired with a focus-aware key router that dispatches events to the focused widget | [`src/interaction-registry.ts`](./src/interaction-registry.ts) + [`src/sumo-tui/input/key-router.ts`](./src/sumo-tui/input/key-router.ts) | (in ADR) |
+| **Cancellable WorkerRuntime** | jobs that respect Ctrl+C and don't leak across session switches | [`src/sumo-tui/runtime/worker-runtime.ts`](./src/sumo-tui/runtime/worker-runtime.ts) | (in ADR) |
+| **Typed render primitives** | `Style`, `Span`, `Line` instead of hand-rolled ANSI; prevents stale-style + cell-width bugs | [`src/sumo-tui/render/primitives.ts`](./src/sumo-tui/render/primitives.ts) | [`SUMO_TUI_RENDER_PRIMITIVES.md`](./docs/SUMO_TUI_RENDER_PRIMITIVES.md) |
+| **Headless TestBackend** | retained-renderer logic tested without parsing real PTY bytes | [`src/sumo-tui/testing/test-backend.ts`](./src/sumo-tui/testing/test-backend.ts) | [`SUMO_TUI_TEST_BACKEND.md`](./docs/SUMO_TUI_TEST_BACKEND.md) |
+| **Structured TranscriptViewModel** | typed `ChatBlock` (markdown / code / tool / skill / question / delegation) instead of flattened strings | [`src/sumo-tui/transcript/view-model.ts`](./src/sumo-tui/transcript/view-model.ts) | [`SUMO_TUI_TRANSCRIPT_MODEL.md`](./docs/SUMO_TUI_TRANSCRIPT_MODEL.md) |
+
+additionally, the **scriptorium modal chrome** — the lifted-bg overlay shared by Divine Query, Approval, and Memory Scriptorium — is its own contract: [`docs/cathedral/SCRIPTORIUM_CHROME.md`](./docs/cathedral/SCRIPTORIUM_CHROME.md). the typed primitives + the chrome contract together are why the three modals look like the same thing.
+
+### the visual parity contract
+
+the themes feel coherent because three different rendering paths agree, cell for cell, with the same Bible mockups. [`docs/visual/parity/CONTRACT.md`](./docs/visual/parity/CONTRACT.md) defines three lanes:
+
+- **component** — deterministic fixture → ANSI → cell snapshot
+- **fixture** — a `TranscriptViewModel` fixture → full-scene ANSI → cell snapshot
+- **runtime** — `bin/sumocode.sh` via node-pty → cell snapshot
+
+all three converge through `@xterm/headless` into a per-cell `{ char, fg, bg, bold, dim }` grid. the verifier is **styled-cell diff** (text-level, deterministic) plus a **geometry audit** that classifies each row and bounds it against the spec. PNG diffs exist for human review packs but they aren't the gate.
+
+```bash
+pnpm visual:ci
+cat docs/visual/out/parity/<scenario>/raw/styled-cell-diff.txt
+```
+
+### portrait + sidebar policy
+
+at width ≥ 120 columns, the sidebar docks. below 120, it deliberately disappears and project / branch context moves into the hint row. portrait — the canonical 60 × 100 viewport on the mac mini in portrait orientation — has its own policy: no sidebar, ever, no matter the width. documented in [`docs/SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md`](./docs/SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md).
+
 ## reading the source
 
-this is a personal Pi extension. it runs in my fork of Pi with a small private patch (`patches/@earendil-works__pi-coding-agent@0.74.0.patch`, 36 lines) that lets SumoCode own the root TUI. the package isn't designed to drop into your machine clean — but the source is yours to read, fork, and lift from. the patch is small and well-documented.
+this is a personal Pi extension, not a clean drop-in. the patch is tiny and well-documented; the renderer is yours to read, fork, lift from. start with [`src/extension.ts`](./src/extension.ts) for the Pi-extension entry point and [`src/sumo-tui/`](./src/sumo-tui/) for the renderer.
 
-if you want to actually run it, [`DEV_LOOP.md`](./DEV_LOOP.md) walks the dev loop and [`SETUP.md`](./SETUP.md) is what i run on a new machine. you'll need the public companion config too: [`dhruvkelawala/sumocode-config`](https://github.com/dhruvkelawala/sumocode-config) is private and personal, so you'd be writing your own.
+if you want to actually run it, [`DEV_LOOP.md`](./DEV_LOOP.md) walks the dev loop and [`SETUP.md`](./SETUP.md) is what i run on a new machine. you'll also need a personal companion config: [`dhruvkelawala/sumocode-config`](https://github.com/dhruvkelawala/sumocode-config) is private, so you'd be writing your own.
 
-## how it's built
+## the bigger picture
 
 ```
 ┌──────────────────────────────────────────────────────────┐
@@ -135,12 +190,16 @@ if you want to actually run it, [`DEV_LOOP.md`](./DEV_LOOP.md) walks the dev loo
                           ▼
 ┌──────────────────────────────────────────────────────────┐
 │  SumoCode  ·  this repo                                  │
-│   · retained terminal renderer (yoga flex layout)        │
-│   · cathedral / amber CRT / obsidian themes              │
-│   · memory scriptorium                                   │
-│   · approval modal · divine query · skill pills          │
-│   · cell-precise selection + OSC 52 auto-copy            │
-│   · 5 preattentive status states + working indicator     │
+│   ┌─ src/sumo-tui/  retained renderer kernel ─────────┐  │
+│   │  yoga flex layout · cell compositor · frame diff │  │
+│   │  modal layer · mouse routing · OSC 52 selection   │  │
+│   └─ headless TestBackend · typed render primitives ──┘  │
+│   ┌─ src/themes/    cathedral / amber-CRT / obsidian ─┐  │
+│   │  palette + chrome glyphs + working indicator      │  │
+│   └─ Ctrl+Shift+T to cycle, persisted via Pi ─────────┘  │
+│   ┌─ src/cathedral/, src/memory-editor.ts, etc. ──────┐  │
+│   │  cathedral surfaces · memory scriptorium ·        │  │
+│   └─ approval modal · divine query · skill pills ─────┘  │
 └──────────────────────────────────────────────────────────┘
                           ▲
                           │ symlink into ~/.pi/agent/
@@ -151,7 +210,7 @@ if you want to actually run it, [`DEV_LOOP.md`](./DEV_LOOP.md) walks the dev loo
 └──────────────────────────────────────────────────────────┘
 ```
 
-the design history lives in [`docs/prd.md`](./docs/prd.md) (PRD), [`docs/adr/0001-sumo-tui-framework.md`](./docs/adr/0001-sumo-tui-framework.md) (the retained-renderer ADR), and [`docs/ui/CATHEDRAL_UX_SPEC_V2.md`](./docs/ui/CATHEDRAL_UX_SPEC_V2.md) (the visual canon).
+the full design trail: [PRD](./docs/prd.md) · [ADR 0001 — build SumoTUI as a retained renderer](./docs/adr/0001-sumo-tui-framework.md) · [Pi patch strategy](./docs/SUMO_TUI_PI_PATCH_STRATEGY.md) · [render primitives contract](./docs/SUMO_TUI_RENDER_PRIMITIVES.md) · [transcript view-model](./docs/SUMO_TUI_TRANSCRIPT_MODEL.md) · [test backend](./docs/SUMO_TUI_TEST_BACKEND.md) · [scriptorium chrome](./docs/cathedral/SCRIPTORIUM_CHROME.md) · [visual parity contract](./docs/visual/parity/CONTRACT.md) · [V2 UX spec](./docs/ui/CATHEDRAL_UX_SPEC_V2.md) · [Pi tool architecture](./docs/PI_TOOL_ARCHITECTURE.md) · [portrait sidebar policy](./docs/SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md).
 
 ## credits
 


### PR DESCRIPTION
## Summary

Dhruv pushed back: "the readme doesn't mention SumoTUI much and other stuff from the architecture doc that we built". v1 was 80% surface features, 20% architecture. This rewrite expands the engineering story without losing the casual-reader hook at the top.

## What changed

Only `README.md` modified. Structure now:

1. Hero (kept)
2. **What you're looking at** — now leads with "SumoCode is a Pi extension that ships its own terminal renderer" + introduces SumoTUI explicitly
3. Theme tour (kept)
4. What makes it personal (kept — 6-card user feature grid)
5. **NEW: `## under the hood`** with five h3 subsections:
   - **SumoTUI — the retained renderer** (why pi-tui hit a ceiling, what SumoTUI does instead, link to ADR 0001)
   - **the seam — 36 lines of patch** (the actual patch code shown inline; link to PI_PATCH_STRATEGY)
   - **the kernel** (markdown table of 6 contracts with code paths + doc links)
   - **the visual parity contract** (three lanes, styled-cell diff, `pnpm visual:ci`)
   - **portrait + sidebar policy** (width-120 dock + portrait override)
6. Reading the source (trimmed; points at `src/extension.ts` + `src/sumo-tui/`)
7. **`## the bigger picture`** (3-tier diagram now expanded with nested boxes for SumoCode's internal structure: `src/sumo-tui/`, `src/themes/`, `src/cathedral/`)
8. Credits + License (kept)
9. Final paragraph: full design-trail link list to PRD / ADR / patch strategy / render primitives / transcript model / test backend / scriptorium chrome / parity contract / V2 UX spec / Pi tool architecture / portrait policy

## Codex review findings fixed

- **P1**: TerminalSessionOwner kernel row pointed to `terminal-controller.ts` but raw-mode + stdin live in `lifecycle.ts`. Fixed: row now cites both files and explains the output/input split.
- **P1**: InteractionRegistry kernel row pointed to `src/sumo-tui/input/key-router.ts` (which is just a focus-aware key dispatcher). The actual collision-detecting command/shortcut registry is `src/interaction-registry.ts`. Fixed: row now cites both with the right framing (registry + router).
- **P2**: Tests badge said 821 — stale. Bumped to 807 to match current `pnpm test` output (count dropped after spike code deletion in PR #246).

## Verification

```txt
pnpm exec tsc --noEmit              → clean
pnpm test                            → 92 files / 807 passed
ls -la for every relative README link → all 25 resolve
source-claim audit                    → 6/6 cited contracts in the kernel table
                                       map to actual code
patch code shown in README             → matches
                                       patches/@earendil-works__pi-coding-agent@0.74.0.patch
```