### PR TITLE
feat(splash): show model and thinking level

### DIFF
--- a/src/cathedral/input-frame.test.ts
+++ b/src/cathedral/input-frame.test.ts
@@ -178,6 +178,15 @@ describe("renderInputHints", () => {
 		expect(line).toContain("\u001b[38;2;139;122;99m (main)");
 	});
 
+	it("colors splash model with accent and leaves thinking dim", () => {
+		const line = renderInputHints(80, {
+			leftHint: "╰─ claude-sonnet-4.6 · high",
+			leftHintStyle: "model-thinking",
+		});
+		expect(line).toContain("\u001b[38;2;217;119;6mclaude-sonnet-4.6");
+		expect(line).toContain("\u001b[38;2;139;122;99m · high");
+	});
+
 	it("colors CTRL+/ modifier key in accent (#D97706)", () => {
 		const line = renderInputHints(80);
 		expect(line).not.toContain("TAB");

--- a/src/cathedral/input-frame.ts
+++ b/src/cathedral/input-frame.ts
@@ -180,8 +180,8 @@ export type InputHintsOptions = {
 	leftHint?: string;
 	/** When set, truncate the left hint instead of dropping it at narrow widths. */
 	leftHintOverflow?: "drop" | "truncate";
-	/** Project context renders project in foreground and branch in dim. */
-	leftHintStyle?: "dim" | "project-branch";
+	/** Project context renders project in foreground and branch in dim; splash invocation highlights model with theme accent. */
+	leftHintStyle?: "dim" | "project-branch" | "model-thinking";
 };
 
 /**
@@ -206,6 +206,17 @@ export function renderInputHints(width: number, options: InputHintsOptions = {})
 	// Build the colored right-hand string: CTRL+/ in accent, label in dim.
 	const rightColored = `${accent}CTRL+/${RESET} ${dimFg}· COMMANDS${RESET}`;
 	const colorLeftHint = (text: string): string => {
+		if (options.leftHintStyle === "model-thinking") {
+			const prefix = "╰─ ";
+			const separator = " · ";
+			if (!text.startsWith(prefix)) return `${dimFg}${text}${RESET}`;
+			const rest = text.slice(prefix.length);
+			const separatorIndex = rest.lastIndexOf(separator);
+			if (separatorIndex === -1) return `${dimFg}${prefix}${RESET}${color(rest, activeThemeColors().accent)}`;
+			const model = rest.slice(0, separatorIndex);
+			const thinking = rest.slice(separatorIndex + separator.length);
+			return `${dimFg}${prefix}${RESET}${color(model, activeThemeColors().accent)}${dimFg}${separator}${thinking}${RESET}`;
+		}
 		if (options.leftHintStyle !== "project-branch") return `${dimFg}${text}${RESET}`;
 		const branchStart = text.indexOf(" (");
 		if (branchStart === -1) return color(text, activeThemeColors().foreground);

--- a/src/cathedral/input-hints.test.ts
+++ b/src/cathedral/input-hints.test.ts
@@ -4,10 +4,12 @@ import { installInputHints } from "./input-hints.js";
 type Handler = (...args: unknown[]) => unknown;
 
 describe("installInputHints", () => {
-	it("subscribes to session_start", () => {
+	it("subscribes to session_start and selector updates", () => {
 		const on = vi.fn();
 		installInputHints({ on } as never);
 		expect(on).toHaveBeenCalledWith("session_start", expect.any(Function));
+		expect(on).toHaveBeenCalledWith("model_select", expect.any(Function));
+		expect(on).toHaveBeenCalledWith("thinking_level_select", expect.any(Function));
 	});
 
 	it("on session_start, registers a widget below the editor", () => {
@@ -114,8 +116,43 @@ describe("installInputHints", () => {
 		const lines = component!.render(120);
 		expect(lines.length).toBe(1);
 		const stripped = lines[0]!.replace(/\u001b\[[0-9;]*m/g, "");
-		expect(stripped).toContain("╰─ AWAITING PROMPT");
+		expect(stripped).toContain("╰─ no model · thinking");
 		expect(stripped).toContain("CTRL+/ · COMMANDS");
+		expect(stripped).not.toContain("AWAITING PROMPT");
 		expect(stripped).not.toContain("TAB · AGENTS");
+	});
+
+	it("updates splash hint when model or thinking changes", () => {
+		const handlers = new Map<string, Handler[]>();
+		const on = vi.fn((event: string, handler: Handler) => {
+			const list = handlers.get(event) ?? [];
+			list.push(handler);
+			handlers.set(event, list);
+		});
+		installInputHints({ on } as never);
+
+		let factory: ((tui: { requestRender: () => void }, theme: unknown) => { render(width: number): string[] }) | undefined;
+		const setWidget = vi.fn((_key: string, f: typeof factory) => {
+			factory = f;
+		});
+		const ctx = {
+			hasUI: true,
+			ui: { setWidget },
+			model: { id: "claude-sonnet-4.6" },
+			sessionManager: { getBranch: () => [{ type: "thinking_level_change", thinkingLevel: "high" }] },
+		} as unknown;
+		for (const handler of handlers.get("session_start") ?? []) handler({ type: "session_start" }, ctx);
+
+		const requestRender = vi.fn();
+		const component = factory!({ requestRender }, undefined);
+		const initial = component.render(120)[0]!.replace(/\u001b\[[0-9;]*m/g, "");
+		expect(initial).toContain("╰─ claude-sonnet-4.6 · high");
+
+		for (const handler of handlers.get("model_select") ?? []) handler({ type: "model_select", model: { id: "gpt-5.3-codex" } });
+		for (const handler of handlers.get("thinking_level_select") ?? []) handler({ type: "thinking_level_select", level: "xhigh" });
+
+		const updated = component.render(120)[0]!.replace(/\u001b\[[0-9;]*m/g, "");
+		expect(updated).toContain("╰─ gpt-5.3-codex · xhigh");
+		expect(requestRender).toHaveBeenCalledTimes(2);
 	});
 });

--- a/src/cathedral/input-hints.ts
+++ b/src/cathedral/input-hints.ts
@@ -5,22 +5,23 @@
  *   right-aligned dim:    TAB · AGENTS  CTRL+/ · COMMANDS
  *
  * Splash state (Element 3):
- *   left dim flavour:     └─ AWAITING DIVINE INVOCATION
- *   right-aligned dim:    TAB · AGENTS  CTRL+/ · COMMANDS
+ *   left dim context:     ╰─ <model> · <thinking>
+ *   right-aligned dim:    CTRL+/ · COMMANDS
  *
  * Mounted via `setWidget(..., { placement: "belowEditor" })`.
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import type { Component } from "@earendil-works/pi-tui";
+import type { Component, TUI } from "@earendil-works/pi-tui";
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { formatCwd } from "../footer.js";
 import { getGitBranch, sessionHasMessages as cachedSessionHasMessages } from "../session-cache.js";
-import { INPUT_FRAME_HINT_AWAITING, renderInputHints } from "./input-frame.js";
+import { renderInputHints } from "./input-frame.js";
 
 const SPLASH_INPUT_FRAME_WIDTH = 60;
 const ACTIVE_HINT_HORIZONTAL_PADDING = 1;
 const ANSI_PATTERN = /\u001b\[[0-9;]*m/g;
+type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 
 function centerAnsi(line: string, width: number): string {
 	const visible = visibleWidth(line.replace(ANSI_PATTERN, ""));
@@ -33,6 +34,7 @@ function centerAnsi(line: string, width: number): string {
 class InputHintsComponent implements Component {
 	constructor(
 		private readonly isSplash: () => boolean,
+		private readonly splashLeftHint: () => string,
 		private readonly activeLeftHint: () => string | undefined,
 	) {}
 	invalidate(): void {}
@@ -42,7 +44,7 @@ class InputHintsComponent implements Component {
 			// block. Return just the hint (no leading blank) so Pi's belowEditor
 			// slot stays compact and the input frame sits close to the content.
 			const frameWidth = Math.min(width, SPLASH_INPUT_FRAME_WIDTH);
-			return [centerAnsi(renderInputHints(frameWidth, { leftHint: INPUT_FRAME_HINT_AWAITING }), width)];
+			return [centerAnsi(renderInputHints(frameWidth, { leftHint: this.splashLeftHint(), leftHintStyle: "model-thinking" }), width)];
 		}
 		// Active bottom breathing rows are owned by the retained shell layout shim,
 		// not by the hint component. This keeps the component semantic: one hint row.
@@ -61,6 +63,26 @@ function activeContextHint(ctx: ExtensionContext): string | undefined {
 	return branch ? `${project} (${branch})` : project;
 }
 
+function latestThinkingLevel(ctx: ExtensionContext): ThinkingLevel | undefined {
+	let latest: ThinkingLevel | undefined;
+	try {
+		for (const entry of ctx.sessionManager.getBranch()) {
+			if (entry.type === "thinking_level_change") latest = entry.thinkingLevel as ThinkingLevel;
+		}
+	} catch {
+		return undefined;
+	}
+	return latest;
+}
+
+function modelDisplayName(ctx: ExtensionContext): string {
+	return ctx.model?.id ?? "no model";
+}
+
+function splashInvocationHint(modelId: string, thinkingLevel: ThinkingLevel | undefined): string {
+	return `╰─ ${modelId} · ${thinkingLevel ?? "thinking"}`;
+}
+
 function sessionHasMessages(ctx: ExtensionContext): boolean {
 	try {
 		return cachedSessionHasMessages(ctx);
@@ -70,12 +92,35 @@ function sessionHasMessages(ctx: ExtensionContext): boolean {
 }
 
 export function installInputHints(pi: ExtensionAPI): void {
+	let requestRender: (() => void) | undefined;
+	let currentModelId = "no model";
+	let currentThinkingLevel: ThinkingLevel | undefined;
+
 	pi.on("session_start", (_event, ctx) => {
 		if (!ctx.hasUI) return;
+		currentModelId = modelDisplayName(ctx);
+		currentThinkingLevel = latestThinkingLevel(ctx);
 		ctx.ui.setWidget(
 			"sumocode-input-hints",
-			() => new InputHintsComponent(() => !sessionHasMessages(ctx), () => activeContextHint(ctx)),
+			(tui: TUI) => {
+				requestRender = () => tui.requestRender();
+				return new InputHintsComponent(
+					() => !sessionHasMessages(ctx),
+					() => splashInvocationHint(currentModelId, currentThinkingLevel),
+					() => activeContextHint(ctx),
+				);
+			},
 			{ placement: "belowEditor" },
 		);
+	});
+
+	pi.on("model_select", (event) => {
+		currentModelId = event.model.id;
+		requestRender?.();
+	});
+
+	pi.on("thinking_level_select", (event) => {
+		currentThinkingLevel = event.level;
+		requestRender?.();
 	});
 }

--- a/src/question-tool.test.ts
+++ b/src/question-tool.test.ts
@@ -1,8 +1,119 @@
-import { describe, expect, it } from "vitest";
-import { withCathedralForeground } from "./question-tool.js";
+import { describe, expect, it, vi } from "vitest";
+import { installQuestionTool, normalizeQuestionOptions, withCathedralForeground } from "./question-tool.js";
 
 const ANSI_PATTERN = /\[[0-9;]*m/g;
 const stripAnsi = (value: string): string => value.replace(ANSI_PATTERN, "");
+
+describe("normalizeQuestionOptions", () => {
+	it("normalizes string and object options", () => {
+		expect(normalizeQuestionOptions([
+			"Keep it high-level",
+			{ label: "Mention losses", description: "show real-money context" },
+			"  ",
+		])).toEqual([
+			"Keep it high-level",
+			"Mention losses — show real-money context",
+		]);
+	});
+
+	it("returns empty list when options are omitted", () => {
+		expect(normalizeQuestionOptions(undefined)).toEqual([]);
+	});
+});
+
+describe("question tool options", () => {
+	function themeStub() {
+		return {
+			fg: (_name: string, text: string) => text,
+			bold: (text: string) => text,
+		};
+	}
+
+	it("renders provided options as selectable Divine Query choices", async () => {
+		let tool: { execute: (...args: unknown[]) => Promise<{ content: { text: string }[]; details: { answer?: string; wasCustom?: boolean } }> } | undefined;
+		const pi = {
+			registerTool: vi.fn((definition) => { tool = definition; }),
+		};
+		let rendered = "";
+		const ctx = {
+			hasUI: true,
+			ui: {
+				custom: vi.fn((factory) => new Promise((resolve) => {
+					const component = factory({ requestRender: vi.fn(), terminal: { rows: 24 } }, themeStub(), {}, resolve);
+					rendered = component.render(80).join("\n");
+					component.handleInput("enter");
+				})),
+			},
+		};
+
+		installQuestionTool(pi as never);
+		const result = await tool!.execute("call-1", {
+			question: "Preferred framing?",
+			options: ["Keep it high-level", "Mention real-money bets/losses"],
+		}, undefined, undefined, ctx);
+
+		expect(stripAnsi(rendered)).toContain("A) Keep it high-level");
+		expect(stripAnsi(rendered)).toContain("B) Mention real-money bets/losses");
+		expect(stripAnsi(rendered)).toContain("C) Type something…");
+		expect(result.details).toMatchObject({ answer: "Keep it high-level", wasCustom: false });
+		expect(result.content[0]?.text).toBe("User answered: Keep it high-level");
+	});
+
+	it("treats a real option named like the free-text label as a selectable option", async () => {
+		let tool: { execute: (...args: unknown[]) => Promise<{ content: { text: string }[]; details: { answer?: string; wasCustom?: boolean } }> } | undefined;
+		const pi = {
+			registerTool: vi.fn((definition) => { tool = definition; }),
+		};
+		let rendered = "";
+		const ctx = {
+			hasUI: true,
+			ui: {
+				custom: vi.fn((factory) => new Promise((resolve) => {
+					const component = factory({ requestRender: vi.fn(), terminal: { rows: 24 } }, themeStub(), {}, resolve);
+					rendered = component.render(80).join("\n");
+					component.handleInput("enter");
+				})),
+			},
+		};
+
+		installQuestionTool(pi as never);
+		const result = await tool!.execute("call-1", {
+			question: "Pick one",
+			options: ["Type something…"],
+		}, undefined, undefined, ctx);
+
+		const plain = stripAnsi(rendered);
+		expect(plain).toContain("A) Type something…");
+		expect(plain).toContain("B) Type something…");
+		expect(result.details).toMatchObject({ answer: "Type something…", wasCustom: false });
+	});
+
+	it("auto-focuses free-text input when no options are provided", async () => {
+		let tool: { execute: (...args: unknown[]) => Promise<{ details: { cancelled?: boolean } }> } | undefined;
+		const pi = {
+			registerTool: vi.fn((definition) => { tool = definition; }),
+		};
+		let rendered = "";
+		const ctx = {
+			hasUI: true,
+			ui: {
+				custom: vi.fn((factory) => new Promise((resolve) => {
+					const component = factory({ requestRender: vi.fn(), terminal: { rows: 24 } }, themeStub(), {}, resolve);
+					rendered = component.render(80).join("\n");
+					resolve(null);
+				})),
+			},
+		};
+
+		installQuestionTool(pi as never);
+		const result = await tool!.execute("call-1", { question: "What should I do?" }, undefined, undefined, ctx);
+
+		const plain = stripAnsi(rendered);
+		expect(plain).toContain("Your answer:");
+		expect(plain).not.toContain("A) Type something…");
+		expect(result.details).toMatchObject({ cancelled: true });
+	});
+});
 
 describe("withCathedralForeground", () => {
 	it("re-applies Cathedral foreground after Pi default-fg reset (\\x1b[39m)", () => {

--- a/src/question-tool.test.ts
+++ b/src/question-tool.test.ts
@@ -142,6 +142,33 @@ describe("question tool options", () => {
 		expect(plain).not.toContain("A) Type something…");
 		expect(result.details).toMatchObject({ cancelled: true });
 	});
+
+	it("keeps free-text-only questions editable after an empty submit", async () => {
+		let tool: { execute: (...args: unknown[]) => Promise<{ details: { cancelled?: boolean } }> } | undefined;
+		const pi = {
+			registerTool: vi.fn((definition) => { tool = definition; }),
+		};
+		let renderedAfterEmptySubmit = "";
+		const ctx = {
+			hasUI: true,
+			ui: {
+				custom: vi.fn((factory) => new Promise((resolve) => {
+					const component = factory({ requestRender: vi.fn(), terminal: { rows: 24 } }, themeStub(), {}, resolve);
+					component.handleInput("enter");
+					renderedAfterEmptySubmit = component.render(80).join("\n");
+					component.handleInput("\u001b");
+				})),
+			},
+		};
+
+		installQuestionTool(pi as never);
+		const result = await tool!.execute("call-1", { question: "What should I do?" }, undefined, undefined, ctx);
+
+		const plain = stripAnsi(renderedAfterEmptySubmit);
+		expect(plain).toContain("Your answer:");
+		expect(plain).not.toContain("A) Type something…");
+		expect(result.details).toMatchObject({ cancelled: true });
+	});
 });
 
 describe("withCathedralForeground", () => {

--- a/src/question-tool.test.ts
+++ b/src/question-tool.test.ts
@@ -11,8 +11,8 @@ describe("normalizeQuestionOptions", () => {
 			{ label: "Mention losses", description: "show real-money context" },
 			"  ",
 		])).toEqual([
-			"Keep it high-level",
-			"Mention losses — show real-money context",
+			{ label: "Keep it high-level", value: "Keep it high-level" },
+			{ label: "Mention losses — show real-money context", value: "Mention losses" },
 		]);
 	});
 
@@ -57,6 +57,35 @@ describe("question tool options", () => {
 		expect(stripAnsi(rendered)).toContain("C) Type something…");
 		expect(result.details).toMatchObject({ answer: "Keep it high-level", wasCustom: false });
 		expect(result.content[0]?.text).toBe("User answered: Keep it high-level");
+	});
+
+	it("returns the raw option label when an object option has helper text", async () => {
+		let tool: { execute: (...args: unknown[]) => Promise<{ content: { text: string }[]; details: { answer?: string; wasCustom?: boolean } }> } | undefined;
+		const pi = {
+			registerTool: vi.fn((definition) => { tool = definition; }),
+		};
+		let rendered = "";
+		const ctx = {
+			hasUI: true,
+			ui: {
+				custom: vi.fn((factory) => new Promise((resolve) => {
+					const component = factory({ requestRender: vi.fn(), terminal: { rows: 24 } }, themeStub(), {}, resolve);
+					rendered = component.render(80).join("\n");
+					component.handleInput("enter");
+				})),
+			},
+		};
+
+		installQuestionTool(pi as never);
+		const result = await tool!.execute("call-1", {
+			question: "Approve?",
+			options: [{ label: "approve", description: "safe to proceed" }],
+		}, undefined, undefined, ctx);
+
+		const plain = stripAnsi(rendered);
+		expect(plain).toContain("A) approve — safe to proceed");
+		expect(result.details).toMatchObject({ answer: "approve", wasCustom: false });
+		expect(result.content[0]?.text).toBe("User answered: approve");
 	});
 
 	it("treats a real option named like the free-text label as a selectable option", async () => {

--- a/src/question-tool.ts
+++ b/src/question-tool.ts
@@ -46,28 +46,37 @@ type QuestionEntry = {
 	options?: QuestionOptionParam[];
 };
 
-type DialogOption = {
+export type NormalizedQuestionOption = {
+	/** Text rendered in Divine Query. May include helper description. */
 	label: string;
+	/** Raw option value returned to the tool caller. Never includes description. */
+	value: string;
+};
+
+type DialogOption = NormalizedQuestionOption & {
 	isFreeText: boolean;
 };
 
-export function normalizeQuestionOptions(options: readonly QuestionOptionParam[] | undefined): string[] {
+export function normalizeQuestionOptions(options: readonly QuestionOptionParam[] | undefined): NormalizedQuestionOption[] {
 	if (!options?.length) return [];
 	return options
-		.map((option) => {
-			if (typeof option === "string") return option.trim();
-			const label = option.label.trim();
+		.map((option): NormalizedQuestionOption => {
+			if (typeof option === "string") {
+				const label = option.trim();
+				return { label, value: label };
+			}
+			const value = option.label.trim();
 			const description = option.description?.trim();
-			return description ? `${label} — ${description}` : label;
+			return { label: description ? `${value} — ${description}` : value, value };
 		})
-		.filter((option) => option.length > 0);
+		.filter((option) => option.value.length > 0);
 }
 
 function dialogOptionsFor(options: readonly QuestionOptionParam[] | undefined): DialogOption[] {
 	const normalized = normalizeQuestionOptions(options);
 	return [
-		...normalized.map((label) => ({ label, isFreeText: false })),
-		{ label: FREE_TEXT_LABEL, isFreeText: true },
+		...normalized.map((option) => ({ ...option, isFreeText: false })),
+		{ label: FREE_TEXT_LABEL, value: "", isFreeText: true },
 	];
 }
 
@@ -172,7 +181,7 @@ async function showCathedralQuestion(
 						refresh();
 						return;
 					}
-					done({ answer: selected?.label ?? "", wasCustom: false });
+					done({ answer: selected?.value ?? "", wasCustom: false });
 					return;
 				}
 

--- a/src/question-tool.ts
+++ b/src/question-tool.ts
@@ -13,14 +13,24 @@ import { Editor, type EditorTheme, Key, matchesKey, Text } from "@earendil-works
 import { Type } from "typebox";
 import { renderDivineQuery, updateDivineQuery, type DivineQuerySnapshot, DIVINE_QUERY_OVERLAY_OPTIONS } from "./divine-query.js";
 
+const OptionParam = Type.Union([
+	Type.String({ description: "Option label shown to the user" }),
+	Type.Object({
+		label: Type.String({ description: "Option label shown to the user" }),
+		description: Type.Optional(Type.String({ description: "Optional helper text for the option" })),
+	}),
+]);
+
 const QuestionParams = Type.Object({
 	question: Type.String({ description: "The question to ask the user" }),
 	context: Type.Optional(Type.String({ description: "Optional context/help text shown under the question" })),
+	options: Type.Optional(Type.Array(OptionParam, { description: "Options for the user to choose from. Do not prefix with A)/B)/1./2.; the UI adds labels automatically." })),
 	questions: Type.Optional(
 		Type.Array(
 			Type.Object({
 				question: Type.String({ description: "Question text to ask the user" }),
 				context: Type.Optional(Type.String({ description: "Optional context/help text shown under the question" })),
+				options: Type.Optional(Type.Array(OptionParam, { description: "Options for this question. Omit for free-text input." })),
 			}),
 			{ minItems: 1, description: "Questions to ask, in order" },
 		),
@@ -28,6 +38,38 @@ const QuestionParams = Type.Object({
 });
 
 const FREE_TEXT_LABEL = "Type something…";
+
+type QuestionOptionParam = string | { label: string; description?: string };
+type QuestionEntry = {
+	question: string;
+	context?: string;
+	options?: QuestionOptionParam[];
+};
+
+type DialogOption = {
+	label: string;
+	isFreeText: boolean;
+};
+
+export function normalizeQuestionOptions(options: readonly QuestionOptionParam[] | undefined): string[] {
+	if (!options?.length) return [];
+	return options
+		.map((option) => {
+			if (typeof option === "string") return option.trim();
+			const label = option.label.trim();
+			const description = option.description?.trim();
+			return description ? `${label} — ${description}` : label;
+		})
+		.filter((option) => option.length > 0);
+}
+
+function dialogOptionsFor(options: readonly QuestionOptionParam[] | undefined): DialogOption[] {
+	const normalized = normalizeQuestionOptions(options);
+	return [
+		...normalized.map((label) => ({ label, isFreeText: false })),
+		{ label: FREE_TEXT_LABEL, isFreeText: true },
+	];
+}
 
 /**
  * Pi's `Editor` renders with its own theme tokens — its default cursor and
@@ -56,18 +98,17 @@ interface QuestionResult {
 async function showCathedralQuestion(
 	ctx: ExtensionContext,
 	title: string,
-	options: readonly string[],
+	options: readonly DialogOption[],
 ): Promise<QuestionResult | null> {
-	// If the only "option" is the free-text placeholder, start directly in
-	// edit mode so the user sees an auto-focused input — no dummy
-	// "A) Type something…" row.
-	const freeTextOnly = options.length === 1 && options[0] === FREE_TEXT_LABEL;
+	// If the only option is the free-text sentinel, start directly in edit mode
+	// so the user sees an auto-focused input — no dummy "A) Type something…" row.
+	const freeTextOnly = options.length === 1 && options[0]?.isFreeText === true;
 
 	return ctx.ui.custom<QuestionResult | null>(
 		(tui, theme, _kb, done) => {
 			// When freeTextOnly, render the query with NO options (empty array)
 			// so the option list is hidden; the editor is shown immediately.
-			let snapshot: DivineQuerySnapshot = { title, options: freeTextOnly ? [] : options, focusedIndex: 0 };
+			let snapshot: DivineQuerySnapshot = { title, options: freeTextOnly ? [] : options.map((option) => option.label), focusedIndex: 0 };
 			let editMode = freeTextOnly;
 			let cachedLines: string[] | undefined;
 
@@ -126,12 +167,12 @@ async function showCathedralQuestion(
 						return;
 					}
 					const selected = options[result.done];
-					if (selected === FREE_TEXT_LABEL) {
+					if (selected?.isFreeText) {
 						editMode = true;
 						refresh();
 						return;
 					}
-					done({ answer: selected ?? "", wasCustom: false });
+					done({ answer: selected?.label ?? "", wasCustom: false });
 					return;
 				}
 
@@ -173,7 +214,7 @@ export function installQuestionTool(pi: ExtensionAPI): void {
 	pi.registerTool({
 		name: "question",
 		label: "Question",
-		description: "Ask the user a question and let them pick from options. Use when you need user input to proceed. Do NOT prefix options with A)/B)/1./2. — the Cathedral UI adds labels automatically.",
+		description: "Ask the user a question and let them pick from options, or omit options for free-text input. Use when you need user input to proceed. Do NOT prefix options with A)/B)/1./2. — the Cathedral UI adds labels automatically.",
 		parameters: QuestionParams,
 
 		async execute(_toolCallId, params, _signal, _onUpdate, ctx) {
@@ -184,11 +225,13 @@ export function installQuestionTool(pi: ExtensionAPI): void {
 				};
 			}
 
-			// Normalize: support both single question and questions array
-			const questions = params.questions?.length
+			// Normalize: support both single question and questions array.
+			// Top-level `options` belongs to the single-question form; sequential
+			// questions can each specify their own `options`.
+			const questions: QuestionEntry[] = params.questions?.length
 				? params.questions
 				: params.question
-					? [{ question: params.question, context: params.context }]
+					? [{ question: params.question, context: params.context, options: params.options }]
 					: [];
 
 			if (questions.length === 0) {
@@ -202,8 +245,7 @@ export function installQuestionTool(pi: ExtensionAPI): void {
 			if (questions.length === 1) {
 				const q = questions[0];
 				const title = q.context ? `${q.question}\n${q.context}` : q.question;
-				// No predefined options — just free text via the "Type something…" option
-				const result = await showCathedralQuestion(ctx, title, [FREE_TEXT_LABEL]);
+				const result = await showCathedralQuestion(ctx, title, dialogOptionsFor(q.options));
 
 				if (!result) {
 					return {
@@ -222,7 +264,7 @@ export function installQuestionTool(pi: ExtensionAPI): void {
 			const answers: { question: string; answer: string }[] = [];
 			for (const q of questions) {
 				const title = q.context ? `${q.question}\n${q.context}` : q.question;
-				const result = await showCathedralQuestion(ctx, title, [FREE_TEXT_LABEL]);
+				const result = await showCathedralQuestion(ctx, title, dialogOptionsFor(q.options));
 
 				if (!result) {
 					return {

--- a/src/question-tool.ts
+++ b/src/question-tool.ts
@@ -137,6 +137,9 @@ async function showCathedralQuestion(
 				const trimmed = value.trim();
 				if (trimmed) {
 					done({ answer: trimmed, wasCustom: true });
+				} else if (freeTextOnly) {
+					editor.setText("");
+					refresh();
 				} else {
 					editMode = false;
 					editor.setText("");

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
@@ -464,6 +464,46 @@ describe("ChatViewportController", () => {
 		root.dispose();
 	});
 
+	it("mirrors Pi status text into retained system messages when owned-shell is active", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const chat = ChatPager.create(yoga, root);
+		const host = {
+			ui: { terminal: { rows: 24, columns: 120 }, requestRender: vi.fn() },
+			chatContainer: {
+				children: [] as unknown[],
+				addChild(child: unknown) {
+					this.children.push(child);
+				},
+				render: vi.fn(() => []),
+				clear: vi.fn(),
+				invalidate: vi.fn(),
+			},
+		};
+		const runtime = {
+			getSnapshot: () => ({ chat }),
+			setExternalRenderControls: vi.fn(),
+			renderChatLines: vi.fn(() => []),
+			writeChatViewport: vi.fn(() => true),
+			requestRender: vi.fn(),
+			setEmptyChatQuoteState: vi.fn(),
+			noteUserMessage: vi.fn(),
+			isOwnedShellActive: () => true,
+		};
+
+		const cleanup = installChatViewportBridge(host, runtime);
+		host.chatContainer.addChild({ render: (_width: number) => ["\u001b[2mShare URL: https://pi.dev/session/abc\u001b[0m", "Gist: https://gist.github.com/me/abc"] });
+		host.chatContainer.addChild({ render: (_width: number) => [""] });
+
+		const messages = chat.getRenderedMessages().map((message) => message.toSnapshot());
+		expect(messages).toHaveLength(1);
+		expect(messages[0]).toMatchObject({ role: "system", text: "Share URL: https://pi.dev/session/abc\nGist: https://gist.github.com/me/abc" });
+		expect(runtime.requestRender).toHaveBeenCalledTimes(1);
+
+		cleanup?.();
+		root.dispose();
+	});
+
 	it("short-circuits Pi chat rendering when owned-shell becomes active after bridge install", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.test.ts
@@ -464,7 +464,7 @@ describe("ChatViewportController", () => {
 		root.dispose();
 	});
 
-	it("mirrors Pi status text into retained system messages when owned-shell is active", async () => {
+	it("mirrors Pi share status text into retained system messages when owned-shell is active", async () => {
 		const yoga = await loadYoga();
 		const root = new SumoNode(yoga.Node.create());
 		const chat = ChatPager.create(yoga, root);
@@ -499,6 +499,43 @@ describe("ChatViewportController", () => {
 		expect(messages).toHaveLength(1);
 		expect(messages[0]).toMatchObject({ role: "system", text: "Share URL: https://pi.dev/session/abc\nGist: https://gist.github.com/me/abc" });
 		expect(runtime.requestRender).toHaveBeenCalledTimes(1);
+
+		cleanup?.();
+		root.dispose();
+	});
+
+	it("does not mirror generic Pi status text into retained chat on splash", async () => {
+		const yoga = await loadYoga();
+		const root = new SumoNode(yoga.Node.create());
+		const chat = ChatPager.create(yoga, root);
+		const host = {
+			ui: { terminal: { rows: 24, columns: 120 }, requestRender: vi.fn() },
+			chatContainer: {
+				children: [] as unknown[],
+				addChild(child: unknown) {
+					this.children.push(child);
+				},
+				render: vi.fn(() => []),
+				clear: vi.fn(),
+				invalidate: vi.fn(),
+			},
+		};
+		const runtime = {
+			getSnapshot: () => ({ chat }),
+			setExternalRenderControls: vi.fn(),
+			renderChatLines: vi.fn(() => []),
+			writeChatViewport: vi.fn(() => true),
+			requestRender: vi.fn(),
+			setEmptyChatQuoteState: vi.fn(),
+			noteUserMessage: vi.fn(),
+			isOwnedShellActive: () => true,
+		};
+
+		const cleanup = installChatViewportBridge(host, runtime);
+		host.chatContainer.addChild({ render: (_width: number) => ["✓ New session started"] });
+
+		expect(chat.hasMessages()).toBe(false);
+		expect(runtime.requestRender).not.toHaveBeenCalled();
 
 		cleanup?.();
 		root.dispose();

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -354,6 +354,10 @@ function renderForeignSystemText(component: ForeignRenderableLike, width: number
 	}
 }
 
+function shouldMirrorForeignSystemText(text: string): boolean {
+	return text.startsWith("Share URL: ") || text.startsWith("Gist: ") || text.startsWith("Failed to create gist:") || text.startsWith("Failed to parse gist ID from gh output");
+}
+
 /**
  * Deep Module for the retained chat viewport seam.
  *
@@ -436,7 +440,7 @@ export class ChatViewportController {
 		if (this.bashMirror.attach(component)) return;
 		if (!isForeignRenderableLike(component)) return;
 		const text = renderForeignSystemText(component, this.host.ui?.terminal?.columns ?? this.lastChatWidth);
-		if (text.length === 0) return;
+		if (text.length === 0 || !shouldMirrorForeignSystemText(text)) return;
 		this.chat.addMessage("system", text);
 		this.markRenderDirty();
 		this.runtime.requestRender();

--- a/src/sumo-tui/pi-compat/chat-viewport-controller.ts
+++ b/src/sumo-tui/pi-compat/chat-viewport-controller.ts
@@ -25,6 +25,7 @@ const PORTRAIT_CHAT_GUTTER_MIN_WIDTH = 80;
 const STREAMING_CHAT_RENDER_COALESCE_MS = 100;
 const MOUSE_CHAT_RENDER_COALESCE_MS = 50;
 const BOTTOM_CHROME_SPACERS_INSTALLED = Symbol("sumo-tui.bottom-chrome-spacers-installed");
+const ANSI_PATTERN = /\u001b(?:\[[0-?]*[ -/]*[@-~]|\][^\u0007]*(?:\u0007|\u001b\\))/g;
 export const ACTIVE_BOTTOM_CHROME_SPACER_ROWS = 2;
 
 interface PiRenderableComponent {
@@ -37,6 +38,10 @@ interface PiChatContainer {
 	invalidate?(): void;
 	render?(width: number): string[];
 	addChild?(component: unknown): void;
+}
+
+interface ForeignRenderableLike {
+	render(width: number): string[];
 }
 
 interface PiTuiLike {
@@ -334,6 +339,21 @@ function countUserMessages(messages: readonly unknown[]): number {
 	return messages.filter(isUserMessage).length;
 }
 
+function isForeignRenderableLike(value: unknown): value is ForeignRenderableLike {
+	return !!value && typeof value === "object" && typeof (value as { render?: unknown }).render === "function";
+}
+
+function renderForeignSystemText(component: ForeignRenderableLike, width: number): string {
+	try {
+		return component.render(width)
+			.map((line) => line.replace(ANSI_PATTERN, "").trimEnd())
+			.join("\n")
+			.trim();
+	} catch {
+		return "";
+	}
+}
+
 /**
  * Deep Module for the retained chat viewport seam.
  *
@@ -412,8 +432,14 @@ export class ChatViewportController {
 		return lines;
 	}
 
-	public attachForeignBashComponent(component: unknown): void {
-		this.bashMirror.attach(component);
+	public attachForeignChatComponent(component: unknown): void {
+		if (this.bashMirror.attach(component)) return;
+		if (!isForeignRenderableLike(component)) return;
+		const text = renderForeignSystemText(component, this.host.ui?.terminal?.columns ?? this.lastChatWidth);
+		if (text.length === 0) return;
+		this.chat.addMessage("system", text);
+		this.markRenderDirty();
+		this.runtime.requestRender();
 	}
 
 	public clear(): void {
@@ -973,14 +999,14 @@ export function installChatViewportBridge(upstream: unknown, runtime: ChatViewpo
 		chatContainer.addChild = (component: unknown): void => {
 			originalAddChild(component);
 			if (replayingSessionHistory) return;
-			if (isOwnedShellActive()) controller.attachForeignBashComponent(component);
+			if (isOwnedShellActive()) controller.attachForeignChatComponent(component);
 		};
 	}
 	if (pendingMessagesContainer && originalPendingAddChild) {
 		pendingMessagesContainer.addChild = (component: unknown): void => {
 			originalPendingAddChild(component);
 			if (replayingSessionHistory) return;
-			if (isOwnedShellActive()) controller.attachForeignBashComponent(component);
+			if (isOwnedShellActive()) controller.attachForeignChatComponent(component);
 		};
 	}
 	chatContainer.render = (width: number): string[] => {


### PR DESCRIPTION
## Summary
- replace the splash left hint with current model + thinking level
- update the hint when model/thinking selectors change
- keep active hint behavior unchanged

## Verification
- pnpm vitest run src/cathedral/input-hints.test.ts src/cathedral/input-frame.test.ts
- pnpm exec tsc --noEmit && pnpm build