### PR TITLE
Show real MCP roster in sidebar (drop hardcoded PLACEHOLDER_MCP at runtime)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,13 @@ last several weeks; the announce release is built on top of this commit.
   state and `pi-mcp-adapter` defaults to lazy lifecycle. Cache keyed by
   `(cwd, piAgentDir)` so session switches inside the same process get a
   fresh read. `PLACEHOLDER_MCP` is retained for the visual-fixture lane only.
+  Known gap: `pi-mcp-adapter`'s `imports: ["cursor", "claude-code", ...]`
+  field is not resolved here — each host has its own config-path layout per
+  platform and reproducing that is several hundred lines of host-aware code.
+  When `imports` is present the reader emits an `mcp_imports_unresolved`
+  diagnostic to `SUMO_TUI_DIAG_FILE`. Workaround: run `pi-mcp-adapter init`
+  which expands imports into `mcpServers` in-place; once expanded, the
+  reader picks them up.
 
 ### Changed
 - **Pi 0.70.2 → 0.74.0** (#222). Patch surface trimmed to 36 lines for the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,15 @@ last several weeks; the announce release is built on top of this commit.
 - **Visual CI flake remediation** (#186, PR #236) — empty captures retry,
   `waitForStableOutput`, `awaitChildExit`, `clampPositiveInt(maxAttempts)`,
   diagnostics fields.
+- **Real MCP server roster in sidebar** (PR #250) — `src/mcp-config-reader.ts`
+  reads `pi-mcp-adapter`'s on-disk config files in documented precedence order
+  (`~/.config/mcp/mcp.json` → `<piAgentDir>/mcp.json` → `<cwd>/.mcp.json` →
+  `<cwd>/.pi/mcp.json`) and shows the configured roster instead of the
+  hardcoded 4-server placeholder. Each server appears once with status `idle`
+  — honest given Pi 0.74's `ExtensionAPI` exposes no runtime MCP connection
+  state and `pi-mcp-adapter` defaults to lazy lifecycle. Cache keyed by
+  `(cwd, piAgentDir)` so session switches inside the same process get a
+  fresh read. `PLACEHOLDER_MCP` is retained for the visual-fixture lane only.
 
 ### Changed
 - **Pi 0.70.2 → 0.74.0** (#222). Patch surface trimmed to 36 lines for the

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -30,7 +30,7 @@ It does not replace Pi. It does not fork Pi. It loads as a regular Pi package an
 
 1. **Establish a consistent identity.** A persona layer (Zeus, in the Temple of SumoDeus) lives in `APPEND_SYSTEM.md` and is appended to every Pi session's system prompt. The agent introduces itself the same way, talks the same way, has the same memory of who I am — across every session, every day, every machine.
 
-2. **Show what's happening.** A custom footer replaces Pi's default with a concise status line: `~/repo (main) · ↑12k ↓8k · $0.42 · 42%/200k · ● <state> · <model>`. The `●` dot uses one of five preattentive colors (idle / thinking / tool-running / needs-approval / learning-write) — the kind of color-coding a production observability tool uses, brought to a coding agent. A right-sidebar overlay (auto-hidden on narrow terminals, repositionable to bottom on portrait monitors) shows live context: project name, token usage, cost, MCP server health, and top relevant memory facts.
+2. **Show what's happening.** A custom footer replaces Pi's default with a concise status line: `~/repo (main) · ↑12k ↓8k · $0.42 · 42%/200k · ● <state> · <model>`. The `●` dot uses one of five preattentive colors (idle / thinking / tool-running / needs-approval / learning-write) — the kind of color-coding a production observability tool uses, brought to a coding agent. A right-sidebar overlay (auto-hidden on narrow terminals, repositionable to bottom on portrait monitors) shows live context: project name, token usage, cost, MCP server roster, and top relevant memory facts. (MCP runtime health is a v0.4+ goal once Pi or `pi-mcp-adapter` exposes server state to extensions; v0.3 ships the configured roster only.)
 
 3. **Remember me across sessions.** A local Remnic daemon (built on QMD, which I already use for OpenClaw) auto-extracts durable facts from each session — preferences, project context, decisions made — and injects the relevant ones back into future sessions. Memory storage is plain markdown, git-syncable via the same private repo as my settings and extensions.
 
@@ -59,7 +59,7 @@ The end state: I open a terminal on either machine, run `pi`, and SumoCode greet
 
 2. As a developer, I want to glance at the footer and know whether the agent is idle / thinking / running a tool / waiting for my approval / writing to memory, in under 250ms, so that I can keep working without breaking flow.
 
-3. As a developer, I want the sidebar to show the current project, token usage, cost, connected MCP servers (with their health), and my top 5 most-relevant memory facts, so that I have permanent situational awareness without typing a query.
+3. As a developer, I want the sidebar to show the current project, token usage, cost, the MCP servers configured for this project (live health when the toolchain exposes it, otherwise the configured roster), and my top 5 most-relevant memory facts, so that I have permanent situational awareness without typing a query.
 
 4. As a developer working at 80-character terminal width, I want the sidebar to auto-hide so it doesn't crowd my chat area, but I want it to come back as soon as I widen my window past 120 cols.
 

--- a/src/mcp-config-reader.test.ts
+++ b/src/mcp-config-reader.test.ts
@@ -1,0 +1,181 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+	clearCachedMcpRoster,
+	getCachedMcpRoster,
+	loadConfiguredMcpServers,
+	resolveMcpConfigCandidates,
+} from "./mcp-config-reader.js";
+
+let tmpRoot: string;
+
+beforeEach(() => {
+	tmpRoot = mkdtempSync(join(tmpdir(), "sumocode-mcp-test-"));
+	clearCachedMcpRoster();
+});
+
+afterEach(() => {
+	rmSync(tmpRoot, { recursive: true, force: true });
+	clearCachedMcpRoster();
+});
+
+function writeJson(path: string, value: unknown): void {
+	mkdirSync(join(path, ".."), { recursive: true });
+	writeFileSync(path, JSON.stringify(value), "utf8");
+}
+
+describe("resolveMcpConfigCandidates", () => {
+	it("returns the four candidate paths in pi-mcp-adapter precedence order", () => {
+		const cwd = "/tmp/some-project";
+		const piAgentDir = "/tmp/.pi/agent";
+		const candidates = resolveMcpConfigCandidates({ cwd, piAgentDir });
+		expect(candidates).toHaveLength(4);
+		// User-global shared MCP config wins lowest precedence.
+		expect(candidates[0]).toMatch(/\.config\/mcp\/mcp\.json$/);
+		// Pi global override second.
+		expect(candidates[1]).toBe("/tmp/.pi/agent/mcp.json");
+		// Project-local shared third.
+		expect(candidates[2]).toBe("/tmp/some-project/.mcp.json");
+		// Pi project override last (highest precedence).
+		expect(candidates[3]).toBe("/tmp/some-project/.pi/mcp.json");
+	});
+});
+
+describe("loadConfiguredMcpServers", () => {
+	it("returns an empty array when no config files exist", () => {
+		const cwd = join(tmpRoot, "project");
+		const piAgentDir = join(tmpRoot, ".pi", "agent");
+		mkdirSync(cwd, { recursive: true });
+		mkdirSync(piAgentDir, { recursive: true });
+		expect(loadConfiguredMcpServers({ cwd, piAgentDir })).toEqual([]);
+	});
+
+	it("reads a single Pi global config", () => {
+		const cwd = join(tmpRoot, "project");
+		const piAgentDir = join(tmpRoot, ".pi", "agent");
+		mkdirSync(cwd, { recursive: true });
+		writeJson(join(piAgentDir, "mcp.json"), {
+			mcpServers: {
+				github: { command: "npx" },
+				stitch: { url: "https://stitch.googleapis.com/mcp" },
+			},
+		});
+		const servers = loadConfiguredMcpServers({ cwd, piAgentDir });
+		expect(servers.map((s) => s.name)).toEqual(["github", "stitch"]);
+		// Status reflects pi-mcp-adapter's lazy default.
+		expect(servers.every((s) => s.status === "idle")).toBe(true);
+	});
+
+	it("project .mcp.json overrides Pi global by name; both names appear when distinct", () => {
+		const cwd = join(tmpRoot, "project");
+		const piAgentDir = join(tmpRoot, ".pi", "agent");
+		mkdirSync(cwd, { recursive: true });
+		writeJson(join(piAgentDir, "mcp.json"), {
+			mcpServers: {
+				github: { command: "npx" },
+				railway: { command: "railway" },
+			},
+		});
+		writeJson(join(cwd, ".mcp.json"), {
+			mcpServers: {
+				github: { command: "npx -y newer-github" },
+				stitch: { url: "https://stitch.googleapis.com/mcp" },
+			},
+		});
+		const servers = loadConfiguredMcpServers({ cwd, piAgentDir });
+		const names = servers.map((s) => s.name);
+		// All three distinct names appear; project does not delete user-global entries it does not name.
+		expect(names).toEqual(expect.arrayContaining(["github", "railway", "stitch"]));
+		expect(names).toHaveLength(3);
+	});
+
+	it("Pi project override .pi/mcp.json wins over project .mcp.json for same name", () => {
+		const cwd = join(tmpRoot, "project");
+		const piAgentDir = join(tmpRoot, ".pi", "agent");
+		mkdirSync(cwd, { recursive: true });
+		writeJson(join(cwd, ".mcp.json"), { mcpServers: { github: {} } });
+		writeJson(join(cwd, ".pi", "mcp.json"), { mcpServers: { github: {}, custom: {} } });
+		const servers = loadConfiguredMcpServers({ cwd, piAgentDir });
+		expect(servers.map((s) => s.name).sort()).toEqual(["custom", "github"]);
+	});
+
+	it("malformed JSON in any source does not crash; that source is silently skipped", () => {
+		const cwd = join(tmpRoot, "project");
+		const piAgentDir = join(tmpRoot, ".pi", "agent");
+		mkdirSync(cwd, { recursive: true });
+		writeJson(join(piAgentDir, "mcp.json"), { mcpServers: { github: {} } });
+		// Write a junk JSON file as the project-local source.
+		mkdirSync(cwd, { recursive: true });
+		writeFileSync(join(cwd, ".mcp.json"), "{ this is not json", "utf8");
+		const servers = loadConfiguredMcpServers({ cwd, piAgentDir });
+		expect(servers.map((s) => s.name)).toEqual(["github"]);
+	});
+
+	it("missing mcpServers key returns no entries from that file", () => {
+		const cwd = join(tmpRoot, "project");
+		const piAgentDir = join(tmpRoot, ".pi", "agent");
+		mkdirSync(cwd, { recursive: true });
+		writeJson(join(piAgentDir, "mcp.json"), { settings: { toolPrefix: "server" } });
+		expect(loadConfiguredMcpServers({ cwd, piAgentDir })).toEqual([]);
+	});
+});
+
+describe("getCachedMcpRoster", () => {
+	it("memoizes the first read and ignores subsequent disk changes within a process", () => {
+		const cwd = join(tmpRoot, "project");
+		const piAgentDir = join(tmpRoot, ".pi", "agent");
+		mkdirSync(cwd, { recursive: true });
+		writeJson(join(piAgentDir, "mcp.json"), { mcpServers: { github: {} } });
+
+		const first = getCachedMcpRoster({ cwd, piAgentDir });
+		expect(first.map((s) => s.name)).toEqual(["github"]);
+
+		// Mutate the file. The cached read should NOT pick this up \u2014 cache flushes only on
+		// process restart (e.g. /sumo:reload).
+		writeJson(join(piAgentDir, "mcp.json"), { mcpServers: { github: {}, stitch: {} } });
+		const second = getCachedMcpRoster({ cwd, piAgentDir });
+		expect(second).toBe(first);
+	});
+
+	it("clearCachedMcpRoster forces a fresh read", () => {
+		const cwd = join(tmpRoot, "project");
+		const piAgentDir = join(tmpRoot, ".pi", "agent");
+		mkdirSync(cwd, { recursive: true });
+		writeJson(join(piAgentDir, "mcp.json"), { mcpServers: { github: {} } });
+
+		const before = getCachedMcpRoster({ cwd, piAgentDir });
+		expect(before.map((s) => s.name)).toEqual(["github"]);
+
+		writeJson(join(piAgentDir, "mcp.json"), { mcpServers: { github: {}, railway: {} } });
+		clearCachedMcpRoster();
+		const after = getCachedMcpRoster({ cwd, piAgentDir });
+		expect(after.map((s) => s.name).sort()).toEqual(["github", "railway"]);
+	});
+
+	it("keys the cache by (cwd, piAgentDir) so session switches don't leak rosters", () => {
+		// Project A and project B coexist in the same process. Pi's session_before_switch
+		// event can change ctx.cwd within a single Pi run, so a global single-slot cache
+		// would leak A's roster into B and break the precedence contract.
+		const cwdA = join(tmpRoot, "project-a");
+		const cwdB = join(tmpRoot, "project-b");
+		const piAgentDir = join(tmpRoot, ".pi", "agent");
+		mkdirSync(cwdA, { recursive: true });
+		mkdirSync(cwdB, { recursive: true });
+		writeJson(join(cwdA, ".mcp.json"), { mcpServers: { github: {}, railway: {} } });
+		writeJson(join(cwdB, ".mcp.json"), { mcpServers: { stitch: {}, context7: {} } });
+
+		const rosterA = getCachedMcpRoster({ cwd: cwdA, piAgentDir });
+		const rosterB = getCachedMcpRoster({ cwd: cwdB, piAgentDir });
+
+		expect(rosterA.map((s) => s.name).sort()).toEqual(["github", "railway"]);
+		expect(rosterB.map((s) => s.name).sort()).toEqual(["context7", "stitch"]);
+
+		// And the second access for each cwd is still memoized (returns the same array reference).
+		expect(getCachedMcpRoster({ cwd: cwdA, piAgentDir })).toBe(rosterA);
+		expect(getCachedMcpRoster({ cwd: cwdB, piAgentDir })).toBe(rosterB);
+	});
+});

--- a/src/mcp-config-reader.test.ts
+++ b/src/mcp-config-reader.test.ts
@@ -9,6 +9,8 @@ import {
 	getCachedMcpRoster,
 	loadConfiguredMcpServers,
 	resolveMcpConfigCandidates,
+	setMcpDiagnosticHandler,
+	type McpDiagnosticHandler,
 } from "./mcp-config-reader.js";
 
 let tmpRoot: string;
@@ -21,6 +23,7 @@ beforeEach(() => {
 afterEach(() => {
 	rmSync(tmpRoot, { recursive: true, force: true });
 	clearCachedMcpRoster();
+	setMcpDiagnosticHandler(undefined);
 });
 
 function writeJson(path: string, value: unknown): void {
@@ -121,6 +124,50 @@ describe("loadConfiguredMcpServers", () => {
 		mkdirSync(cwd, { recursive: true });
 		writeJson(join(piAgentDir, "mcp.json"), { settings: { toolPrefix: "server" } });
 		expect(loadConfiguredMcpServers({ cwd, piAgentDir })).toEqual([]);
+	});
+
+	it("emits an mcp_imports_unresolved diagnostic when imports are present but stays non-fatal", () => {
+		// pi-mcp-adapter's `imports` field pulls server configs from host-specific files
+		// (cursor, claude-code, vscode, etc.). This reader doesn't resolve those, so when
+		// imports are present we emit a diagnostic so the gap is traceable in
+		// SUMO_TUI_DIAG_FILE traces. Workaround for users: run `pi-mcp-adapter init` to
+		// expand imports into mcpServers in-place.
+		const cwd = join(tmpRoot, "project");
+		const piAgentDir = join(tmpRoot, ".pi", "agent");
+		mkdirSync(cwd, { recursive: true });
+		writeJson(join(piAgentDir, "mcp.json"), {
+			imports: ["cursor", "claude-code"],
+			mcpServers: { github: {} },
+		});
+
+		const events: Parameters<McpDiagnosticHandler>[0][] = [];
+		setMcpDiagnosticHandler((event) => {
+			events.push(event);
+		});
+
+		const roster = loadConfiguredMcpServers({ cwd, piAgentDir });
+		// Explicit servers still load.
+		expect(roster.map((s) => s.name)).toEqual(["github"]);
+		expect(events).toHaveLength(1);
+		expect(events[0]).toMatchObject({
+			type: "mcp_imports_unresolved",
+			importsCount: 2,
+		});
+		expect(events[0]?.path).toContain("mcp.json");
+	});
+
+	it("empty imports array does NOT emit a diagnostic", () => {
+		const cwd = join(tmpRoot, "project");
+		const piAgentDir = join(tmpRoot, ".pi", "agent");
+		mkdirSync(cwd, { recursive: true });
+		writeJson(join(piAgentDir, "mcp.json"), { imports: [], mcpServers: { github: {} } });
+
+		const events: Parameters<McpDiagnosticHandler>[0][] = [];
+		setMcpDiagnosticHandler((event) => events.push(event));
+
+		const roster = loadConfiguredMcpServers({ cwd, piAgentDir });
+		expect(roster.map((s) => s.name)).toEqual(["github"]);
+		expect(events).toHaveLength(0);
 	});
 
 	it("non-object mcpServers (string, array) is skipped instead of producing bogus synthetic keys", () => {

--- a/src/mcp-config-reader.test.ts
+++ b/src/mcp-config-reader.test.ts
@@ -122,6 +122,27 @@ describe("loadConfiguredMcpServers", () => {
 		writeJson(join(piAgentDir, "mcp.json"), { settings: { toolPrefix: "server" } });
 		expect(loadConfiguredMcpServers({ cwd, piAgentDir })).toEqual([]);
 	});
+
+	it("non-object mcpServers (string, array) is skipped instead of producing bogus synthetic keys", () => {
+		// `Object.keys("oops")` returns `["0","1","2","3"]` and `Object.keys(["github"])` returns
+		// `["0"]`. Without the type guard we'd register servers named "0", "1", "2", "3" —
+		// codex caught this on PR #250 as a real edge case for hand-edited config files.
+		const cwd = join(tmpRoot, "project");
+		const piAgentDir = join(tmpRoot, ".pi", "agent");
+		mkdirSync(cwd, { recursive: true });
+
+		writeJson(join(piAgentDir, "mcp.json"), { mcpServers: "oops" });
+		expect(loadConfiguredMcpServers({ cwd, piAgentDir })).toEqual([]);
+
+		writeJson(join(piAgentDir, "mcp.json"), { mcpServers: ["github", "railway"] });
+		expect(loadConfiguredMcpServers({ cwd, piAgentDir })).toEqual([]);
+
+		writeJson(join(piAgentDir, "mcp.json"), { mcpServers: 42 });
+		expect(loadConfiguredMcpServers({ cwd, piAgentDir })).toEqual([]);
+
+		writeJson(join(piAgentDir, "mcp.json"), { mcpServers: null });
+		expect(loadConfiguredMcpServers({ cwd, piAgentDir })).toEqual([]);
+	});
 });
 
 describe("getCachedMcpRoster", () => {

--- a/src/mcp-config-reader.test.ts
+++ b/src/mcp-config-reader.test.ts
@@ -14,16 +14,31 @@ import {
 } from "./mcp-config-reader.js";
 
 let tmpRoot: string;
+let originalHome: string | undefined;
+let originalUserProfile: string | undefined;
 
 beforeEach(() => {
 	tmpRoot = mkdtempSync(join(tmpdir(), "sumocode-mcp-test-"));
 	clearCachedMcpRoster();
+	// Sandbox `homedir()` so the test never reads a real `~/.config/mcp/mcp.json`
+	// that the developer or CI runner happens to have. `homedir()` consults
+	// `HOME` on POSIX and `USERPROFILE` on Windows; override both.
+	originalHome = process.env.HOME;
+	originalUserProfile = process.env.USERPROFILE;
+	process.env.HOME = tmpRoot;
+	process.env.USERPROFILE = tmpRoot;
 });
 
 afterEach(() => {
 	rmSync(tmpRoot, { recursive: true, force: true });
 	clearCachedMcpRoster();
 	setMcpDiagnosticHandler(undefined);
+	// Restore the real `homedir()` resolution for any unrelated tests in the
+	// same vitest worker.
+	if (originalHome === undefined) delete process.env.HOME;
+	else process.env.HOME = originalHome;
+	if (originalUserProfile === undefined) delete process.env.USERPROFILE;
+	else process.env.USERPROFILE = originalUserProfile;
 });
 
 function writeJson(path: string, value: unknown): void {
@@ -37,8 +52,9 @@ describe("resolveMcpConfigCandidates", () => {
 		const piAgentDir = "/tmp/.pi/agent";
 		const candidates = resolveMcpConfigCandidates({ cwd, piAgentDir });
 		expect(candidates).toHaveLength(4);
-		// User-global shared MCP config wins lowest precedence.
-		expect(candidates[0]).toMatch(/\.config\/mcp\/mcp\.json$/);
+		// User-global shared MCP config wins lowest precedence. `homedir()` is
+		// sandboxed to `tmpRoot` in beforeEach, so this candidate lives there.
+		expect(candidates[0]).toBe(join(tmpRoot, ".config", "mcp", "mcp.json"));
 		// Pi global override second.
 		expect(candidates[1]).toBe("/tmp/.pi/agent/mcp.json");
 		// Project-local shared third.

--- a/src/mcp-config-reader.ts
+++ b/src/mcp-config-reader.ts
@@ -16,18 +16,32 @@ import type { McpServerSnapshot } from "./sumo-tui/cathedral/sidebar-rendering.j
  * Files are read in that order; later sources merge over earlier ones by
  * server name. The result is a roster of configured servers, each with a
  * status of `"idle"`. Pi 0.74's `ExtensionAPI` does not expose runtime MCP
- * connection state \u2014 see `docs/research/pi-fork-upgrade.md` and the comment
+ * connection state — see `docs/research/pi-fork-upgrade.md` and the comment
  * in `src/sidebar.ts` for the longer reasoning. `"idle"` is honest: it
  * reflects the configured-but-unconnected default for `pi-mcp-adapter`'s
  * lazy lifecycle.
  *
  * The reader tolerates missing files, malformed JSON, and missing
- * `mcpServers` keys silently \u2014 a broken or absent config should never
+ * `mcpServers` keys silently — a broken or absent config should never
  * crash sidebar rendering.
+ *
+ * Known limitation: pi-mcp-adapter's `imports` field (which pulls server
+ * configs from host-specific files like `cursor`, `claude-code`,
+ * `claude-desktop`, `vscode`, `windsurf`, `codex`) is NOT resolved here.
+ * Each host has its own config path layout per platform; replicating that
+ * resolution is several hundred lines of host-aware code that v0.3 doesn't
+ * carry. Users with `imports` in their config will see only the explicitly
+ * listed `mcpServers`. The workaround is to run `pi-mcp-adapter init`,
+ * which expands imports into `mcpServers` in `<piAgentDir>/mcp.json`
+ * directly — once expanded, this reader picks them up. When `imports` is
+ * present, `loadConfiguredMcpServers` emits a diagnostic event
+ * (`mcp_imports_unresolved`) so the gap is visible in `SUMO_TUI_DIAG_FILE`
+ * traces.
  */
 
 interface McpConfigFile {
 	readonly mcpServers?: Record<string, unknown>;
+	readonly imports?: unknown;
 }
 
 export interface LoadMcpServersOptions {
@@ -73,14 +87,47 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function hasNonEmptyImports(cfg: McpConfigFile): boolean {
+	return Array.isArray(cfg.imports) && cfg.imports.length > 0;
+}
+
+/**
+ * Hook for emitting a diagnostic when `imports` are present but unresolved.
+ * Imported by tests via `setMcpDiagnosticHandler`; production wiring goes
+ * through `src/sumo-tui/runtime/diagnostics.ts` via `setMcpDiagnosticHandler`
+ * called once at extension boot. Keeping the dependency injected here
+ * avoids a hard import cycle between this module and the runtime layer.
+ */
+export type McpDiagnosticHandler = (event: {
+	readonly type: "mcp_imports_unresolved";
+	readonly path: string;
+	readonly importsCount: number;
+}) => void;
+
+let mcpDiagnosticHandler: McpDiagnosticHandler | undefined;
+
+export function setMcpDiagnosticHandler(handler: McpDiagnosticHandler | undefined): void {
+	mcpDiagnosticHandler = handler;
+}
+
 export function loadConfiguredMcpServers(opts: LoadMcpServersOptions): readonly McpServerSnapshot[] {
 	const merged = new Map<string, McpServerSnapshot>();
 	for (const path of resolveMcpConfigCandidates(opts)) {
 		const cfg = readMcpConfig(path);
+		if (!cfg) continue;
+		if (hasNonEmptyImports(cfg)) {
+			// pi-mcp-adapter would expand these at runtime; this reader doesn't.
+			// Emit a diagnostic so the gap is traceable.
+			mcpDiagnosticHandler?.({
+				type: "mcp_imports_unresolved",
+				path,
+				importsCount: (cfg.imports as readonly unknown[]).length,
+			});
+		}
 		// Guard against `mcpServers` being any non-object shape (string, array, number).
 		// `Object.keys("oops")` produces synthetic numeric keys; `Object.keys(["github"])`
 		// produces `["0"]`. Either would corrupt the roster with bogus server names.
-		if (!cfg || !isPlainObject(cfg.mcpServers)) continue;
+		if (!isPlainObject(cfg.mcpServers)) continue;
 		for (const name of Object.keys(cfg.mcpServers)) {
 			merged.set(name, { name, status: "idle" });
 		}

--- a/src/mcp-config-reader.ts
+++ b/src/mcp-config-reader.ts
@@ -1,0 +1,119 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+import type { McpServerSnapshot } from "./sumo-tui/cathedral/sidebar-rendering.js";
+
+/**
+ * Reads the configured MCP server roster from disk, following the precedence
+ * order documented by `pi-mcp-adapter`:
+ *
+ *   1. `~/.config/mcp/mcp.json`        — user-global shared MCP config
+ *   2. `<Pi agent dir>/mcp.json`       — Pi global override (default `~/.pi/agent/mcp.json`)
+ *   3. `<cwd>/.mcp.json`               — project-local shared MCP config
+ *   4. `<cwd>/.pi/mcp.json`            — Pi project override
+ *
+ * Files are read in that order; later sources merge over earlier ones by
+ * server name. The result is a roster of configured servers, each with a
+ * status of `"idle"`. Pi 0.74's `ExtensionAPI` does not expose runtime MCP
+ * connection state \u2014 see `docs/research/pi-fork-upgrade.md` and the comment
+ * in `src/sidebar.ts` for the longer reasoning. `"idle"` is honest: it
+ * reflects the configured-but-unconnected default for `pi-mcp-adapter`'s
+ * lazy lifecycle.
+ *
+ * The reader tolerates missing files, malformed JSON, and missing
+ * `mcpServers` keys silently \u2014 a broken or absent config should never
+ * crash sidebar rendering.
+ */
+
+interface McpConfigFile {
+	readonly mcpServers?: Record<string, unknown>;
+}
+
+export interface LoadMcpServersOptions {
+	readonly cwd: string;
+	readonly piAgentDir: string;
+}
+
+/**
+ * Resolve the four candidate config paths in precedence order.
+ *
+ * Exposed for tests; production callers should use `loadConfiguredMcpServers`.
+ */
+export function resolveMcpConfigCandidates(opts: LoadMcpServersOptions): readonly string[] {
+	const home = homedir();
+	return [
+		join(home, ".config", "mcp", "mcp.json"),
+		join(opts.piAgentDir, "mcp.json"),
+		join(opts.cwd, ".mcp.json"),
+		join(opts.cwd, ".pi", "mcp.json"),
+	];
+}
+
+function readMcpConfig(path: string): McpConfigFile | undefined {
+	try {
+		if (!existsSync(path)) return undefined;
+		const raw = readFileSync(path, "utf8");
+		const parsed: unknown = JSON.parse(raw);
+		if (!parsed || typeof parsed !== "object") return undefined;
+		return parsed as McpConfigFile;
+	} catch {
+		// Malformed JSON, permission denied, etc. \u2014 fail closed: no servers from this file.
+		return undefined;
+	}
+}
+
+/**
+ * Load the merged MCP server roster from the precedence chain. Returns an
+ * empty array when no config files exist. Each server appears at most once;
+ * a higher-precedence file (project) overrides a lower-precedence one (user
+ * global) for a given server name.
+ */
+export function loadConfiguredMcpServers(opts: LoadMcpServersOptions): readonly McpServerSnapshot[] {
+	const merged = new Map<string, McpServerSnapshot>();
+	for (const path of resolveMcpConfigCandidates(opts)) {
+		const cfg = readMcpConfig(path);
+		if (!cfg?.mcpServers) continue;
+		for (const name of Object.keys(cfg.mcpServers)) {
+			merged.set(name, { name, status: "idle" });
+		}
+	}
+	return [...merged.values()];
+}
+
+/**
+ * Cache keyed by (cwd, piAgentDir). Different sessions can run against
+ * different working directories — Pi's `session_before_switch` /
+ * `session_start` events fire when switching, and `ctx.cwd` is
+ * session-scoped. A single-slot cache would leak project A's roster into
+ * project B after a session switch and break the precedence contract.
+ */
+const cachedRosters = new Map<string, readonly McpServerSnapshot[]>();
+
+function cacheKey(opts: LoadMcpServersOptions): string {
+	return `${opts.cwd}\u0000${opts.piAgentDir}`;
+}
+
+/**
+ * Cached variant of `loadConfiguredMcpServers`. Reads once per
+ * (cwd, piAgentDir) pair and memoizes. Sidebar snapshots are built on
+ * every paint, so re-reading four JSON files per tick would be wasteful.
+ * `/sumo:reload` respawns the process, so the cache flushes on its own
+ * when Dhruv hot-reloads. Session switches inside the same process get a
+ * fresh read because the cache key changes with `ctx.cwd`.
+ *
+ * Tests can call `clearCachedMcpRoster()` between cases.
+ */
+export function getCachedMcpRoster(opts: LoadMcpServersOptions): readonly McpServerSnapshot[] {
+	const key = cacheKey(opts);
+	let roster = cachedRosters.get(key);
+	if (roster === undefined) {
+		roster = loadConfiguredMcpServers(opts);
+		cachedRosters.set(key, roster);
+	}
+	return roster;
+}
+
+export function clearCachedMcpRoster(): void {
+	cachedRosters.clear();
+}

--- a/src/mcp-config-reader.ts
+++ b/src/mcp-config-reader.ts
@@ -69,11 +69,18 @@ function readMcpConfig(path: string): McpConfigFile | undefined {
  * a higher-precedence file (project) overrides a lower-precedence one (user
  * global) for a given server name.
  */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export function loadConfiguredMcpServers(opts: LoadMcpServersOptions): readonly McpServerSnapshot[] {
 	const merged = new Map<string, McpServerSnapshot>();
 	for (const path of resolveMcpConfigCandidates(opts)) {
 		const cfg = readMcpConfig(path);
-		if (!cfg?.mcpServers) continue;
+		// Guard against `mcpServers` being any non-object shape (string, array, number).
+		// `Object.keys("oops")` produces synthetic numeric keys; `Object.keys(["github"])`
+		// produces `["0"]`. Either would corrupt the roster with bogus server names.
+		if (!cfg || !isPlainObject(cfg.mcpServers)) continue;
 		for (const name of Object.keys(cfg.mcpServers)) {
 			merged.set(name, { name, status: "idle" });
 		}

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -2,7 +2,7 @@ import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { Component } from "@earendil-works/pi-tui";
-import { getCachedMcpRoster } from "./mcp-config-reader.js";
+import { getCachedMcpRoster, setMcpDiagnosticHandler } from "./mcp-config-reader.js";
 import {
 	getGitBranch as getCachedGitBranch,
 	getSessionUsage as getCachedSessionUsage,
@@ -54,6 +54,13 @@ export const PLACEHOLDER_MCP: readonly McpServerSnapshot[] = [
 function resolvePiAgentDir(): string {
 	return process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
 }
+
+// Wire pi-mcp-adapter `imports` diagnostics through the existing diagnostics
+// pipeline. Module-level so the handler is set exactly once when sidebar.ts
+// loads, before any sidebar snapshot triggers a config read.
+setMcpDiagnosticHandler((event) => {
+	logDiagnostic(event.type, { path: event.path, importsCount: event.importsCount });
+});
 
 export { SIDEBAR_SUB_TABS };
 export type { McpServerSnapshot, SidebarSessionSnapshot, SidebarSubTab };

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,6 +1,8 @@
-import { basename } from "node:path";
+import { homedir } from "node:os";
+import { basename, join } from "node:path";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { Component } from "@earendil-works/pi-tui";
+import { getCachedMcpRoster } from "./mcp-config-reader.js";
 import {
 	getGitBranch as getCachedGitBranch,
 	getSessionUsage as getCachedSessionUsage,
@@ -34,13 +36,24 @@ export {
 export const SIDEBAR_MEMORY_DEBOUNCE_MS = 200;
 /** Retry cadence while Remnic is unavailable. */
 export const SIDEBAR_MEMORY_RETRY_MS = 5_000;
-/** Static placeholder until Pi exposes MCP server health. */
+/**
+ * Deterministic MCP roster used by the visual-v2 fixture lane. The
+ * fixture lane needs a stable, reproducible roster so cell-diff golden
+ * comparisons stay deterministic; this constant is intentionally NOT
+ * what the runtime sidebar shows. Runtime callers go through
+ * `mcp-config-reader.ts` instead, which reads `pi-mcp-adapter`'s real
+ * config files.
+ */
 export const PLACEHOLDER_MCP: readonly McpServerSnapshot[] = [
 	{ name: "github", status: "idle" },
 	{ name: "stitch", status: "ok" },
 	{ name: "context7", status: "idle" },
 	{ name: "chrome-dev", status: "idle" },
 ];
+
+function resolvePiAgentDir(): string {
+	return process.env.PI_CODING_AGENT_DIR ?? join(homedir(), ".pi", "agent");
+}
 
 export { SIDEBAR_SUB_TABS };
 export type { McpServerSnapshot, SidebarSessionSnapshot, SidebarSubTab };
@@ -183,7 +196,7 @@ function snapshotFromContext(
 		contextWindow,
 		cumulativeTokens: input + output,
 		costUsd: cost,
-		mcpServers: PLACEHOLDER_MCP,
+		mcpServers: getCachedMcpRoster({ cwd: ctx.cwd, piAgentDir: resolvePiAgentDir() }),
 		memory: memorySnapshot.memory,
 		memoryTotal: memorySnapshot.memory.length,
 		memoryUnavailable: memorySnapshot.memoryUnavailable,


### PR DESCRIPTION
## Summary

Fixes a codex review finding from PR #245: the sidebar's MCP section was claiming to show "server roster and current state" but was actually rendering a hardcoded 4-server list (`github / stitch / context7 / chrome-dev`) with fictional `idle/ok` labels. Dhruv's real `~/.pi/agent/mcp.json` has 6 servers (`railway / github / chrome-devtools / rn / stitch / context7`); the placeholder was missing two of them and using the wrong name for `chrome-devtools`.

This PR is **Phase 1** of the three-phase plan we agreed on:

| Phase | What | Status |
|---|---|---|
| **1** | Real configured roster from `pi-mcp-adapter` config files | ✅ this PR |
| 2 | Live activity tracking via `tool_call` events for `mcp({...})` | deferred (post-announce) |
| 3 | Upstream `pi-mcp-adapter` PR for true connection state | deferred (long-tail) |

## What's actually fixable today

Pi 0.74's `ExtensionAPI` exposes nothing about MCP — no `mcpServers` field, no `mcp_*` events, no enumeration helper. `pi-mcp-adapter` keeps connection state in its runtime memory and surfaces it via `/mcp` but no external event. So Phase 1 reads the on-disk config files instead. That's the configured roster, not real-time state, but it's honest and accurate.

## How

New `src/mcp-config-reader.ts` reads MCP config files in pi-mcp-adapter's documented precedence order:

1. `~/.config/mcp/mcp.json` — user-global shared
2. `<piAgentDir>/mcp.json` — Pi global override (default `~/.pi/agent/mcp.json`)
3. `<cwd>/.mcp.json` — project-local shared
4. `<cwd>/.pi/mcp.json` — Pi project override

Later sources merge over earlier ones by server name. Each result is a `McpServerSnapshot` with `status: "idle"` (matches pi-mcp-adapter's lazy lifecycle default and is honest about Pi 0.74's lack of runtime state surface).

The reader tolerates missing files, malformed JSON, and missing `mcpServers` keys silently — a broken config should never crash the sidebar.

Roster is cached per `(cwd, piAgentDir)` to avoid re-reading four JSON files on every paint tick. Cache flushes naturally when `/sumo:reload` respawns the process.

## Files

- **New** `src/mcp-config-reader.ts` (119 lines) — `loadConfiguredMcpServers`, `getCachedMcpRoster`, `clearCachedMcpRoster`, `resolveMcpConfigCandidates`
- **New** `src/mcp-config-reader.test.ts` (181 lines, 10 tests) — precedence order, empty roster, single source, multi-source merge, project-override-wins, malformed-JSON resilience, missing-mcpServers-key, cache memoization, clearCachedMcpRoster, **per-(cwd, piAgentDir) keying for session switches**
- **Modified** `src/sidebar.ts` (+19 / -3) — `PLACEHOLDER_MCP` kept exported but its docstring now declares it fixture-only (consumed by `scripts/visual-v2/fixture-capture.mjs`); runtime path goes through `getCachedMcpRoster`

## Codex review

First pass caught a real **P1**: the cache was a single global value but the loaded roster depends on `cwd` + `piAgentDir`. Pi's `session_before_switch` event can change `ctx.cwd` within a process, so a global cache leaks roster A into project B. Fixed by keying the cache as `Map<"${cwd}\u0000${piAgentDir}", roster>`. NUL byte separator avoids any path-collision concern. Added a regression test.

Second pass: GREEN.

## Verification

```txt
pnpm exec tsc --noEmit                  → clean
pnpm test                                → 93 files / 816 passed (was 807; +9 net)
pnpm test:integration                    → 19 files / 32 passed
pnpm visual:ci                            → no new regressions; fixture lane unaffected
scripts/visual-v2/fixture-capture.mjs    → still imports PLACEHOLDER_MCP from sidebar.ts
```