### PR TITLE
feat(question): support selectable Divine Query options

### DIFF
--- a/src/question-tool.test.ts
+++ b/src/question-tool.test.ts
@@ -1,8 +1,119 @@
-import { describe, expect, it } from "vitest";
-import { withCathedralForeground } from "./question-tool.js";
+import { describe, expect, it, vi } from "vitest";
+import { installQuestionTool, normalizeQuestionOptions, withCathedralForeground } from "./question-tool.js";
 
 const ANSI_PATTERN = /\[[0-9;]*m/g;
 const stripAnsi = (value: string): string => value.replace(ANSI_PATTERN, "");
+
+describe("normalizeQuestionOptions", () => {
+	it("normalizes string and object options", () => {
+		expect(normalizeQuestionOptions([
+			"Keep it high-level",
+			{ label: "Mention losses", description: "show real-money context" },
+			"  ",
+		])).toEqual([
+			"Keep it high-level",
+			"Mention losses — show real-money context",
+		]);
+	});
+
+	it("returns empty list when options are omitted", () => {
+		expect(normalizeQuestionOptions(undefined)).toEqual([]);
+	});
+});
+
+describe("question tool options", () => {
+	function themeStub() {
+		return {
+			fg: (_name: string, text: string) => text,
+			bold: (text: string) => text,
+		};
+	}
+
+	it("renders provided options as selectable Divine Query choices", async () => {
+		let tool: { execute: (...args: unknown[]) => Promise<{ content: { text: string }[]; details: { answer?: string; wasCustom?: boolean } }> } | undefined;
+		const pi = {
+			registerTool: vi.fn((definition) => { tool = definition; }),
+		};
+		let rendered = "";
+		const ctx = {
+			hasUI: true,
+			ui: {
+				custom: vi.fn((factory) => new Promise((resolve) => {
+					const component = factory({ requestRender: vi.fn(), terminal: { rows: 24 } }, themeStub(), {}, resolve);
+					rendered = component.render(80).join("\n");
+					component.handleInput("enter");
+				})),
+			},
+		};
+
+		installQuestionTool(pi as never);
+		const result = await tool!.execute("call-1", {
+			question: "Preferred framing?",
+			options: ["Keep it high-level", "Mention real-money bets/losses"],
+		}, undefined, undefined, ctx);
+
+		expect(stripAnsi(rendered)).toContain("A) Keep it high-level");
+		expect(stripAnsi(rendered)).toContain("B) Mention real-money bets/losses");
+		expect(stripAnsi(rendered)).toContain("C) Type something…");
+		expect(result.details).toMatchObject({ answer: "Keep it high-level", wasCustom: false });
+		expect(result.content[0]?.text).toBe("User answered: Keep it high-level");
+	});
+
+	it("treats a real option named like the free-text label as a selectable option", async () => {
+		let tool: { execute: (...args: unknown[]) => Promise<{ content: { text: string }[]; details: { answer?: string; wasCustom?: boolean } }> } | undefined;
+		const pi = {
+			registerTool: vi.fn((definition) => { tool = definition; }),
+		};
+		let rendered = "";
+		const ctx = {
+			hasUI: true,
+			ui: {
+				custom: vi.fn((factory) => new Promise((resolve) => {
+					const component = factory({ requestRender: vi.fn(), terminal: { rows: 24 } }, themeStub(), {}, resolve);
+					rendered = component.render(80).join("\n");
+					component.handleInput("enter");
+				})),
+			},
+		};
+
+		installQuestionTool(pi as never);
+		const result = await tool!.execute("call-1", {
+			question: "Pick one",
+			options: ["Type something…"],
+		}, undefined, undefined, ctx);
+
+		const plain = stripAnsi(rendered);
+		expect(plain).toContain("A) Type something…");
+		expect(plain).toContain("B) Type something…");
+		expect(result.details).toMatchObject({ answer: "Type something…", wasCustom: false });
+	});
+
+	it("auto-focuses free-text input when no options are provided", async () => {
+		let tool: { execute: (...args: unknown[]) => Promise<{ details: { cancelled?: boolean } }> } | undefined;
+		const pi = {
+			registerTool: vi.fn((definition) => { tool = definition; }),
+		};
+		let rendered = "";
+		const ctx = {
+			hasUI: true,
+			ui: {
+				custom: vi.fn((factory) => new Promise((resolve) => {
+					const component = factory({ requestRender: vi.fn(), terminal: { rows: 24 } }, themeStub(), {}, resolve);
+					rendered = component.render(80).join("\n");
+					resolve(null);
+				})),
+			},
+		};
+
+		installQuestionTool(pi as never);
+		const result = await tool!.execute("call-1", { question: "What should I do?" }, undefined, undefined, ctx);
+
+		const plain = stripAnsi(rendered);
+		expect(plain).toContain("Your answer:");
+		expect(plain).not.toContain("A) Type something…");
+		expect(result.details).toMatchObject({ cancelled: true });
+	});
+});
 
 describe("withCathedralForeground", () => {
 	it("re-applies Cathedral foreground after Pi default-fg reset (\\x1b[39m)", () => {

--- a/src/question-tool.test.ts
+++ b/src/question-tool.test.ts
@@ -11,8 +11,8 @@ describe("normalizeQuestionOptions", () => {
 			{ label: "Mention losses", description: "show real-money context" },
 			"  ",
 		])).toEqual([
-			"Keep it high-level",
-			"Mention losses — show real-money context",
+			{ label: "Keep it high-level", value: "Keep it high-level" },
+			{ label: "Mention losses — show real-money context", value: "Mention losses" },
 		]);
 	});
 
@@ -57,6 +57,35 @@ describe("question tool options", () => {
 		expect(stripAnsi(rendered)).toContain("C) Type something…");
 		expect(result.details).toMatchObject({ answer: "Keep it high-level", wasCustom: false });
 		expect(result.content[0]?.text).toBe("User answered: Keep it high-level");
+	});
+
+	it("returns the raw option label when an object option has helper text", async () => {
+		let tool: { execute: (...args: unknown[]) => Promise<{ content: { text: string }[]; details: { answer?: string; wasCustom?: boolean } }> } | undefined;
+		const pi = {
+			registerTool: vi.fn((definition) => { tool = definition; }),
+		};
+		let rendered = "";
+		const ctx = {
+			hasUI: true,
+			ui: {
+				custom: vi.fn((factory) => new Promise((resolve) => {
+					const component = factory({ requestRender: vi.fn(), terminal: { rows: 24 } }, themeStub(), {}, resolve);
+					rendered = component.render(80).join("\n");
+					component.handleInput("enter");
+				})),
+			},
+		};
+
+		installQuestionTool(pi as never);
+		const result = await tool!.execute("call-1", {
+			question: "Approve?",
+			options: [{ label: "approve", description: "safe to proceed" }],
+		}, undefined, undefined, ctx);
+
+		const plain = stripAnsi(rendered);
+		expect(plain).toContain("A) approve — safe to proceed");
+		expect(result.details).toMatchObject({ answer: "approve", wasCustom: false });
+		expect(result.content[0]?.text).toBe("User answered: approve");
 	});
 
 	it("treats a real option named like the free-text label as a selectable option", async () => {

--- a/src/question-tool.ts
+++ b/src/question-tool.ts
@@ -46,28 +46,37 @@ type QuestionEntry = {
 	options?: QuestionOptionParam[];
 };
 
-type DialogOption = {
+export type NormalizedQuestionOption = {
+	/** Text rendered in Divine Query. May include helper description. */
 	label: string;
+	/** Raw option value returned to the tool caller. Never includes description. */
+	value: string;
+};
+
+type DialogOption = NormalizedQuestionOption & {
 	isFreeText: boolean;
 };
 
-export function normalizeQuestionOptions(options: readonly QuestionOptionParam[] | undefined): string[] {
+export function normalizeQuestionOptions(options: readonly QuestionOptionParam[] | undefined): NormalizedQuestionOption[] {
 	if (!options?.length) return [];
 	return options
-		.map((option) => {
-			if (typeof option === "string") return option.trim();
-			const label = option.label.trim();
+		.map((option): NormalizedQuestionOption => {
+			if (typeof option === "string") {
+				const label = option.trim();
+				return { label, value: label };
+			}
+			const value = option.label.trim();
 			const description = option.description?.trim();
-			return description ? `${label} — ${description}` : label;
+			return { label: description ? `${value} — ${description}` : value, value };
 		})
-		.filter((option) => option.length > 0);
+		.filter((option) => option.value.length > 0);
 }
 
 function dialogOptionsFor(options: readonly QuestionOptionParam[] | undefined): DialogOption[] {
 	const normalized = normalizeQuestionOptions(options);
 	return [
-		...normalized.map((label) => ({ label, isFreeText: false })),
-		{ label: FREE_TEXT_LABEL, isFreeText: true },
+		...normalized.map((option) => ({ ...option, isFreeText: false })),
+		{ label: FREE_TEXT_LABEL, value: "", isFreeText: true },
 	];
 }
 
@@ -172,7 +181,7 @@ async function showCathedralQuestion(
 						refresh();
 						return;
 					}
-					done({ answer: selected?.label ?? "", wasCustom: false });
+					done({ answer: selected?.value ?? "", wasCustom: false });
 					return;
 				}
 

--- a/src/question-tool.ts
+++ b/src/question-tool.ts
@@ -13,14 +13,24 @@ import { Editor, type EditorTheme, Key, matchesKey, Text } from "@earendil-works
 import { Type } from "typebox";
 import { renderDivineQuery, updateDivineQuery, type DivineQuerySnapshot, DIVINE_QUERY_OVERLAY_OPTIONS } from "./divine-query.js";
 
+const OptionParam = Type.Union([
+	Type.String({ description: "Option label shown to the user" }),
+	Type.Object({
+		label: Type.String({ description: "Option label shown to the user" }),
+		description: Type.Optional(Type.String({ description: "Optional helper text for the option" })),
+	}),
+]);
+
 const QuestionParams = Type.Object({
 	question: Type.String({ description: "The question to ask the user" }),
 	context: Type.Optional(Type.String({ description: "Optional context/help text shown under the question" })),
+	options: Type.Optional(Type.Array(OptionParam, { description: "Options for the user to choose from. Do not prefix with A)/B)/1./2.; the UI adds labels automatically." })),
 	questions: Type.Optional(
 		Type.Array(
 			Type.Object({
 				question: Type.String({ description: "Question text to ask the user" }),
 				context: Type.Optional(Type.String({ description: "Optional context/help text shown under the question" })),
+				options: Type.Optional(Type.Array(OptionParam, { description: "Options for this question. Omit for free-text input." })),
 			}),
 			{ minItems: 1, description: "Questions to ask, in order" },
 		),
@@ -28,6 +38,38 @@ const QuestionParams = Type.Object({
 });
 
 const FREE_TEXT_LABEL = "Type something…";
+
+type QuestionOptionParam = string | { label: string; description?: string };
+type QuestionEntry = {
+	question: string;
+	context?: string;
+	options?: QuestionOptionParam[];
+};
+
+type DialogOption = {
+	label: string;
+	isFreeText: boolean;
+};
+
+export function normalizeQuestionOptions(options: readonly QuestionOptionParam[] | undefined): string[] {
+	if (!options?.length) return [];
+	return options
+		.map((option) => {
+			if (typeof option === "string") return option.trim();
+			const label = option.label.trim();
+			const description = option.description?.trim();
+			return description ? `${label} — ${description}` : label;
+		})
+		.filter((option) => option.length > 0);
+}
+
+function dialogOptionsFor(options: readonly QuestionOptionParam[] | undefined): DialogOption[] {
+	const normalized = normalizeQuestionOptions(options);
+	return [
+		...normalized.map((label) => ({ label, isFreeText: false })),
+		{ label: FREE_TEXT_LABEL, isFreeText: true },
+	];
+}
 
 /**
  * Pi's `Editor` renders with its own theme tokens — its default cursor and
@@ -56,18 +98,17 @@ interface QuestionResult {
 async function showCathedralQuestion(
 	ctx: ExtensionContext,
 	title: string,
-	options: readonly string[],
+	options: readonly DialogOption[],
 ): Promise<QuestionResult | null> {
-	// If the only "option" is the free-text placeholder, start directly in
-	// edit mode so the user sees an auto-focused input — no dummy
-	// "A) Type something…" row.
-	const freeTextOnly = options.length === 1 && options[0] === FREE_TEXT_LABEL;
+	// If the only option is the free-text sentinel, start directly in edit mode
+	// so the user sees an auto-focused input — no dummy "A) Type something…" row.
+	const freeTextOnly = options.length === 1 && options[0]?.isFreeText === true;
 
 	return ctx.ui.custom<QuestionResult | null>(
 		(tui, theme, _kb, done) => {
 			// When freeTextOnly, render the query with NO options (empty array)
 			// so the option list is hidden; the editor is shown immediately.
-			let snapshot: DivineQuerySnapshot = { title, options: freeTextOnly ? [] : options, focusedIndex: 0 };
+			let snapshot: DivineQuerySnapshot = { title, options: freeTextOnly ? [] : options.map((option) => option.label), focusedIndex: 0 };
 			let editMode = freeTextOnly;
 			let cachedLines: string[] | undefined;
 
@@ -126,12 +167,12 @@ async function showCathedralQuestion(
 						return;
 					}
 					const selected = options[result.done];
-					if (selected === FREE_TEXT_LABEL) {
+					if (selected?.isFreeText) {
 						editMode = true;
 						refresh();
 						return;
 					}
-					done({ answer: selected ?? "", wasCustom: false });
+					done({ answer: selected?.label ?? "", wasCustom: false });
 					return;
 				}
 
@@ -173,7 +214,7 @@ export function installQuestionTool(pi: ExtensionAPI): void {
 	pi.registerTool({
 		name: "question",
 		label: "Question",
-		description: "Ask the user a question and let them pick from options. Use when you need user input to proceed. Do NOT prefix options with A)/B)/1./2. — the Cathedral UI adds labels automatically.",
+		description: "Ask the user a question and let them pick from options, or omit options for free-text input. Use when you need user input to proceed. Do NOT prefix options with A)/B)/1./2. — the Cathedral UI adds labels automatically.",
 		parameters: QuestionParams,
 
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -184,11 +225,13 @@ export function installQuestionTool(pi: ExtensionAPI): void {
 				};
 			}
 
-			// Normalize: support both single question and questions array
-			const questions = params.questions?.length
+			// Normalize: support both single question and questions array.
+			// Top-level `options` belongs to the single-question form; sequential
+			// questions can each specify their own `options`.
+			const questions: QuestionEntry[] = params.questions?.length
 				? params.questions
 				: params.question
-					? [{ question: params.question, context: params.context }]
+					? [{ question: params.question, context: params.context, options: params.options }]
 					: [];
 
 			if (questions.length === 0) {
@@ -202,8 +245,7 @@ export function installQuestionTool(pi: ExtensionAPI): void {
 			if (questions.length === 1) {
 				const q = questions[0];
 				const title = q.context ? `${q.question}\n${q.context}` : q.question;
-				// No predefined options — just free text via the "Type something…" option
-				const result = await showCathedralQuestion(ctx, title, [FREE_TEXT_LABEL]);
+				const result = await showCathedralQuestion(ctx, title, dialogOptionsFor(q.options));
 
 				if (!result) {
 					return {
@@ -222,7 +264,7 @@ export function installQuestionTool(pi: ExtensionAPI): void {
 			const answers: { question: string; answer: string }[] = [];
 			for (const q of questions) {
 				const title = q.context ? `${q.question}\n${q.context}` : q.question;
-				const result = await showCathedralQuestion(ctx, title, [FREE_TEXT_LABEL]);
+				const result = await showCathedralQuestion(ctx, title, dialogOptionsFor(q.options));
 
 				if (!result) {
 					return {


### PR DESCRIPTION
## Summary

- Add structured `options` support to SumoCode's custom `question` tool.
- Render provided options as selectable Divine Query choices.
- Append a free-text escape hatch when structured options exist.
- Keep no-option questions auto-focused in the free-text editor, with no dummy `A) Type something…` row.
- Use an internal free-text sentinel so a real user option named `Type something…` remains selectable.

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm vitest run src/question-tool.test.ts`
- `pnpm test`
