### PR TITLE
chore(paths): update repo path refs after move out of openclaw workspace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ User-specific state (persona, memory, settings, MCP, skills) lives in the separa
 ## Non-negotiables
 
 - Do not delete branches, force-push, merge PRs, remove files, or run destructive cleanup unless Dhruv explicitly approves it.
-- Always quote paths with spaces. The primary dev tree is `/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode`.
+- Always quote paths with spaces. The primary dev tree is `/Volumes/SumoDeus NVMe/code/sumocode`.
 - Preserve the public/private split: this repo is public MIT; secrets and personal config belong in `sumocode-config`.
 - Visual UI work is not done until the relevant capture/review evidence is produced and Dhruv approves any golden promotion.
 - Use the project's existing patterns before introducing new abstractions.

--- a/DEV_LOOP.md
+++ b/DEV_LOOP.md
@@ -6,7 +6,7 @@ How I edit, test, and release SumoCode. This is the workflow I actually use, not
 
 ## Where the repo lives
 
-**Dev repo (authoring):** `/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode/`
+**Dev repo (authoring):** `/Volumes/SumoDeus NVMe/code/sumocode/`
 
 **Installed version (consumed by Pi):** `~/.pi/agent/git/github.com/dhruvkelawala/sumocode/` (clone managed by `pi install`)
 
@@ -22,7 +22,7 @@ These are two different directories on purpose:
 ### 1. Edit at the dev repo
 
 ```bash
-cd "/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode"
+cd "/Volumes/SumoDeus NVMe/code/sumocode"
 # open src/extension.ts or wherever the change lives
 ```
 
@@ -116,7 +116,7 @@ For a feature change, verify the specific surface I just touched.
 ### 4. Commit to the dev repo
 
 ```bash
-cd "/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode"
+cd "/Volumes/SumoDeus NVMe/code/sumocode"
 git add -A
 git commit -m "feat: add custom footer with memory-count indicator"
 ```
@@ -224,7 +224,7 @@ Fallback when running plain `pi -e .` or when the reload signal is unavailable. 
 ### Need to see what Pi actually has for the extension
 
 ```bash
-ls -la "/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode/src/"
+ls -la "/Volumes/SumoDeus NVMe/code/sumocode/src/"
 # Then compare to:
 ls -la ~/.pi/agent/git/github.com/dhruvkelawala/sumocode/src/
 ```

--- a/PLAN.md
+++ b/PLAN.md
@@ -227,7 +227,7 @@ The 3 theme bundles live at `src/themes/cathedral.ts`, `src/themes/amber-crt.ts`
 
 ### Done
 - [x] Resolve Q1–Q7 via grilling session 1 (2026-04-24)
-- [x] Scaffold `sumocode` repo at `/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode`
+- [x] Scaffold `sumocode` repo at `/Volumes/SumoDeus NVMe/code/sumocode`
 - [x] Write v0.1.0 hello-world extension
 - [x] Publish to `github.com/dhruvkelawala/sumocode` (public)
 - [x] Tag v0.1.0

--- a/SETUP.md
+++ b/SETUP.md
@@ -64,7 +64,7 @@ You should see:
 
 ### Development clone (only on machines where I want to author changes)
 
-The dev repo lives at `/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode` on my Mac mini. If I want to author changes from another machine, clone it there too:
+The dev repo lives at `/Volumes/SumoDeus NVMe/code/sumocode` on my Mac mini. If I want to author changes from another machine, clone it there too:
 
 ```bash
 mkdir -p ~/code && cd ~/code
@@ -125,7 +125,7 @@ See [README.md](./README.md) for architecture and roadmap.
 
 | File | Managed by | Location |
 |------|-----------|----------|
-| Extension code | this repo | `/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode/` (dev) + `~/.pi/agent/git/github.com/dhruvkelawala/sumocode/` (installed) |
+| Extension code | this repo | `/Volumes/SumoDeus NVMe/code/sumocode/` (dev) + `~/.pi/agent/git/github.com/dhruvkelawala/sumocode/` (installed) |
 | Synced config (settings, mcp, extensions, persona) | sumocode-config repo | `~/sumocode-config/`, symlinked to `~/.pi/agent/` |
 | Local secrets (auth.json, API keys) | local only, never synced | `~/.pi/agent/auth.json`, `~/.zshrc` |
 | Skills (mattpocock, stitch-kit, etc.) | auto-cloned by `pi install` | `~/.pi/agent/git/github.com/…` |

--- a/src/approval-modal.test.ts
+++ b/src/approval-modal.test.ts
@@ -89,7 +89,7 @@ describe("renderApprovalModal", () => {
 	});
 
 	it("wraps long commands and descriptions inside the modal width", () => {
-		const longCommand = `cd \"/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode\" && gh issue create --title \"Approval modal leaks long commands across the terminal\" --body \"long quoted body with spaces\"`;
+		const longCommand = `cd \"/Volumes/SumoDeus NVMe/code/sumocode\" && gh issue create --title \"Approval modal leaks long commands across the terminal\" --body \"long quoted body with spaces\"`;
 		const lines = renderApprovalModal(snapshot({
 			command: longCommand,
 			descriptionLines: ["This command mutates GitHub state and has a very long quoted body that should wrap inside the lifted modal without leaking past the terminal edge."],

--- a/src/footer.test.ts
+++ b/src/footer.test.ts
@@ -156,7 +156,7 @@ describe("formatCwd", () => {
 	});
 
 	it("returns just the basename for paths outside $HOME", () => {
-		expect(formatCwd("/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode")).toBe("sumocode");
+		expect(formatCwd("/Volumes/SumoDeus NVMe/code/sumocode")).toBe("sumocode");
 		expect(formatCwd("/opt/homebrew/etc")).toBe("etc");
 	});
 

--- a/src/sumo-tui/transcript/tool-renderer.test.ts
+++ b/src/sumo-tui/transcript/tool-renderer.test.ts
@@ -61,7 +61,7 @@ describe("tool renderer", () => {
 		const rows = renderToolBlockRows({
 			name: "read",
 			status: "success",
-			input: { path: "/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode/src/sumo-tui/pi-compat/sumo-interactive-mode.ts" },
+			input: { path: "/Volumes/SumoDeus NVMe/code/sumocode/src/sumo-tui/pi-compat/sumo-interactive-mode.ts" },
 			details: { lineCount: 184 },
 			expanded: false,
 		}, 80);


### PR DESCRIPTION
## Why

The SumoCode dev tree moved from `/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode` to `/Volumes/SumoDeus NVMe/code/sumocode` so the OpenClaw operator `AGENTS.md` two levels up stops parent-loading into SumoCode agent sessions. SumoCode is a public OSS project — its agent context should be the project's own `AGENTS.md`, not the operator's personal layer.

This PR is the in-repo cleanup that follows the on-disk move (Pi symlink, pnpm shim, session dir rename, `git worktree repair`, and session-metadata `cwd` rewrites were handled out-of-band by `~/move-sumocode.sh`).

## What changed

Pure path-string substitution (`/Volumes/SumoDeus NVMe/openclaw/workspace/sumocode` → `/Volumes/SumoDeus NVMe/code/sumocode`) in 7 files:

| File | Occurrences | Kind |
|---|---|---|
| `AGENTS.md` | 1 | primary dev tree note |
| `DEV_LOOP.md` | 4 | dev repo location + `cd` examples |
| `PLAN.md` | 1 | scaffold history line |
| `SETUP.md` | 2 | dev path + installed-vs-dev table cell |
| `src/approval-modal.test.ts` | 1 | long-command fixture |
| `src/footer.test.ts` | 1 | `formatCwd` basename test |
| `src/sumo-tui/transcript/tool-renderer.test.ts` | 1 | tool-render path fixture |

The test refs are just fixture strings — assertions check command length, basename, and rendered output, not actual file I/O. Tests pass either way; the substitution keeps the fixtures current and grep-clean.

## Verification

```txt
git grep 'openclaw/workspace/sumocode'   → empty (0 hits)
pnpm exec tsc --noEmit                    → clean
pnpm test                                  → 93 files / 825 passed
```

Diff size: 7 files, +11/-11 lines.