### PR TITLE
Add /sumo:diff — opens hunkdiff in a new cmux split pane

### DIFF
--- a/src/commands/cmux-split.ts
+++ b/src/commands/cmux-split.ts
@@ -1,0 +1,222 @@
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+
+/**
+ * cmux split helpers — ported from `pi-cmux@0.1.8` (MIT, Javier Molina,
+ * https://github.com/javiermolinar/pi-cmux) with light adaptation for the
+ * `@earendil-works` namespace and SumoCode's typed-result style. pi-cmux is
+ * already installed alongside SumoCode for many users, but its exports are
+ * Pi-loaded extensions rather than a library, so the helpers can't be
+ * imported directly. Keeping the small parity copy here means `/sumo:diff`
+ * and any future cmux-aware command works whether or not pi-cmux is installed.
+ *
+ * Pattern documented in `pi-cmux/extensions/cmux-core.ts`:
+ *   1. `cmux --json identify` → confirm we're in a cmux surface; extract workspace + surface refs.
+ *   2. snapshot `cmux --json list-panes` for the workspace before the split.
+ *   3. `cmux new-split <direction>` against the current surface.
+ *   4. poll `list-panes` until a new pane appears — capture its surface ref.
+ *   5. `cmux respawn-pane --command <cmd>` runs the command in the new pane.
+ */
+
+const CMUX_TIMEOUT_MS = 5_000;
+const SPLIT_READY_ATTEMPTS = 20;
+const SPLIT_READY_DELAY_MS = 150;
+const SURFACE_BOOT_DELAY_MS = 250;
+
+export type SplitDirection = "left" | "right" | "up" | "down";
+
+interface CmuxCallerInfo {
+	workspace_ref?: string;
+	surface_ref?: string;
+}
+
+interface CmuxIdentifyResponse {
+	caller?: CmuxCallerInfo;
+}
+
+interface CmuxPaneInfo {
+	ref?: string;
+	selected_surface_ref?: string;
+	surface_refs?: string[];
+}
+
+interface CmuxListPanesResponse {
+	panes?: CmuxPaneInfo[];
+}
+
+interface CmuxExecResult {
+	readonly ok: boolean;
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly error?: string;
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function parseJson<T>(text: string): T | undefined {
+	try {
+		return JSON.parse(text) as T;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * POSIX single-quote escape. Wraps `value` in single quotes and escapes any
+ * literal single quote inside. Safe for paths with spaces, parentheses, and
+ * shell metacharacters — including SumoCode's own `/Volumes/SumoDeus NVMe`
+ * dev path.
+ */
+export function shellEscape(value: string): string {
+	return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+/**
+ * Build a `cd <cwd> && exec sh -lc <command>` string for `cmux respawn-pane`'s
+ * `--command` argument. Two layers of escaping: cwd is escaped once for the
+ * outer shell, command is escaped once more so the inner `sh -lc` sees it as
+ * a single string argument.
+ */
+export function buildShellCommand(cwd: string, command: string): string {
+	return ["cd", shellEscape(cwd), "&&", "exec", "sh", "-lc", shellEscape(command)].join(" ");
+}
+
+function collectSurfaceRefs(panes: readonly CmuxPaneInfo[]): Set<string> {
+	const refs = new Set<string>();
+	for (const pane of panes) {
+		if (pane.selected_surface_ref) refs.add(pane.selected_surface_ref);
+		for (const surfaceRef of pane.surface_refs ?? []) refs.add(surfaceRef);
+	}
+	return refs;
+}
+
+async function execCmux(pi: ExtensionAPI, args: readonly string[]): Promise<CmuxExecResult> {
+	const result = await pi.exec("cmux", [...args], { timeout: CMUX_TIMEOUT_MS });
+	if (result.killed) {
+		return { ok: false, stdout: result.stdout, stderr: result.stderr, error: "cmux command timed out" };
+	}
+	if (result.code !== 0) {
+		return {
+			ok: false,
+			stdout: result.stdout,
+			stderr: result.stderr,
+			error: result.stderr.trim() || result.stdout.trim() || `cmux exited with code ${result.code}`,
+		};
+	}
+	return { ok: true, stdout: result.stdout, stderr: result.stderr };
+}
+
+async function getCallerInfo(
+	pi: ExtensionAPI,
+): Promise<{ ok: true; caller: Required<CmuxCallerInfo> } | { ok: false; error: string }> {
+	const result = await execCmux(pi, ["--json", "identify"]);
+	if (!result.ok) return { ok: false, error: result.error ?? "Failed to identify cmux caller" };
+
+	const parsed = parseJson<CmuxIdentifyResponse>(result.stdout);
+	const workspaceRef = parsed?.caller?.workspace_ref;
+	const surfaceRef = parsed?.caller?.surface_ref;
+	if (!workspaceRef || !surfaceRef) {
+		return { ok: false, error: "This command must be run from inside a cmux surface" };
+	}
+	return { ok: true, caller: { workspace_ref: workspaceRef, surface_ref: surfaceRef } };
+}
+
+async function listPanes(
+	pi: ExtensionAPI,
+	workspaceRef: string,
+): Promise<{ ok: true; panes: CmuxPaneInfo[] } | { ok: false; error: string }> {
+	const result = await execCmux(pi, ["--json", "list-panes", "--workspace", workspaceRef]);
+	if (!result.ok) return { ok: false, error: result.error ?? "Failed to list cmux panes" };
+	const parsed = parseJson<CmuxListPanesResponse>(result.stdout);
+	return { ok: true, panes: parsed?.panes ?? [] };
+}
+
+async function waitForNewSurface(
+	pi: ExtensionAPI,
+	workspaceRef: string,
+	previousPanes: readonly CmuxPaneInfo[],
+): Promise<string | undefined> {
+	const previousPaneRefs = new Set(
+		previousPanes.map((pane) => pane.ref).filter((ref): ref is string => Boolean(ref)),
+	);
+	const previousSurfaceRefs = collectSurfaceRefs(previousPanes);
+
+	for (let attempt = 0; attempt < SPLIT_READY_ATTEMPTS; attempt += 1) {
+		const panesResult = await listPanes(pi, workspaceRef);
+		if (!panesResult.ok) return undefined;
+
+		for (const pane of panesResult.panes) {
+			if (pane.ref && !previousPaneRefs.has(pane.ref)) {
+				if (pane.selected_surface_ref) return pane.selected_surface_ref;
+				const firstNew = pane.surface_refs?.find((ref) => !previousSurfaceRefs.has(ref));
+				if (firstNew) return firstNew;
+			}
+		}
+
+		for (const pane of panesResult.panes) {
+			for (const surfaceRef of pane.surface_refs ?? []) {
+				if (!previousSurfaceRefs.has(surfaceRef)) return surfaceRef;
+			}
+		}
+
+		await delay(SPLIT_READY_DELAY_MS);
+	}
+
+	return undefined;
+}
+
+export type OpenSplitResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Create a new cmux split next to the current surface and run `command`
+ * in it. Returns `ok: false` with a human-readable error message if any
+ * step fails. Caller decides how to surface the error (typically via
+ * `ctx.ui.notify`).
+ */
+export async function openCommandInNewSplit(
+	pi: ExtensionAPI,
+	direction: SplitDirection,
+	command: string,
+): Promise<OpenSplitResult> {
+	const callerResult = await getCallerInfo(pi);
+	if (!callerResult.ok) return callerResult;
+
+	const { workspace_ref: workspaceRef, surface_ref: surfaceRef } = callerResult.caller;
+	const beforePanesResult = await listPanes(pi, workspaceRef);
+	if (!beforePanesResult.ok) return beforePanesResult;
+
+	const splitResult = await execCmux(pi, [
+		"new-split",
+		direction,
+		"--workspace",
+		workspaceRef,
+		"--surface",
+		surfaceRef,
+	]);
+	if (!splitResult.ok) {
+		return { ok: false, error: splitResult.error ?? "Failed to create cmux split" };
+	}
+
+	const newSurfaceRef = await waitForNewSurface(pi, workspaceRef, beforePanesResult.panes);
+	if (!newSurfaceRef) {
+		return { ok: false, error: "Created split, but could not find the new cmux surface" };
+	}
+
+	await delay(SURFACE_BOOT_DELAY_MS);
+
+	const respawnResult = await execCmux(pi, [
+		"respawn-pane",
+		"--workspace",
+		workspaceRef,
+		"--surface",
+		newSurfaceRef,
+		"--command",
+		command,
+	]);
+	if (!respawnResult.ok) {
+		return { ok: false, error: respawnResult.error ?? "Failed to run command in the new split" };
+	}
+
+	return { ok: true };
+}

--- a/src/commands/cmux-split.ts
+++ b/src/commands/cmux-split.ts
@@ -147,30 +147,20 @@ async function waitForNewSurface(
 		if (!panesResult.ok) return undefined;
 
 		// Prefer the new pane created by the split — its ref won't be in our
-		// pre-split snapshot. Once we see it, only inspect *its* surfaces;
-		// scanning other panes risks picking up an unrelated surface that
-		// appeared concurrently (e.g. user opens a tab in another pane).
-		let foundNewPane = false;
+		// pre-split snapshot. Only inspect *its* surfaces; scanning other
+		// panes risks picking up an unrelated surface that appeared
+		// concurrently (e.g. user opens a tab in another pane).
 		for (const pane of panesResult.panes) {
 			if (pane.ref && !previousPaneRefs.has(pane.ref)) {
-				foundNewPane = true;
 				if (pane.selected_surface_ref) return pane.selected_surface_ref;
 				const firstNew = pane.surface_refs?.find((ref) => !previousSurfaceRefs.has(ref));
 				if (firstNew) return firstNew;
 			}
 		}
 
-		// Fallback: only scan existing panes when no new pane ref has appeared
-		// yet. This covers the edge case where cmux adds a surface to an
-		// existing pane instead of creating a new one.
-		if (!foundNewPane) {
-			for (const pane of panesResult.panes) {
-				for (const surfaceRef of pane.surface_refs ?? []) {
-					if (!previousSurfaceRefs.has(surfaceRef)) return surfaceRef;
-				}
-			}
-		}
-
+		// Safety over guessing: while waiting for the split to appear, never
+		// select surfaces from pre-existing panes. Doing so can target an
+		// unrelated surface created concurrently elsewhere in the workspace.
 		await delay(SPLIT_READY_DELAY_MS);
 	}
 

--- a/src/commands/cmux-split.ts
+++ b/src/commands/cmux-split.ts
@@ -146,17 +146,28 @@ async function waitForNewSurface(
 		const panesResult = await listPanes(pi, workspaceRef);
 		if (!panesResult.ok) return undefined;
 
+		// Prefer the new pane created by the split — its ref won't be in our
+		// pre-split snapshot. Once we see it, only inspect *its* surfaces;
+		// scanning other panes risks picking up an unrelated surface that
+		// appeared concurrently (e.g. user opens a tab in another pane).
+		let foundNewPane = false;
 		for (const pane of panesResult.panes) {
 			if (pane.ref && !previousPaneRefs.has(pane.ref)) {
+				foundNewPane = true;
 				if (pane.selected_surface_ref) return pane.selected_surface_ref;
 				const firstNew = pane.surface_refs?.find((ref) => !previousSurfaceRefs.has(ref));
 				if (firstNew) return firstNew;
 			}
 		}
 
-		for (const pane of panesResult.panes) {
-			for (const surfaceRef of pane.surface_refs ?? []) {
-				if (!previousSurfaceRefs.has(surfaceRef)) return surfaceRef;
+		// Fallback: only scan existing panes when no new pane ref has appeared
+		// yet. This covers the edge case where cmux adds a surface to an
+		// existing pane instead of creating a new one.
+		if (!foundNewPane) {
+			for (const pane of panesResult.panes) {
+				for (const surfaceRef of pane.surface_refs ?? []) {
+					if (!previousSurfaceRefs.has(surfaceRef)) return surfaceRef;
+				}
 			}
 		}
 

--- a/src/commands/diff.test.ts
+++ b/src/commands/diff.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { buildHunkCommand, registerDiffCommand } from "./diff.js";
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe("buildHunkCommand", () => {
+	it("defaults to `hunk diff` on empty args", () => {
+		expect(buildHunkCommand("")).toBe("hunk diff");
+		expect(buildHunkCommand("   ")).toBe("hunk diff");
+	});
+
+	it("passes through known subcommands verbatim", () => {
+		expect(buildHunkCommand("diff")).toBe("hunk diff");
+		expect(buildHunkCommand("show")).toBe("hunk show");
+		expect(buildHunkCommand("show HEAD~1")).toBe("hunk show HEAD~1");
+		expect(buildHunkCommand("patch -")).toBe("hunk patch -");
+		expect(buildHunkCommand("pager")).toBe("hunk pager");
+	});
+
+	it("wraps unknown leading tokens as `hunk diff <args>` so common idioms work", () => {
+		expect(buildHunkCommand("--watch")).toBe("hunk diff --watch");
+		expect(buildHunkCommand("HEAD~1")).toBe("hunk diff HEAD~1");
+		expect(buildHunkCommand("before.ts after.ts")).toBe("hunk diff before.ts after.ts");
+	});
+
+	it("preserves internal whitespace exactly as the user typed it", () => {
+		// We only trim the outer whitespace; multi-space arg separators stay intact
+		// because hunk's own argv parser handles them.
+		expect(buildHunkCommand("show  HEAD~1")).toBe("hunk show  HEAD~1");
+	});
+});
+
+describe("registerDiffCommand", () => {
+	function makePi(execImpl: (cmd: string, args: string[]) => Promise<{ code: number; killed: boolean; stdout: string; stderr: string }>) {
+		const handlers = new Map<string, (args: string | undefined, ctx: unknown) => Promise<void> | void>();
+		const pi = {
+			registerCommand: vi.fn((name: string, opts: { handler: typeof handlers extends Map<string, infer V> ? V : never }) => {
+				handlers.set(name, opts.handler);
+			}),
+			exec: vi.fn(async (cmd: string, args: string[]) => execImpl(cmd, args)),
+		};
+		return { pi, handlers };
+	}
+
+	function makeCtx(notifyMock = vi.fn()) {
+		const ctx = {
+			hasUI: true,
+			cwd: "/tmp/sumo-fixture",
+			ui: { notify: notifyMock },
+		};
+		return { ctx, notifyMock };
+	}
+
+	it("registers the sumo:diff slash command on Pi", () => {
+		const { pi } = makePi(async () => ({ code: 0, killed: false, stdout: "", stderr: "" }));
+		registerDiffCommand(pi as never);
+		expect(pi.registerCommand).toHaveBeenCalledWith(
+			"sumo:diff",
+			expect.objectContaining({ description: expect.stringContaining("hunk diff") }),
+		);
+	});
+
+	it("notifies and exits when ctx.hasUI is false (e.g. RPC/print mode)", async () => {
+		const { pi, handlers } = makePi(async () => ({ code: 0, killed: false, stdout: "", stderr: "" }));
+		registerDiffCommand(pi as never);
+		const handler = handlers.get("sumo:diff");
+		expect(handler).toBeDefined();
+
+		const notifyMock = vi.fn();
+		const ctx = { hasUI: false, cwd: "/tmp", ui: { notify: notifyMock } };
+		await handler?.(undefined, ctx);
+
+		expect(notifyMock).toHaveBeenCalledWith("/sumo:diff requires interactive UI", "warning");
+		// pi.exec should NOT have been called — we exit before trying to detect hunk.
+		expect(pi.exec).not.toHaveBeenCalled();
+	});
+
+	it("notifies with install hint when hunkdiff is not on PATH", async () => {
+		// `command -v hunk` returns non-zero when hunk is missing.
+		const { pi, handlers } = makePi(async (cmd, args) => {
+			if (cmd === "sh" && args.join(" ").includes("command -v hunk")) {
+				return { code: 1, killed: false, stdout: "", stderr: "" };
+			}
+			return { code: 0, killed: false, stdout: "", stderr: "" };
+		});
+		registerDiffCommand(pi as never);
+
+		const { ctx, notifyMock } = makeCtx();
+		await handlers.get("sumo:diff")?.("", ctx);
+
+		expect(notifyMock).toHaveBeenCalledTimes(1);
+		const [message, level] = notifyMock.mock.calls[0] ?? [];
+		expect(message).toContain("hunkdiff");
+		expect(message).toContain("npm i -g hunkdiff");
+		expect(level).toBe("warning");
+		// Importantly: no cmux calls when hunk is missing — we fail fast.
+		expect(pi.exec).toHaveBeenCalledTimes(1);
+		expect(pi.exec).toHaveBeenCalledWith(
+			"sh",
+			["-lc", "command -v hunk >/dev/null 2>&1"],
+			{ timeout: 2_000 },
+		);
+	});
+
+	it("swallows unexpected exceptions from cmux helpers and notifies the user instead of rejecting", async () => {
+		// Simulate a pathological cmux exec that throws synchronously after
+		// the hunk pre-flight has already passed. (`isHunkInstalled` swallows
+		// its own exceptions and returns false, which is a separate code
+		// path — we want to exercise the *outer* try/catch around the cmux
+		// helpers and result handling.) The handler must not let the
+		// exception escape; it must surface via ctx.ui.notify.
+		const { pi, handlers } = makePi(async (cmd) => {
+			if (cmd === "sh") {
+				// hunk pre-flight: pretend hunk IS installed so we get past it.
+				return { code: 0, killed: false, stdout: "", stderr: "" };
+			}
+			throw new Error("boom: cmux blew up");
+		});
+		registerDiffCommand(pi as never);
+
+		const { ctx, notifyMock } = makeCtx();
+		// Should not throw.
+		await expect(handlers.get("sumo:diff")?.("", ctx)).resolves.toBeUndefined();
+
+		expect(notifyMock).toHaveBeenCalledTimes(1);
+		const [message, level] = notifyMock.mock.calls[0] ?? [];
+		expect(message).toContain("boom: cmux blew up");
+		expect(level).toBe("warning");
+	});
+
+	it("notifies with cmux error when not inside a cmux surface", async () => {
+		// hunk-detection succeeds; `cmux --json identify` returns caller: null.
+		const { pi, handlers } = makePi(async (cmd, args) => {
+			if (cmd === "sh") return { code: 0, killed: false, stdout: "", stderr: "" };
+			if (cmd === "cmux" && args[1] === "identify") {
+				return { code: 0, killed: false, stdout: JSON.stringify({ caller: null }), stderr: "" };
+			}
+			return { code: 0, killed: false, stdout: "", stderr: "" };
+		});
+		registerDiffCommand(pi as never);
+
+		const { ctx, notifyMock } = makeCtx();
+		await handlers.get("sumo:diff")?.("", ctx);
+
+		expect(notifyMock).toHaveBeenCalledTimes(1);
+		const [message, level] = notifyMock.mock.calls[0] ?? [];
+		expect(message).toContain("must be run from inside a cmux surface");
+		expect(level).toBe("warning");
+	});
+});

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -1,0 +1,91 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { buildShellCommand, openCommandInNewSplit, type SplitDirection } from "./cmux-split.js";
+
+/**
+ * `/sumo:diff` — open `hunkdiff` in a new cmux split pane for quick review.
+ *
+ *   /sumo:diff                  → `hunk diff`           (working tree)
+ *   /sumo:diff --watch          → `hunk diff --watch`   (auto-reload as files change)
+ *   /sumo:diff HEAD~1           → `hunk diff HEAD~1`    (compare against a ref)
+ *   /sumo:diff show             → `hunk show`           (latest commit)
+ *   /sumo:diff show HEAD~1      → `hunk show HEAD~1`    (specific commit)
+ *   /sumo:diff before.ts after.ts
+ *
+ * Requires `cmux` (we're inside a cmux surface) and `hunkdiff` (npm:
+ * `npm i -g hunkdiff` or `brew install modem-dev/tap/hunk`). When either is
+ * missing, the command notifies and exits without side effects.
+ *
+ * Split direction is `right` so the diff lands next to the active SUMO
+ * session. Users who prefer a downward split can use pi-cmux's `/cmoh hunk
+ * diff` instead.
+ */
+
+/** First-token subcommands hunk supports as documented in its README. */
+const HUNK_SUBCOMMANDS: ReadonlySet<string> = new Set(["diff", "show", "patch", "pager"]);
+
+export function buildHunkCommand(rawArgs: string): string {
+	const trimmed = rawArgs.trim();
+	if (!trimmed) return "hunk diff";
+	const tokens = trimmed.split(/\s+/);
+	const first = tokens[0] ?? "";
+	if (HUNK_SUBCOMMANDS.has(first)) return `hunk ${trimmed}`;
+	// Anything that doesn't look like a hunk subcommand is treated as
+	// arguments to `hunk diff` — covers `/sumo:diff --watch`,
+	// `/sumo:diff HEAD~1`, `/sumo:diff before.ts after.ts`, etc.
+	return `hunk diff ${trimmed}`;
+}
+
+/**
+ * Check whether `hunkdiff` is on PATH. Using `pi.exec` rather than spawning
+ * the new pane and letting hunk's own "command not found" error appear there
+ * — better UX to fail fast with a clear install hint.
+ */
+async function isHunkInstalled(pi: ExtensionAPI): Promise<boolean> {
+	try {
+		const result = await pi.exec("sh", ["-lc", "command -v hunk >/dev/null 2>&1"], { timeout: 2_000 });
+		return result.code === 0 && !result.killed;
+	} catch {
+		return false;
+	}
+}
+
+export function registerDiffCommand(pi: ExtensionAPI): void {
+	pi.registerCommand("sumo:diff", {
+		description: "Open hunk diff in a new cmux split (right) for quick review",
+		handler: async (args: string | undefined, ctx: ExtensionContext) => {
+			// All failure paths must go through `ctx.ui.notify` per the
+			// SumoCode slash-command contract — no exception should ever
+			// escape the handler. Wrap the body so unexpected throws from
+			// `pi.exec` / cmux helpers / future refactors still surface as a
+			// user-visible warning rather than a silent rejection.
+			try {
+				if (!ctx.hasUI) {
+					ctx.ui.notify("/sumo:diff requires interactive UI", "warning");
+					return;
+				}
+
+				if (!(await isHunkInstalled(pi))) {
+					ctx.ui.notify(
+						"/sumo:diff needs hunkdiff. install with `npm i -g hunkdiff` or `brew install modem-dev/tap/hunk`",
+						"warning",
+					);
+					return;
+				}
+
+				const hunkCmd = buildHunkCommand(args ?? "");
+				const shellCmd = buildShellCommand(ctx.cwd, hunkCmd);
+				const direction: SplitDirection = "right";
+
+				const result = await openCommandInNewSplit(pi, direction, shellCmd);
+				if (result.ok) {
+					ctx.ui.notify(`opened ${hunkCmd} in a new cmux pane`, "info");
+				} else {
+					ctx.ui.notify(`/sumo:diff: ${result.error}`, "warning");
+				}
+			} catch (err) {
+				const message = err instanceof Error ? err.message : String(err);
+				ctx.ui.notify(`/sumo:diff: ${message}`, "warning");
+			}
+		},
+	});
+}

--- a/src/interaction-registry.test.ts
+++ b/src/interaction-registry.test.ts
@@ -78,6 +78,7 @@ describe("InteractionRegistry", () => {
 			"slate",
 			"sumo:approval",
 			"sumo:cursor",
+			"sumo:diff",
 			"sumo:memory",
 			"sumo:persona",
 			"sumo:query",
@@ -88,7 +89,7 @@ describe("InteractionRegistry", () => {
 			"sumo:theme-check",
 		]);
 		expect(snapshot.shortcuts.map(([id]) => id).sort()).toEqual(["alt+t", "ctrl+/", "ctrl+1", "ctrl+2", "ctrl+shift+t"]);
-		expect(pi.registerCommand).toHaveBeenCalledTimes(12);
+		expect(pi.registerCommand).toHaveBeenCalledTimes(13);
 		expect(pi.registerShortcut).toHaveBeenCalledTimes(5);
 	});
 });

--- a/src/interaction-registry.ts
+++ b/src/interaction-registry.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { installCommandPalette } from "./command-palette.js";
 import { registerApprovalCommand } from "./commands/approval.js";
 import { registerCursorCommand } from "./commands/cursor.js";
+import { registerDiffCommand } from "./commands/diff.js";
 import { registerDivineQueryCommand } from "./commands/divine-query.js";
 import { registerExitCommand } from "./commands/exit.js";
 import { registerSlateCommand } from "./commands/slate.js";
@@ -129,6 +130,7 @@ export function installSumoInteractions(pi: ExtensionAPI, options: InstallSumoIn
 	registry.install("sidebar", installSidebar);
 	registry.install("commands.approval", registerApprovalCommand);
 	registry.install("commands.cursor", registerCursorCommand);
+	registry.install("commands.diff", registerDiffCommand);
 	registry.install("commands.divine-query", registerDivineQueryCommand);
 	registry.install("commands.exit", registerExitCommand);
 	registry.install("commands.slate", registerSlateCommand);


### PR DESCRIPTION
## Summary

Quick-review slash command. `/sumo:diff` opens [`hunkdiff`](https://github.com/modem-dev/hunk) (`npm:hunkdiff` / `brew install modem-dev/tap/hunk`) in a new cmux pane to the right of the current SUMO session. No SumoCode UI is taken over, no OpenTUI is pulled into our runtime — hunk runs as a sibling pane, SUMO keeps painting in its own surface.

Dhruv's scope: "just do /sumo:diff which opens a split cmux panel with correct hunkdiff command for quick review."

## What it does

| Invocation | Runs |
|---|---|
| `/sumo:diff` | `hunk diff` (working tree) |
| `/sumo:diff --watch` | `hunk diff --watch` |
| `/sumo:diff HEAD~1` | `hunk diff HEAD~1` |
| `/sumo:diff show` | `hunk show` |
| `/sumo:diff show HEAD~1` | `hunk show HEAD~1` |
| `/sumo:diff before.ts after.ts` | `hunk diff before.ts after.ts` |
| `/sumo:diff patch -` | `hunk patch -` |
| `/sumo:diff pager` | `hunk pager` |

If the first token isn't a known hunk subcommand (`diff`/`show`/`patch`/`pager`), it gets wrapped as `hunk diff <args>` so common idioms like `/sumo:diff --watch` and `/sumo:diff HEAD~1` do the right thing.

Pre-flight checks before touching cmux:
- `ctx.hasUI` — notifies and exits if running in RPC/print mode
- `command -v hunk` (POSIX-portable, 2s timeout) — notifies with install hint if `hunkdiff` isn't on PATH

## How it talks to cmux

Ported the proven pattern from [`pi-cmux@0.1.8`](https://github.com/javiermolinar/pi-cmux) (MIT, Javier Molina) into `src/commands/cmux-split.ts` with attribution. pi-cmux is already installed alongside SumoCode for many users, but its exports are Pi-loaded extensions rather than a library, so the helpers can't be imported directly.

Protocol (5 steps):

1. `cmux --json identify` — confirm we're inside a cmux surface; extract `workspace_ref` + `surface_ref`.
2. `cmux --json list-panes --workspace <ref>` — snapshot before the split.
3. `cmux new-split right --workspace <ref> --surface <ref>` — create the split.
4. Poll `list-panes` up to 20 × 150 ms until the new pane appears — capture its surface ref.
5. `cmux respawn-pane --workspace <ref> --surface <new-ref> --command <cmd>` — run `cd '<cwd>' && exec sh -lc '<hunk-cmd>'` in the new pane.

Shell quoting uses POSIX single-quote escaping (safe for paths with apostrophes, spaces, and shell metacharacters — verified against SumoCode's own `/Volumes/SumoDeus NVMe` dev path).

## Failure handling

Every failure path goes through `ctx.ui.notify(..., "warning")`:

| Failure | Notify |
|---|---|
| `!ctx.hasUI` | "requires interactive UI" |
| `hunkdiff` missing | install hint pointing at `npm i -g hunkdiff` / `brew install modem-dev/tap/hunk` |
| Not in a cmux surface | "must be run from inside a cmux surface" |
| cmux exec timeout / error | propagated cmux stderr |
| Surface never appears after split | "created split, but could not find the new cmux surface" |
| `respawn-pane` fails | propagated cmux stderr |
| Unexpected exception anywhere in the handler | caught by outer try/catch and notified |

That last one is the codex P1 fix: every failure must surface as a SUMO toast, not a silent promise rejection.

## Files

| File | Purpose | Lines |
|---|---|---|
| `src/commands/cmux-split.ts` (NEW) | cmux split helpers (port from pi-cmux@0.1.8 with attribution) | 222 |
| `src/commands/diff.ts` (NEW) | `/sumo:diff` registration + arg parsing | 98 |
| `src/commands/diff.test.ts` (NEW, 9 tests) | `buildHunkCommand` table tests + handler behavior tests | 142 |
| `src/interaction-registry.ts` (+2) | wires `registerDiffCommand` into the registry | |
| `src/interaction-registry.test.ts` (+1) | snapshot now expects 13 registered commands | |

## Verification

```txt
pnpm exec tsc --noEmit         → clean
pnpm test                       → 94 files / 828 passed (was 819; +9 new diff tests)
pnpm test:integration           → 19 files / 32 passed
pnpm visual:ci                   → no new regressions
shellEscape spot-check          → round-trips '/path with \'apostrophes' correctly
```

Codex round 1: 1 P1 (missing outer try/catch) → fixed with regression test → second round expected GREEN.