### PR TITLE
feat(fast-mode): add OpenAI service tier toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ A Pi extension that ships its own retained terminal renderer (SumoTUI), three th
 
 [![MIT License](https://img.shields.io/badge/license-MIT-2D211A?style=flat-square)](./LICENSE)
 [![Version](https://img.shields.io/badge/v0.3.0-B85A22?style=flat-square)](./CHANGELOG.md)
-[![Pi 0.74](https://img.shields.io/badge/pi-0.74.0-4A6B3A?style=flat-square)](https://github.com/earendil-works/pi)
-[![Tests](https://img.shields.io/badge/tests-807%20passing-4A6B3A?style=flat-square)](./test)
+[![Pi 0.75](https://img.shields.io/badge/pi-0.75.3-4A6B3A?style=flat-square)](https://github.com/earendil-works/pi)
+[![Tests](https://img.shields.io/badge/tests-868%20passing-4A6B3A?style=flat-square)](./test)
 
 <br>
 
@@ -55,6 +55,7 @@ Three themes ship: Cathedral (default), Amber CRT, and Obsidian Temple. Cycle wi
 | **Five preattentive states** | `idle`, `thinking`, `tool`, `approval`, `learning`. Each maps to a distinct theme-defined colour, surfaced in the footer dot and working indicator. |
 | **Owned-shell mode** | Full altscreen ownership: retained renderer, in-app scroll, modal layer, mouse routing, OSC 52 cell-precise selection. Pi reduced to LLM, tools, sessions through adapters in [`src/sumo-tui/pi-compat/`](./src/sumo-tui/pi-compat/). |
 | **`/sumo:reload`** | Hot-reload via launcher loop and exit code 100. Strips `--resume`, replaces with `--continue`. Resumes the in-flight session. |
+| **`/fast`** | Session-local OpenAI/Codex fast-mode toggle. Wraps Pi's native `openai-responses` and `openai-codex-responses` streamers and passes `serviceTier: "priority"` through provider options instead of patching raw payloads. |
 | **Cathedral approval modal** | Pattern-gated approval for dangerous bash commands. Default patterns cover `rm -rf`, `sudo`, `git push --force`, mutating `gh` calls. Configurable via `ApprovalGateConfig`. Modal height capped at 12 visible command rows. |
 | **Sidebar** | Three sections at width ≥ 120: context (token meter, session cost), MCP (server roster), memory (persisted bullets). Hidden in portrait orientation per [`SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md`](./docs/SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md). |
 | **Theme system** | Three first-party themes plus a chrome contract: each theme defines its own glyph set (`frame`, `sectionGlyphs`, `bullet`, `ruleChar`, `tabActive` / `tabInactive`) and an 8-frame working indicator. |
@@ -88,7 +89,7 @@ Reasoning is documented in [ADR 0001](./docs/adr/0001-sumo-tui-framework.md).
 
 ### The seam
 
-SumoTUI must initialise before Pi's `InteractiveMode` is constructed. Pi's public extension API does not expose that hook — it composes on top of the existing TUI rather than replacing it. SumoCode therefore carries a 36-line pnpm patch against `@earendil-works/pi-coding-agent`'s `dist/main.js` ([`patches/@earendil-works__pi-coding-agent@0.74.0.patch`](./patches/)):
+SumoTUI must initialise before Pi's `InteractiveMode` is constructed. Pi's public extension API does not expose that hook — it composes on top of the existing TUI rather than replacing it. SumoCode therefore carries a 36-line pnpm patch against `@earendil-works/pi-coding-agent`'s `dist/main.js` ([`patches/@earendil-works__pi-coding-agent@0.75.3.patch`](./patches/)):
 
 ```js
 const useSumoTui = isTruthyEnvFlag(process.env.SUMO_TUI) || parsed.unknownFlags.has("sumo-tui");
@@ -139,7 +140,7 @@ Sidebar docks at terminal width ≥ 120. Below 120, the sidebar disappears and p
 
 ```
 ┌──────────────────────────────────────────────────────────┐
-│  Pi  ·  @earendil-works/pi-coding-agent@0.74.0           │
+│  Pi  ·  @earendil-works/pi-coding-agent@0.75.3           │
 │   · LLM abstraction (pi-ai)                              │
 │   · agent loop + tools (pi-agent-core)                   │
 │   · sessions, compaction, auth, skills, MCP              │

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     ]
   },
   "peerDependencies": {
+    "@earendil-works/pi-ai": "~0.75.0",
     "@earendil-works/pi-coding-agent": "~0.75.0",
     "@earendil-works/pi-tui": "~0.75.0",
     "typebox": "*"

--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import { executeSumoSync, formatSyncResults, registerSumoSyncCommand } from "./sync.js";
+
+function ctx() {
+	return {
+		ui: { notify: vi.fn() },
+	};
+}
+
+describe("/sumo:sync", () => {
+	it("registers the slash command", () => {
+		const registerCommand = vi.fn();
+		registerSumoSyncCommand({ registerCommand } as never);
+		expect(registerCommand).toHaveBeenCalledWith(
+			"sumo:sync",
+			expect.objectContaining({ description: expect.stringContaining("Pull SumoCode") }),
+		);
+	});
+
+	it("pulls config, pulls source, then runs bootstrap", async () => {
+		const calls: Array<{ file: string; args: readonly string[]; cwd?: string }> = [];
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const context = ctx();
+		const results = await executeSumoSync(context as never, {
+			env: {},
+			homeDir: "/Users/test",
+			cwd: "/repo/sumocode/src",
+			moduleUrl: "file:///repo/sumocode/src/commands/sync.ts",
+			exists: (path) =>
+				[
+					"/Users/test/.pi/agent/settings.json",
+					"/repo/sumocode/package.json",
+					"/repo/sumocode/src/extension.ts",
+					"/repo/sumocode/.git",
+				].includes(path),
+			readFile: () => JSON.stringify({ name: "@dhruvkelawala/sumocode" }),
+			realpath: () => "/Users/test/sumocode-config/pi-agent/settings.json",
+			exec: async (file, args, options) => {
+				calls.push({ file, args, cwd: options.cwd });
+				return { stdout: "done", stderr: "" };
+			},
+		});
+
+		expect(results.map((step) => step.label)).toEqual([
+			"sumocode-config git pull",
+			"sumocode source git pull",
+			"sumocode-config bootstrap",
+		]);
+		expect(calls).toEqual([
+			{ file: "git", args: ["pull", "--ff-only"], cwd: "/Users/test/sumocode-config" },
+			{ file: "git", args: ["pull", "--ff-only"], cwd: "/repo/sumocode" },
+			{ file: "/Users/test/sumocode-config/bootstrap.sh", args: [], cwd: "/Users/test/sumocode-config" },
+		]);
+		expect(context.ui.notify).toHaveBeenLastCalledWith("SumoCode sync complete — run /sumo:reload if source changed", "info");
+		stdout.mockRestore();
+	});
+
+	it("reports the first failed step", async () => {
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const context = ctx();
+		await executeSumoSync(context as never, {
+			env: { SUMOCODE_CONFIG_DIR: "/config" },
+			cwd: "/tmp",
+			moduleUrl: "file:///repo/sumocode/src/commands/sync.ts",
+			exists: () => false,
+			exec: async (file) => {
+				if (file === "git") throw Object.assign(new Error("dirty tree"), { stderr: "local changes" });
+				return { stdout: "", stderr: "" };
+			},
+		});
+
+		expect(context.ui.notify).toHaveBeenLastCalledWith(
+			"/sumo:sync failed at sumocode-config git pull; inspect terminal output",
+			"warning",
+		);
+		stdout.mockRestore();
+	});
+
+	it("formats sync results for terminal output", () => {
+		expect(formatSyncResults([{ label: "step", ok: true, output: "Already up to date." }])).toBe(
+			"[ok] step\nAlready up to date.\n",
+		);
+	});
+});

--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -58,17 +58,20 @@ describe("/sumo:sync", () => {
 	it("reports the first failed step", async () => {
 		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 		const context = ctx();
-		await executeSumoSync(context as never, {
+		const exec = vi.fn(async (file: string) => {
+			if (file === "git") throw Object.assign(new Error("dirty tree"), { stderr: "local changes" });
+			return { stdout: "", stderr: "" };
+		});
+		const results = await executeSumoSync(context as never, {
 			env: { SUMOCODE_CONFIG_DIR: "/config" },
 			cwd: "/tmp",
 			moduleUrl: "file:///repo/sumocode/src/commands/sync.ts",
 			exists: () => false,
-			exec: async (file) => {
-				if (file === "git") throw Object.assign(new Error("dirty tree"), { stderr: "local changes" });
-				return { stdout: "", stderr: "" };
-			},
+			exec,
 		});
 
+		expect(results).toHaveLength(1);
+		expect(exec).toHaveBeenCalledTimes(1);
 		expect(context.ui.notify).toHaveBeenLastCalledWith(
 			"/sumo:sync failed at sumocode-config git pull; inspect terminal output",
 			"warning",

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,0 +1,151 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+
+const execFile = promisify(execFileCallback);
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+export interface SyncStepResult {
+	readonly label: string;
+	readonly ok: boolean;
+	readonly output: string;
+}
+
+export interface SumoSyncDeps {
+	readonly env?: NodeJS.ProcessEnv;
+	readonly cwd?: string;
+	readonly homeDir?: string;
+	readonly moduleUrl?: string;
+	readonly exists?: (path: string) => boolean;
+	readonly readFile?: (path: string, encoding: BufferEncoding) => string;
+	readonly realpath?: (path: string) => string;
+	readonly exec?: (file: string, args: readonly string[], options: { cwd?: string; timeout: number }) => Promise<{ stdout: string; stderr: string }>;
+}
+
+function moduleUrlToPath(moduleUrl: string): string {
+	return moduleUrl.startsWith("file:") ? fileURLToPath(moduleUrl) : moduleUrl;
+}
+
+function packageRootFromModule(moduleUrl: string): string {
+	// src/commands/sync.ts -> package root
+	return resolve(dirname(moduleUrlToPath(moduleUrl)), "..", "..");
+}
+
+function resolveConfigRepo(deps: SumoSyncDeps): string {
+	const env = deps.env ?? process.env;
+	const homeDir = deps.homeDir ?? homedir();
+	const exists = deps.exists ?? existsSync;
+	const realpath = deps.realpath ?? realpathSync;
+	if (env.SUMOCODE_CONFIG_DIR) return resolve(env.SUMOCODE_CONFIG_DIR);
+
+	const linkedSettings = join(homeDir, ".pi", "agent", "settings.json");
+	if (exists(linkedSettings)) {
+		try {
+			const resolvedSettings = realpath(linkedSettings);
+			return resolve(dirname(resolvedSettings), "..");
+		} catch {
+			// Fall through to conventional locations.
+		}
+	}
+
+	const candidates = [join(homeDir, "sumocode-config"), join(homeDir, "development", "sumocode-config")];
+	return candidates.find((candidate) => exists(join(candidate, "bootstrap.sh"))) ?? candidates[0];
+}
+
+function packageNameAt(dir: string, deps: SumoSyncDeps): string | undefined {
+	const exists = deps.exists ?? existsSync;
+	const readFile = deps.readFile ?? ((path, encoding) => readFileSync(path, encoding));
+	const packagePath = join(dir, "package.json");
+	if (!exists(packagePath)) return undefined;
+	try {
+		const parsed = JSON.parse(readFile(packagePath, "utf8")) as { name?: unknown };
+		return typeof parsed.name === "string" ? parsed.name : undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function findActiveSumoDevTree(cwd: string, deps: SumoSyncDeps): string | undefined {
+	const exists = deps.exists ?? existsSync;
+	let current = resolve(cwd);
+	while (true) {
+		const isSumocodePackage = packageNameAt(current, deps) === "@dhruvkelawala/sumocode";
+		if (isSumocodePackage && exists(join(current, "src", "extension.ts")) && exists(join(current, ".git"))) return current;
+		const parent = dirname(current);
+		if (parent === current) return undefined;
+		current = parent;
+	}
+}
+
+function resolveSumoCodeRepo(deps: SumoSyncDeps): string {
+	const cwd = deps.cwd ?? process.cwd();
+	const devTree = findActiveSumoDevTree(cwd, deps);
+	if (devTree) return devTree;
+	return packageRootFromModule(deps.moduleUrl ?? import.meta.url);
+}
+
+async function runStep(
+	label: string,
+	file: string,
+	args: readonly string[],
+	options: { cwd?: string; timeout?: number },
+	deps: SumoSyncDeps,
+): Promise<SyncStepResult> {
+	const run = deps.exec ?? execFile;
+	try {
+		const result = await run(file, args, { cwd: options.cwd, timeout: options.timeout ?? DEFAULT_TIMEOUT_MS });
+		return { label, ok: true, output: [result.stdout, result.stderr].filter(Boolean).join("\n").trim() };
+	} catch (error) {
+		const err = error as { stdout?: string; stderr?: string; message?: string };
+		return {
+			label,
+			ok: false,
+			output: [err.stdout, err.stderr, err.message].filter(Boolean).join("\n").trim(),
+		};
+	}
+}
+
+export async function executeSumoSync(ctx: ExtensionCommandContext, deps: SumoSyncDeps = {}): Promise<readonly SyncStepResult[]> {
+	const configRepo = resolveConfigRepo(deps);
+	const sumocodeRepo = resolveSumoCodeRepo(deps);
+	const steps: SyncStepResult[] = [];
+
+	ctx.ui.notify("syncing SumoCode config + extensions…", "info");
+	steps.push(await runStep("sumocode-config git pull", "git", ["pull", "--ff-only"], { cwd: configRepo }, deps));
+	steps.push(await runStep("sumocode source git pull", "git", ["pull", "--ff-only"], { cwd: sumocodeRepo }, deps));
+	steps.push(await runStep("sumocode-config bootstrap", join(configRepo, "bootstrap.sh"), [], { cwd: configRepo, timeout: 240_000 }, deps));
+
+	const failed = steps.filter((step) => !step.ok);
+	if (failed.length > 0) {
+		ctx.ui.notify(`/sumo:sync failed at ${failed[0]?.label}; inspect terminal output`, "warning");
+		process.stdout.write(formatSyncResults(steps));
+		return steps;
+	}
+
+	ctx.ui.notify("SumoCode sync complete — run /sumo:reload if source changed", "info");
+	process.stdout.write(formatSyncResults(steps));
+	return steps;
+}
+
+export function formatSyncResults(results: readonly SyncStepResult[]): string {
+	return `${results
+		.map((step) => {
+			const status = step.ok ? "ok" : "failed";
+			const output = step.output ? `\n${step.output}` : "";
+			return `[${status}] ${step.label}${output}`;
+		})
+		.join("\n\n")}\n`;
+}
+
+export function registerSumoSyncCommand(pi: ExtensionAPI, deps: SumoSyncDeps = {}): void {
+	pi.registerCommand("sumo:sync", {
+		description: "Pull SumoCode config/source, hydrate extensions, and update Pi packages",
+		handler: async (_args: string, ctx: ExtensionCommandContext) => {
+			await executeSumoSync(ctx, deps);
+		},
+	});
+}

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -115,9 +115,24 @@ export async function executeSumoSync(ctx: ExtensionCommandContext, deps: SumoSy
 	const steps: SyncStepResult[] = [];
 
 	ctx.ui.notify("syncing SumoCode config + extensions…", "info");
-	steps.push(await runStep("sumocode-config git pull", "git", ["pull", "--ff-only"], { cwd: configRepo }, deps));
-	steps.push(await runStep("sumocode source git pull", "git", ["pull", "--ff-only"], { cwd: sumocodeRepo }, deps));
-	steps.push(await runStep("sumocode-config bootstrap", join(configRepo, "bootstrap.sh"), [], { cwd: configRepo, timeout: 240_000 }, deps));
+
+	const plannedSteps = [
+		{ label: "sumocode-config git pull", file: "git", args: ["pull", "--ff-only"] as const, cwd: configRepo },
+		{ label: "sumocode source git pull", file: "git", args: ["pull", "--ff-only"] as const, cwd: sumocodeRepo },
+		{
+			label: "sumocode-config bootstrap",
+			file: join(configRepo, "bootstrap.sh"),
+			args: [] as const,
+			cwd: configRepo,
+			timeout: 240_000,
+		},
+	];
+
+	for (const step of plannedSteps) {
+		const result = await runStep(step.label, step.file, step.args, { cwd: step.cwd, timeout: step.timeout }, deps);
+		steps.push(result);
+		if (!result.ok) break;
+	}
 
 	const failed = steps.filter((step) => !step.ok);
 	if (failed.length > 0) {

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -20,6 +20,7 @@ function buildPiStub() {
 		registerCommand: vi.fn(),
 		registerShortcut: vi.fn(),
 		registerTool: vi.fn(),
+		registerProvider: vi.fn(),
 		registerMessageRenderer: vi.fn(),
 		sendMessage: vi.fn(),
 	};

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,7 @@ import { installSplash } from "./splash.js";
 import { installTopChrome } from "./top-chrome.js";
 import { installWorkingIndicator } from "./working-indicator.js";
 import { installCompactionIndicator } from "./compaction-indicator.js";
+import { installFastMode } from "./fast-mode.js";
 
 const SUMOCODE_PACKAGE_NAME = "@dhruvkelawala/sumocode";
 const LEGACY_TASK_TOOL_EXTENSION_PATH = join(".pi", "agent", "extensions", "task-tool", "index.ts");
@@ -158,8 +159,7 @@ export default function sumocode(pi: ExtensionAPI): void {
 	}
 	installQuestionTool(pi);
 	installAnswerTool(pi);
-
-
+	installFastMode(pi);
 
 	installWorkingIndicator(pi);
 	installCompactionIndicator(pi);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,7 +127,9 @@ export default function sumocode(pi: ExtensionAPI): void {
 	installAltscreen(pi);
 	installTopChrome(pi);
 	installSplash(pi);
-	installFooter(pi);
+	let requestFooterRender: (() => void) | undefined;
+	const fastModeState = installFastMode(pi, { onChange: () => requestFooterRender?.() });
+	requestFooterRender = installFooter(pi, { fastModeState });
 	installMemoryExtraction(pi);
 	installCathedralEditor(pi);
 	installInputHints(pi);
@@ -159,7 +161,6 @@ export default function sumocode(pi: ExtensionAPI): void {
 	}
 	installQuestionTool(pi);
 	installAnswerTool(pi);
-	installFastMode(pi);
 
 	installWorkingIndicator(pi);
 	installCompactionIndicator(pi);

--- a/src/fast-mode.test.ts
+++ b/src/fast-mode.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { Api, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
+import { buildOpenAICodexResponsesFastOptions, buildOpenAIResponsesFastOptions, isConfiguredFastModel, shouldApplyFastMode } from "./fast-mode.js";
+
+function model(overrides: Partial<Model<Api>> = {}): Model<Api> {
+	return {
+		provider: "openai-codex",
+		id: "gpt-5.5",
+		name: "GPT 5.5",
+		api: "openai-codex-responses",
+		baseUrl: "https://example.test",
+		maxTokens: 128_000,
+		reasoning: true,
+		thinkingLevelMap: {},
+		...overrides,
+	} as Model<Api>;
+}
+
+describe("fast mode", () => {
+	it("matches configured provider-qualified and bare model ids", () => {
+		const config = { enabled: true, models: ["openai/gpt-5.5", "gpt-5.4"] };
+		expect(isConfiguredFastModel(config, model({ provider: "openai", id: "gpt-5.5" }))).toBe(true);
+		expect(isConfiguredFastModel(config, model({ provider: "openai-codex", id: "gpt-5.4" }))).toBe(true);
+		expect(isConfiguredFastModel(config, model({ provider: "anthropic", id: "gpt-5.5" }))).toBe(false);
+	});
+
+	it("only applies to enabled OpenAI response APIs", () => {
+		const config = { enabled: true, models: ["openai-codex/gpt-5.5"] };
+		expect(shouldApplyFastMode(config, model())).toBe(true);
+		expect(shouldApplyFastMode({ ...config, enabled: false }, model())).toBe(false);
+		expect(shouldApplyFastMode(config, model({ api: "openai-completions" }))).toBe(false);
+	});
+
+	it("builds native OpenAI provider options with serviceTier, not payload patches", () => {
+		const options: SimpleStreamOptions = {
+			reasoning: "high",
+			temperature: 0.2,
+			maxTokens: 4096,
+			sessionId: "session-1",
+		};
+		expect(buildOpenAIResponsesFastOptions(model({ api: "openai-responses" }), options)).toMatchObject({
+			reasoningEffort: "high",
+			serviceTier: "priority",
+			temperature: 0.2,
+			maxTokens: 4096,
+			sessionId: "session-1",
+		});
+		expect(buildOpenAICodexResponsesFastOptions(model(), options)).toMatchObject({
+			reasoningEffort: "high",
+			serviceTier: "priority",
+		});
+	});
+});

--- a/src/fast-mode.test.ts
+++ b/src/fast-mode.test.ts
@@ -9,6 +9,7 @@ function model(overrides: Partial<Model<Api>> = {}): Model<Api> {
 		name: "GPT 5.5",
 		api: "openai-codex-responses",
 		baseUrl: "https://example.test",
+		contextWindow: 1_000_000,
 		maxTokens: 128_000,
 		reasoning: true,
 		thinkingLevelMap: {},
@@ -49,5 +50,42 @@ describe("fast mode", () => {
 			reasoningEffort: "high",
 			serviceTier: "priority",
 		});
+	});
+
+	it("preserves model maxTokens when below contextWindow (does not cap at 32k)", () => {
+		// Model with 64k maxTokens, 1M contextWindow → should keep 64k, not cap at 32k
+		const largeOutputModel = model({ api: "openai-responses", maxTokens: 64_000, contextWindow: 1_000_000 });
+		const result = buildOpenAIResponsesFastOptions(largeOutputModel, undefined);
+		expect(result.maxTokens).toBe(64_000);
+	});
+
+	it("caps maxTokens at 32k when maxTokens ≈ contextWindow (sentinel)", () => {
+		// Model where maxTokens == contextWindow → sentinel, cap at 32k
+		const sentinelModel = model({ api: "openai-responses", maxTokens: 200_000, contextWindow: 200_000 });
+		const result = buildOpenAIResponsesFastOptions(sentinelModel, undefined);
+		expect(result.maxTokens).toBe(32_000);
+	});
+
+	it("clamps unsupported reasoning levels via clampThinkingLevel", () => {
+		// Model whose thinkingLevelMap maps xhigh → max (supported)
+		const supportedModel = model({
+			api: "openai-responses",
+			thinkingLevelMap: { xhigh: "max" },
+		});
+		const result = buildOpenAIResponsesFastOptions(supportedModel, { reasoning: "xhigh" });
+		expect(result.reasoningEffort).toBe("xhigh");
+
+		// Model with empty thinkingLevelMap — xhigh is unsupported, should be clamped down
+		const unsupportedModel = model({
+			api: "openai-responses",
+			thinkingLevelMap: {},
+		});
+		const clamped = buildOpenAIResponsesFastOptions(unsupportedModel, { reasoning: "xhigh" });
+		expect(clamped.reasoningEffort).not.toBe("xhigh");
+	});
+
+	it("omits reasoning when not provided in options", () => {
+		const result = buildOpenAICodexResponsesFastOptions(model(), undefined);
+		expect(result.reasoningEffort).toBeUndefined();
 	});
 });

--- a/src/fast-mode.test.ts
+++ b/src/fast-mode.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { Api, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
-import { buildOpenAICodexResponsesFastOptions, buildOpenAIResponsesFastOptions, isConfiguredFastModel, shouldApplyFastMode } from "./fast-mode.js";
+import { buildOpenAICodexResponsesFastOptions, buildOpenAIResponsesFastOptions, installFastMode, isConfiguredFastModel, shouldApplyFastMode } from "./fast-mode.js";
 
 function model(overrides: Partial<Model<Api>> = {}): Model<Api> {
 	return {
@@ -104,5 +104,25 @@ describe("fast mode", () => {
 			{ reasoning: "medium" },
 		);
 		expect(codexResult.reasoningEffort).toBeUndefined();
+	});
+
+	it("resets enabled state on each session_start", async () => {
+		const handlers = new Map<string, Array<(...args: unknown[]) => unknown>>();
+		const pi = {
+			on: vi.fn((event: string, handler: (...args: unknown[]) => unknown) => {
+				const list = handlers.get(event) ?? [];
+				list.push(handler);
+				handlers.set(event, list);
+			}),
+			registerCommand: vi.fn(),
+			registerProvider: vi.fn(),
+		};
+		const state = installFastMode(pi as never, { initialEnabled: true });
+		expect(state.enabled).toBe(true);
+
+		for (const handler of handlers.get("session_start") ?? []) {
+			await handler({}, { model: model() });
+		}
+		expect(state.enabled).toBe(false);
 	});
 });

--- a/src/fast-mode.test.ts
+++ b/src/fast-mode.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it, vi } from "vitest";
-import type { Api, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getApiProvider, resetApiProviders, type Api, type Model, type SimpleStreamOptions } from "@earendil-works/pi-ai";
 import { buildOpenAICodexResponsesFastOptions, buildOpenAIResponsesFastOptions, installFastMode, isConfiguredFastModel, shouldApplyFastMode } from "./fast-mode.js";
 
 function model(overrides: Partial<Model<Api>> = {}): Model<Api> {
@@ -16,6 +16,10 @@ function model(overrides: Partial<Model<Api>> = {}): Model<Api> {
 		...overrides,
 	} as Model<Api>;
 }
+
+afterEach(() => {
+	resetApiProviders();
+});
 
 describe("fast mode", () => {
 	it("matches configured provider-qualified and bare model ids", () => {
@@ -106,28 +110,27 @@ describe("fast mode", () => {
 		expect(codexResult.reasoningEffort).toBeUndefined();
 	});
 
-	it("delegates unsupported OpenAI APIs to Pi's native simple stream", () => {
-		const fallbackStream = {};
-		const streamUnsupportedApi = vi.fn(() => fallbackStream as never);
-		const registerProvider = vi.fn();
+	it("leaves non-Responses OpenAI APIs on their native simple stream", () => {
+		const nativeOpenAICompletions = getApiProvider("openai-completions")?.streamSimple;
 		installFastMode({
 			on: vi.fn(),
 			registerCommand: vi.fn(),
-			registerProvider,
-		} as never, {
-			initialEnabled: true,
-			streamers: { streamUnsupportedApi },
-		});
+		} as never, { initialEnabled: true });
 
-		const openAIProvider = registerProvider.mock.calls.find(([provider]) => provider === "openai")?.[1];
-		const unsupportedModel = model({ provider: "openai", id: "gpt-legacy", api: "openai-completions" });
-		const context = {} as never;
-		const options = { maxTokens: 123 };
+		expect(getApiProvider("openai-completions")?.streamSimple).toBe(nativeOpenAICompletions);
+	});
 
-		const result = openAIProvider.streamSimple(unsupportedModel, context, options);
+	it("registers API wrappers without overriding provider defaults", () => {
+		const pi = {
+			on: vi.fn(),
+			registerCommand: vi.fn(),
+			registerProvider: vi.fn(),
+		};
+		installFastMode(pi as never);
 
-		expect(result).toBe(fallbackStream);
-		expect(streamUnsupportedApi).toHaveBeenCalledWith(unsupportedModel, context, options);
+		expect(pi.registerProvider).not.toHaveBeenCalled();
+		expect(getApiProvider("openai-responses")?.streamSimple).toBeDefined();
+		expect(getApiProvider("openai-codex-responses")?.streamSimple).toBeDefined();
 	});
 
 	it("resets enabled state on each session_start", async () => {

--- a/src/fast-mode.test.ts
+++ b/src/fast-mode.test.ts
@@ -88,4 +88,21 @@ describe("fast mode", () => {
 		const result = buildOpenAICodexResponsesFastOptions(model(), undefined);
 		expect(result.reasoningEffort).toBeUndefined();
 	});
+
+	it("converts clamped 'off' reasoning to undefined (matches Pi native path)", () => {
+		// Model that only supports "off" — clampThinkingLevel will return "off"
+		// for any input, and fast mode must convert that to undefined
+		const offOnlyModel = model({
+			api: "openai-responses",
+			thinkingLevelMap: { off: null, minimal: null, low: null, medium: null, high: null, xhigh: null },
+		});
+		const result = buildOpenAIResponsesFastOptions(offOnlyModel, { reasoning: "high" });
+		expect(result.reasoningEffort).toBeUndefined();
+
+		const codexResult = buildOpenAICodexResponsesFastOptions(
+			{ ...offOnlyModel, api: "openai-codex-responses" } as typeof offOnlyModel,
+			{ reasoning: "medium" },
+		);
+		expect(codexResult.reasoningEffort).toBeUndefined();
+	});
 });

--- a/src/fast-mode.test.ts
+++ b/src/fast-mode.test.ts
@@ -106,6 +106,30 @@ describe("fast mode", () => {
 		expect(codexResult.reasoningEffort).toBeUndefined();
 	});
 
+	it("delegates unsupported OpenAI APIs to Pi's native simple stream", () => {
+		const fallbackStream = {};
+		const streamUnsupportedApi = vi.fn(() => fallbackStream as never);
+		const registerProvider = vi.fn();
+		installFastMode({
+			on: vi.fn(),
+			registerCommand: vi.fn(),
+			registerProvider,
+		} as never, {
+			initialEnabled: true,
+			streamers: { streamUnsupportedApi },
+		});
+
+		const openAIProvider = registerProvider.mock.calls.find(([provider]) => provider === "openai")?.[1];
+		const unsupportedModel = model({ provider: "openai", id: "gpt-legacy", api: "openai-completions" });
+		const context = {} as never;
+		const options = { maxTokens: 123 };
+
+		const result = openAIProvider.streamSimple(unsupportedModel, context, options);
+
+		expect(result).toBe(fallbackStream);
+		expect(streamUnsupportedApi).toHaveBeenCalledWith(unsupportedModel, context, options);
+	});
+
 	it("resets enabled state on each session_start", async () => {
 		const handlers = new Map<string, Array<(...args: unknown[]) => unknown>>();
 		const pi = {

--- a/src/fast-mode.ts
+++ b/src/fast-mode.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@e
 import {
 	clampThinkingLevel,
 	getApiProvider,
+	registerApiProvider,
 	streamOpenAICodexResponses,
 	streamOpenAIResponses,
 	streamSimpleOpenAICodexResponses,
@@ -24,6 +25,8 @@ const DEFAULT_FAST_MODELS = [
 	"openai-codex/gpt-5.4",
 	"openai-codex/gpt-5.5",
 ];
+const OPENAI_RESPONSES_FAST_SOURCE = "sumocode:fast-mode:openai-responses";
+const OPENAI_CODEX_RESPONSES_FAST_SOURCE = "sumocode:fast-mode:openai-codex-responses";
 
 type FastModeConfig = {
 	enabled: boolean;
@@ -180,19 +183,28 @@ export function installFastMode(
 		models: DEFAULT_FAST_MODELS,
 	};
 	let currentModel: FastModeModel | undefined;
+	const nativeOpenAIResponses = getApiProvider("openai-responses");
+	const nativeOpenAICodexResponses = getApiProvider("openai-codex-responses");
 	const streamSimple = createFastModeStream(
 		() => state,
-		{ ...DEFAULT_STREAMERS, ...options.streamers },
+		{
+			...DEFAULT_STREAMERS,
+			streamSimpleOpenAIResponses: nativeOpenAIResponses?.streamSimple ?? DEFAULT_STREAMERS.streamSimpleOpenAIResponses,
+			streamSimpleOpenAICodexResponses: nativeOpenAICodexResponses?.streamSimple ?? DEFAULT_STREAMERS.streamSimpleOpenAICodexResponses,
+			...options.streamers,
+		},
 	);
 
-	pi.registerProvider("openai", {
+	registerApiProvider({
 		api: "openai-responses",
+		stream: nativeOpenAIResponses?.stream ?? ((model, context, streamOptions) => streamOpenAIResponses(model as Model<"openai-responses">, context, streamOptions as OpenAIResponsesOptions | undefined)),
 		streamSimple,
-	});
-	pi.registerProvider("openai-codex", {
+	}, OPENAI_RESPONSES_FAST_SOURCE);
+	registerApiProvider({
 		api: "openai-codex-responses",
+		stream: nativeOpenAICodexResponses?.stream ?? ((model, context, streamOptions) => streamOpenAICodexResponses(model as Model<"openai-codex-responses">, context, streamOptions as OpenAICodexResponsesOptions | undefined)),
 		streamSimple,
-	});
+	}, OPENAI_CODEX_RESPONSES_FAST_SOURCE);
 
 	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
 		state.enabled = false;

--- a/src/fast-mode.ts
+++ b/src/fast-mode.ts
@@ -1,5 +1,6 @@
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
+	clampThinkingLevel,
 	streamOpenAICodexResponses,
 	streamOpenAIResponses,
 	streamSimpleOpenAICodexResponses,
@@ -11,7 +12,6 @@ import {
 	type OpenAICodexResponsesOptions,
 	type OpenAIResponsesOptions,
 	type SimpleStreamOptions,
-	type ThinkingLevel,
 } from "@earendil-works/pi-ai";
 
 const SERVICE_TIER = "priority";
@@ -29,7 +29,7 @@ type FastModeConfig = {
 	models: readonly string[];
 };
 
-type FastModeModel = Pick<Model<Api>, "provider" | "id" | "api" | "maxTokens" | "thinkingLevelMap">;
+type FastModeModel = Pick<Model<Api>, "provider" | "id" | "api" | "maxTokens" | "contextWindow" | "thinkingLevelMap">;
 
 type FastModeStreamers = {
 	streamOpenAIResponses: typeof streamOpenAIResponses;
@@ -69,18 +69,24 @@ export function shouldApplyFastMode(config: FastModeConfig, model: FastModeModel
 	return config.enabled && isConfiguredFastModel(config, model) && SUPPORTED_APIS.has(model?.api ?? "");
 }
 
-function defaultMaxTokens(model: Pick<Model<Api>, "maxTokens">): number | undefined {
-	return model.maxTokens > 0 ? Math.min(model.maxTokens, 32_000) : undefined;
+const DEFAULT_MAX_OUTPUT_TOKENS = 32_000;
+const CONTEXT_WINDOW_OUTPUT_TOLERANCE = 1024;
+
+/**
+ * Match Pi's native `buildBaseOptions` default-maxTokens logic:
+ * only cap at 32k when `maxTokens >= contextWindow - tolerance` (sentinel
+ * meaning "context window IS the output limit"). Otherwise preserve the
+ * model's own maxTokens so 64k/128k output budgets are not silently reduced.
+ */
+function defaultMaxTokens(model: Pick<Model<Api>, "maxTokens" | "contextWindow">): number | undefined {
+	if (model.maxTokens <= 0) return undefined;
+	if (model.maxTokens >= model.contextWindow - CONTEXT_WINDOW_OUTPUT_TOLERANCE) {
+		return Math.min(model.maxTokens, DEFAULT_MAX_OUTPUT_TOKENS);
+	}
+	return model.maxTokens;
 }
 
-function mapReasoningEffort(model: FastModeModel, reasoning: ThinkingLevel | undefined): ThinkingLevel | undefined {
-	if (!reasoning) return undefined;
-	const mapped = model.thinkingLevelMap?.[reasoning];
-	if (mapped === null) return undefined;
-	return reasoning;
-}
-
-function buildBaseProviderOptions(model: Pick<Model<Api>, "maxTokens">, options: SimpleStreamOptions | undefined) {
+function buildBaseProviderOptions(model: Pick<Model<Api>, "maxTokens" | "contextWindow">, options: SimpleStreamOptions | undefined) {
 	return {
 		temperature: options?.temperature,
 		maxTokens: options?.maxTokens ?? defaultMaxTokens(model),
@@ -100,17 +106,19 @@ function buildBaseProviderOptions(model: Pick<Model<Api>, "maxTokens">, options:
 }
 
 export function buildOpenAIResponsesFastOptions(model: Model<Api>, options: SimpleStreamOptions | undefined): OpenAIResponsesOptions {
+	const clamped = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;
 	return {
 		...buildBaseProviderOptions(model, options),
-		reasoningEffort: mapReasoningEffort(model, options?.reasoning) as OpenAIResponsesOptions["reasoningEffort"],
+		reasoningEffort: clamped as OpenAIResponsesOptions["reasoningEffort"],
 		serviceTier: SERVICE_TIER,
 	};
 }
 
 export function buildOpenAICodexResponsesFastOptions(model: Model<Api>, options: SimpleStreamOptions | undefined): OpenAICodexResponsesOptions {
+	const clamped = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;
 	return {
 		...buildBaseProviderOptions(model, options),
-		reasoningEffort: mapReasoningEffort(model, options?.reasoning) as OpenAICodexResponsesOptions["reasoningEffort"],
+		reasoningEffort: clamped as OpenAICodexResponsesOptions["reasoningEffort"],
 		serviceTier: SERVICE_TIER,
 	};
 }

--- a/src/fast-mode.ts
+++ b/src/fast-mode.ts
@@ -183,6 +183,7 @@ export function installFastMode(pi: ExtensionAPI, options: { streamers?: Partial
 	});
 
 	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
+		state.enabled = false;
 		currentModel = ctx.model as FastModeModel | undefined;
 	});
 	pi.on("model_select", async (event) => {

--- a/src/fast-mode.ts
+++ b/src/fast-mode.ts
@@ -105,20 +105,29 @@ function buildBaseProviderOptions(model: Pick<Model<Api>, "maxTokens" | "context
 	};
 }
 
+/**
+ * Clamp reasoning and convert "off" → undefined to match Pi's native
+ * streamSimple* path. OpenAI Responses does not accept "off" as a valid
+ * reasoning effort — Pi drops it before calling the provider stream.
+ */
+function clampReasoning(model: Model<Api>, reasoning: SimpleStreamOptions["reasoning"]): OpenAIResponsesOptions["reasoningEffort"] {
+	if (!reasoning) return undefined;
+	const clamped = clampThinkingLevel(model, reasoning);
+	return (clamped === "off" ? undefined : clamped) as OpenAIResponsesOptions["reasoningEffort"];
+}
+
 export function buildOpenAIResponsesFastOptions(model: Model<Api>, options: SimpleStreamOptions | undefined): OpenAIResponsesOptions {
-	const clamped = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;
 	return {
 		...buildBaseProviderOptions(model, options),
-		reasoningEffort: clamped as OpenAIResponsesOptions["reasoningEffort"],
+		reasoningEffort: clampReasoning(model, options?.reasoning),
 		serviceTier: SERVICE_TIER,
 	};
 }
 
 export function buildOpenAICodexResponsesFastOptions(model: Model<Api>, options: SimpleStreamOptions | undefined): OpenAICodexResponsesOptions {
-	const clamped = options?.reasoning ? clampThinkingLevel(model, options.reasoning) : undefined;
 	return {
 		...buildBaseProviderOptions(model, options),
-		reasoningEffort: clamped as OpenAICodexResponsesOptions["reasoningEffort"],
+		reasoningEffort: clampReasoning(model, options?.reasoning) as OpenAICodexResponsesOptions["reasoningEffort"],
 		serviceTier: SERVICE_TIER,
 	};
 }

--- a/src/fast-mode.ts
+++ b/src/fast-mode.ts
@@ -1,0 +1,195 @@
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+	streamOpenAICodexResponses,
+	streamOpenAIResponses,
+	streamSimpleOpenAICodexResponses,
+	streamSimpleOpenAIResponses,
+	type Api,
+	type AssistantMessageEventStream,
+	type Context,
+	type Model,
+	type OpenAICodexResponsesOptions,
+	type OpenAIResponsesOptions,
+	type SimpleStreamOptions,
+	type ThinkingLevel,
+} from "@earendil-works/pi-ai";
+
+const SERVICE_TIER = "priority";
+const SUPPORTED_PROVIDERS = new Set(["openai", "openai-codex"]);
+const SUPPORTED_APIS = new Set(["openai-responses", "openai-codex-responses"]);
+const DEFAULT_FAST_MODELS = [
+	"openai/gpt-5.4",
+	"openai/gpt-5.5",
+	"openai-codex/gpt-5.4",
+	"openai-codex/gpt-5.5",
+];
+
+type FastModeConfig = {
+	enabled: boolean;
+	models: readonly string[];
+};
+
+type FastModeModel = Pick<Model<Api>, "provider" | "id" | "api" | "maxTokens" | "thinkingLevelMap">;
+
+type FastModeStreamers = {
+	streamOpenAIResponses: typeof streamOpenAIResponses;
+	streamSimpleOpenAIResponses: typeof streamSimpleOpenAIResponses;
+	streamOpenAICodexResponses: typeof streamOpenAICodexResponses;
+	streamSimpleOpenAICodexResponses: typeof streamSimpleOpenAICodexResponses;
+};
+
+export type FastModeState = {
+	enabled: boolean;
+	models: readonly string[];
+};
+
+const DEFAULT_STREAMERS: FastModeStreamers = {
+	streamOpenAIResponses,
+	streamSimpleOpenAIResponses,
+	streamOpenAICodexResponses,
+	streamSimpleOpenAICodexResponses,
+};
+
+function normalizeModelRef(ref: string): string {
+	return ref.trim().toLowerCase();
+}
+
+export function isConfiguredFastModel(config: FastModeConfig, model: FastModeModel | undefined): boolean {
+	if (!model) return false;
+	if (!SUPPORTED_PROVIDERS.has(model.provider)) return false;
+	const bare = normalizeModelRef(model.id);
+	const full = normalizeModelRef(`${model.provider}/${model.id}`);
+	return config.models.some((entry) => {
+		const normalized = normalizeModelRef(entry);
+		return normalized === bare || normalized === full;
+	});
+}
+
+export function shouldApplyFastMode(config: FastModeConfig, model: FastModeModel | undefined): boolean {
+	return config.enabled && isConfiguredFastModel(config, model) && SUPPORTED_APIS.has(model?.api ?? "");
+}
+
+function defaultMaxTokens(model: Pick<Model<Api>, "maxTokens">): number | undefined {
+	return model.maxTokens > 0 ? Math.min(model.maxTokens, 32_000) : undefined;
+}
+
+function mapReasoningEffort(model: FastModeModel, reasoning: ThinkingLevel | undefined): ThinkingLevel | undefined {
+	if (!reasoning) return undefined;
+	const mapped = model.thinkingLevelMap?.[reasoning];
+	if (mapped === null) return undefined;
+	return reasoning;
+}
+
+function buildBaseProviderOptions(model: Pick<Model<Api>, "maxTokens">, options: SimpleStreamOptions | undefined) {
+	return {
+		temperature: options?.temperature,
+		maxTokens: options?.maxTokens ?? defaultMaxTokens(model),
+		signal: options?.signal,
+		apiKey: options?.apiKey,
+		transport: options?.transport,
+		cacheRetention: options?.cacheRetention,
+		sessionId: options?.sessionId,
+		onPayload: options?.onPayload,
+		onResponse: options?.onResponse,
+		headers: options?.headers,
+		timeoutMs: options?.timeoutMs,
+		maxRetries: options?.maxRetries,
+		maxRetryDelayMs: options?.maxRetryDelayMs,
+		metadata: options?.metadata,
+	};
+}
+
+export function buildOpenAIResponsesFastOptions(model: Model<Api>, options: SimpleStreamOptions | undefined): OpenAIResponsesOptions {
+	return {
+		...buildBaseProviderOptions(model, options),
+		reasoningEffort: mapReasoningEffort(model, options?.reasoning) as OpenAIResponsesOptions["reasoningEffort"],
+		serviceTier: SERVICE_TIER,
+	};
+}
+
+export function buildOpenAICodexResponsesFastOptions(model: Model<Api>, options: SimpleStreamOptions | undefined): OpenAICodexResponsesOptions {
+	return {
+		...buildBaseProviderOptions(model, options),
+		reasoningEffort: mapReasoningEffort(model, options?.reasoning) as OpenAICodexResponsesOptions["reasoningEffort"],
+		serviceTier: SERVICE_TIER,
+	};
+}
+
+function createFastModeStream(config: () => FastModeConfig, streamers: FastModeStreamers) {
+	return (model: Model<Api>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream => {
+		const currentConfig = config();
+		if (model.api === "openai-responses") {
+			return shouldApplyFastMode(currentConfig, model)
+				? streamers.streamOpenAIResponses(model as Model<"openai-responses">, context, buildOpenAIResponsesFastOptions(model, options))
+				: streamers.streamSimpleOpenAIResponses(model as Model<"openai-responses">, context, options);
+		}
+		if (model.api === "openai-codex-responses") {
+			return shouldApplyFastMode(currentConfig, model)
+				? streamers.streamOpenAICodexResponses(model as Model<"openai-codex-responses">, context, buildOpenAICodexResponsesFastOptions(model, options))
+				: streamers.streamSimpleOpenAICodexResponses(model as Model<"openai-codex-responses">, context, options);
+		}
+		throw new Error(`sumocode fast mode: unsupported API override ${String(model.api)}`);
+	};
+}
+
+function describeFastMode(state: FastModeState, model: FastModeModel | undefined): string {
+	const stateText = state.enabled ? "ON" : "OFF";
+	if (!model) return `Fast mode ${stateText}. No model selected.`;
+	const modelKey = `${model.provider}/${model.id}`;
+	if (shouldApplyFastMode(state, model)) return `Fast mode ${stateText}. Applying ${SERVICE_TIER} service tier to ${modelKey}.`;
+	if (state.enabled && !isConfiguredFastModel(state, model)) return `Fast mode ${stateText}, inactive for unsupported model ${modelKey}.`;
+	return `Fast mode ${stateText}. Current model: ${modelKey}.`;
+}
+
+function notify(ctx: Pick<ExtensionCommandContext, "hasUI" | "ui">, message: string, level: "info" | "warning" | "error"): void {
+	if (ctx.hasUI) ctx.ui.notify(message, level);
+}
+
+export function installFastMode(pi: ExtensionAPI, options: { streamers?: Partial<FastModeStreamers>; initialEnabled?: boolean } = {}): FastModeState {
+	const state: FastModeState = {
+		enabled: options.initialEnabled ?? false,
+		models: DEFAULT_FAST_MODELS,
+	};
+	let currentModel: FastModeModel | undefined;
+	const streamSimple = createFastModeStream(
+		() => state,
+		{ ...DEFAULT_STREAMERS, ...options.streamers },
+	);
+
+	pi.registerProvider("openai", {
+		api: "openai-responses",
+		streamSimple,
+	});
+	pi.registerProvider("openai-codex", {
+		api: "openai-codex-responses",
+		streamSimple,
+	});
+
+	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
+		currentModel = ctx.model as FastModeModel | undefined;
+	});
+	pi.on("model_select", async (event) => {
+		currentModel = event.model as FastModeModel;
+	});
+
+	pi.registerCommand("fast", {
+		description: "Toggle OpenAI/Codex fast mode",
+		handler: async (args, ctx) => {
+			currentModel = ctx.model as FastModeModel | undefined;
+			const arg = args.trim().toLowerCase();
+			if (!arg || arg === "toggle") state.enabled = !state.enabled;
+			else if (arg === "on") state.enabled = true;
+			else if (arg === "off") state.enabled = false;
+			else if (arg === "status") {
+				notify(ctx, describeFastMode(state, currentModel), "info");
+				return;
+			} else {
+				notify(ctx, "Usage: /fast [on|off|toggle|status]", "error");
+				return;
+			}
+			notify(ctx, describeFastMode(state, currentModel), state.enabled ? "warning" : "info");
+		},
+	});
+
+	return state;
+}

--- a/src/fast-mode.ts
+++ b/src/fast-mode.ts
@@ -1,6 +1,7 @@
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import {
 	clampThinkingLevel,
+	getApiProvider,
 	streamOpenAICodexResponses,
 	streamOpenAIResponses,
 	streamSimpleOpenAICodexResponses,
@@ -36,6 +37,7 @@ type FastModeStreamers = {
 	streamSimpleOpenAIResponses: typeof streamSimpleOpenAIResponses;
 	streamOpenAICodexResponses: typeof streamOpenAICodexResponses;
 	streamSimpleOpenAICodexResponses: typeof streamSimpleOpenAICodexResponses;
+	streamUnsupportedApi: (model: Model<Api>, context: Context, options?: SimpleStreamOptions) => AssistantMessageEventStream;
 };
 
 export type FastModeState = {
@@ -43,11 +45,18 @@ export type FastModeState = {
 	models: readonly string[];
 };
 
+function streamNativeApiProvider(model: Model<Api>, context: Context, options?: SimpleStreamOptions): AssistantMessageEventStream {
+	const provider = getApiProvider(model.api);
+	if (!provider) throw new Error(`sumocode fast mode: unsupported API override ${String(model.api)}`);
+	return provider.streamSimple(model, context, options);
+}
+
 const DEFAULT_STREAMERS: FastModeStreamers = {
 	streamOpenAIResponses,
 	streamSimpleOpenAIResponses,
 	streamOpenAICodexResponses,
 	streamSimpleOpenAICodexResponses,
+	streamUnsupportedApi: streamNativeApiProvider,
 };
 
 function normalizeModelRef(ref: string): string {
@@ -145,7 +154,7 @@ function createFastModeStream(config: () => FastModeConfig, streamers: FastModeS
 				? streamers.streamOpenAICodexResponses(model as Model<"openai-codex-responses">, context, buildOpenAICodexResponsesFastOptions(model, options))
 				: streamers.streamSimpleOpenAICodexResponses(model as Model<"openai-codex-responses">, context, options);
 		}
-		throw new Error(`sumocode fast mode: unsupported API override ${String(model.api)}`);
+		return streamers.streamUnsupportedApi(model, context, options);
 	};
 }
 

--- a/src/fast-mode.ts
+++ b/src/fast-mode.ts
@@ -162,7 +162,10 @@ function notify(ctx: Pick<ExtensionCommandContext, "hasUI" | "ui">, message: str
 	if (ctx.hasUI) ctx.ui.notify(message, level);
 }
 
-export function installFastMode(pi: ExtensionAPI, options: { streamers?: Partial<FastModeStreamers>; initialEnabled?: boolean } = {}): FastModeState {
+export function installFastMode(
+	pi: ExtensionAPI,
+	options: { streamers?: Partial<FastModeStreamers>; initialEnabled?: boolean; onChange?: () => void } = {},
+): FastModeState {
 	const state: FastModeState = {
 		enabled: options.initialEnabled ?? false,
 		models: DEFAULT_FAST_MODELS,
@@ -185,6 +188,7 @@ export function installFastMode(pi: ExtensionAPI, options: { streamers?: Partial
 	pi.on("session_start", async (_event, ctx: ExtensionContext) => {
 		state.enabled = false;
 		currentModel = ctx.model as FastModeModel | undefined;
+		options.onChange?.();
 	});
 	pi.on("model_select", async (event) => {
 		currentModel = event.model as FastModeModel;
@@ -205,6 +209,7 @@ export function installFastMode(pi: ExtensionAPI, options: { streamers?: Partial
 				notify(ctx, "Usage: /fast [on|off|toggle|status]", "error");
 				return;
 			}
+			options.onChange?.();
 			notify(ctx, describeFastMode(state, currentModel), state.enabled ? "warning" : "info");
 		},
 	});

--- a/src/footer.test.ts
+++ b/src/footer.test.ts
@@ -210,7 +210,7 @@ describe("formatFooterLine — F1 two-zone layout", () => {
 		}
 	});
 
-	it("appends fast after thinking when openai-codex fast mode is active", () => {
+	it("appends fast after thinking when fast mode applies", () => {
 		const line = withoutAnsi(formatFooterLine(snapshot({ modelId: "gpt-5.5", thinkingLevel: "high", showFastMode: true })));
 		expect(line).toContain("gpt-5.5");
 		expect(line).toContain("high");

--- a/src/footer.test.ts
+++ b/src/footer.test.ts
@@ -210,6 +210,20 @@ describe("formatFooterLine — F1 two-zone layout", () => {
 		}
 	});
 
+	it("appends fast after thinking when openai-codex fast mode is active", () => {
+		const line = withoutAnsi(formatFooterLine(snapshot({ modelId: "gpt-5.5", thinkingLevel: "high", showFastMode: true })));
+		expect(line).toContain("gpt-5.5");
+		expect(line).toContain("high");
+		expect(line).toContain("fast");
+		expect(line.indexOf("high")).toBeLessThan(line.indexOf("fast"));
+	});
+
+	it("omits fast label when showFastMode is false", () => {
+		const line = withoutAnsi(formatFooterLine(snapshot({ thinkingLevel: "high", showFastMode: false })));
+		expect(line).toContain("high");
+		expect(line).not.toContain("fast");
+	});
+
 	it("omits project and git branch to avoid duplicating sidebar/hint row", () => {
 		const line = withoutAnsi(formatFooterLine(snapshot()));
 

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -9,6 +9,7 @@ import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
  * as a direct dep. Mirrors the upstream definition exactly.
  */
 export type ThinkingLevel = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+import { shouldApplyFastMode, type FastModeState } from "./fast-mode.js";
 import { getSessionUsage as getCachedSessionUsage, sessionHasMessages as cachedSessionHasMessages, linkGitBranchProvider } from "./session-cache.js";
 import { activeThemeColors, type SumoCodeState } from "./themes/index.js";
 import { VOICE } from "./voice.js";
@@ -30,6 +31,8 @@ export type FooterSnapshot = {
 	state: SumoCodeState;
 	modelId: string;
 	thinkingLevel: ThinkingLevel;
+	/** When true, append a `fast` label after thinking (openai-codex + active fast mode). */
+	showFastMode?: boolean;
 	/**
 	 * When true, an additional dim version line is rendered below the main
 	 * footer row. Per Q5.2, this only happens on the splash empty state.
@@ -91,7 +94,7 @@ export function resolveGitBranch(cwd: string, runGit: GitRunner = defaultGitRunn
 /**
  * F1 two-zone footer layout (Element 5 from CATHEDRAL_DECISIONS.md).
  *
- *   left zone  = agent state:    ● <STATE> · <model> · <thinking>
+ *   left zone  = agent state:    ● <STATE> · <model> · <thinking> [· fast]
  *   right zone = session metrics: <ctx>/<window> · $<cost>
  *
  * Zones are separated by spaces sized to fill width. Project/branch are not
@@ -119,7 +122,9 @@ function formatFooterLineInner(snapshot: FooterSnapshot, width: number): string 
 	const thinking = colorHex(snapshot.thinkingLevel, activeThemeColors().foreground);
 	const sep = colorHex(" · ", activeThemeColors().foregroundDim);
 
-	const leftZone = [`${dot} ${stateLabel}`, model, thinking].join(sep);
+	const leftParts = [`${dot} ${stateLabel}`, model, thinking];
+	if (snapshot.showFastMode) leftParts.push(colorHex("fast", activeThemeColors().foreground));
+	const leftZone = leftParts.join(sep);
 	const leftLen = visibleWidth(leftZone);
 
 	const contextTokens = snapshot.contextTokens ?? snapshot.inputTokens + snapshot.outputTokens;
@@ -187,7 +192,7 @@ export function renderFooterBlock(snapshot: FooterSnapshot, width = 160): string
 	];
 }
 
-export function installFooter(pi: ExtensionAPI): void {
+export function installFooter(pi: ExtensionAPI, options: { fastModeState?: FastModeState } = {}): () => void {
 	let state: SumoCodeState = "idle";
 	let render: (() => void) | undefined;
 	let activeCtx: ExtensionContext | undefined;
@@ -226,7 +231,7 @@ export function installFooter(pi: ExtensionAPI): void {
 					const renderCtx = resolveRenderContext(activeCtx, ctx);
 					const branchProvider = activeFooterData ?? footerData;
 					const branch = safeRead(() => branchProvider.getGitBranch(), null);
-					return renderFooterBlock(createSnapshot(pi, renderCtx, branch, state), width);
+					return renderFooterBlock(createSnapshot(pi, renderCtx, branch, state, options.fastModeState), width);
 				},
 			};
 		});
@@ -237,6 +242,9 @@ export function installFooter(pi: ExtensionAPI): void {
 	pi.on("tool_call", () => setState("tool"));
 	pi.on("tool_result", () => setState("thinking"));
 	pi.on("agent_end", () => setState("idle"));
+	pi.on("model_select", () => render?.());
+
+	return () => render?.();
 }
 
 
@@ -252,7 +260,13 @@ function resolveRenderContext(...candidates: Array<ExtensionContext | undefined>
 	return undefined;
 }
 
-function createSnapshot(pi: ExtensionAPI, ctx: ExtensionContext | undefined, branch: string | null, state: SumoCodeState): FooterSnapshot {
+function createSnapshot(
+	pi: ExtensionAPI,
+	ctx: ExtensionContext | undefined,
+	branch: string | null,
+	state: SumoCodeState,
+	fastModeState?: FastModeState,
+): FooterSnapshot {
 	if (!ctx) {
 		return {
 			cwd: "",
@@ -265,11 +279,13 @@ function createSnapshot(pi: ExtensionAPI, ctx: ExtensionContext | undefined, bra
 			state,
 			modelId: "no-model",
 			thinkingLevel: "medium",
+			showFastMode: false,
 			isSplash: false,
 		};
 	}
 
 	const usage = getSessionUsage(ctx);
+	const model = safeRead(() => ctx.model, undefined);
 
 	return {
 		cwd: safeRead(() => ctx.cwd, ""),
@@ -280,10 +296,16 @@ function createSnapshot(pi: ExtensionAPI, ctx: ExtensionContext | undefined, bra
 		contextWindow: getContextWindow(ctx),
 		costUsd: usage.cost,
 		state,
-		modelId: safeRead(() => ctx.model?.id, undefined) ?? "no-model",
+		modelId: model?.id ?? "no-model",
 		thinkingLevel: getThinkingLevel(pi, ctx),
+		showFastMode: shouldShowFastModeInFooter(fastModeState, model),
 		isSplash: !sessionHasMessages(ctx),
 	};
+}
+
+function shouldShowFastModeInFooter(fastModeState: FastModeState | undefined, model: ExtensionContext["model"] | undefined): boolean {
+	if (!fastModeState || !model || model.provider !== "openai-codex") return false;
+	return shouldApplyFastMode(fastModeState, model);
 }
 
 function safeRead<T>(read: () => T, fallback: T): T {

--- a/src/footer.ts
+++ b/src/footer.ts
@@ -31,7 +31,7 @@ export type FooterSnapshot = {
 	state: SumoCodeState;
 	modelId: string;
 	thinkingLevel: ThinkingLevel;
-	/** When true, append a `fast` label after thinking (openai-codex + active fast mode). */
+	/** When true, append a `fast` label after thinking when active fast mode applies. */
 	showFastMode?: boolean;
 	/**
 	 * When true, an additional dim version line is rendered below the main
@@ -304,8 +304,7 @@ function createSnapshot(
 }
 
 function shouldShowFastModeInFooter(fastModeState: FastModeState | undefined, model: ExtensionContext["model"] | undefined): boolean {
-	if (!fastModeState || !model || model.provider !== "openai-codex") return false;
-	return shouldApplyFastMode(fastModeState, model);
+	return shouldApplyFastMode(fastModeState ?? { enabled: false, models: [] }, model);
 }
 
 function safeRead<T>(read: () => T, fallback: T): T {

--- a/src/interaction-registry.test.ts
+++ b/src/interaction-registry.test.ts
@@ -84,12 +84,13 @@ describe("InteractionRegistry", () => {
 			"sumo:query",
 			"sumo:review",
 			"sumo:spinner",
+			"sumo:sync",
 			"sumo:tabs",
 			"sumo:theme",
 			"sumo:theme-check",
 		]);
 		expect(snapshot.shortcuts.map(([id]) => id).sort()).toEqual(["alt+t", "ctrl+/", "ctrl+1", "ctrl+2", "ctrl+shift+t"]);
-		expect(pi.registerCommand).toHaveBeenCalledTimes(13);
+		expect(pi.registerCommand).toHaveBeenCalledTimes(14);
 		expect(pi.registerShortcut).toHaveBeenCalledTimes(5);
 	});
 });

--- a/src/interaction-registry.ts
+++ b/src/interaction-registry.ts
@@ -9,6 +9,7 @@ import { registerSlateCommand } from "./commands/slate.js";
 import { registerPersonaCommand } from "./commands/persona.js";
 import { registerReviewCommand } from "./commands/review.js";
 import { registerSpinnerCommand } from "./commands/spinner.js";
+import { registerSumoSyncCommand } from "./commands/sync.js";
 import { registerTabsCommand } from "./commands/tabs.js";
 import { registerThemeCommand } from "./commands/theme.js";
 import { registerThemeCheckCommand } from "./commands/theme-check.js";
@@ -137,6 +138,7 @@ export function installSumoInteractions(pi: ExtensionAPI, options: InstallSumoIn
 	registry.install("commands.persona", registerPersonaCommand);
 	registry.install("commands.review", registerReviewCommand);
 	registry.install("commands.spinner", registerSpinnerCommand);
+	registry.install("commands.sync", registerSumoSyncCommand);
 	registry.install("commands.tabs", registerTabsCommand);
 	registry.install("commands.theme", registerThemeCommand);
 	registry.install("commands.theme-check", registerThemeCheckCommand);


### PR DESCRIPTION
## Summary
- add SumoCode-owned /fast command for session-local OpenAI/Codex fast mode
- wrap Pi's native openai-responses and openai-codex-responses streamers and pass serviceTier: "priority" via provider options
- document /fast and refresh README Pi/test badges

## Verification
- pnpm vitest run src/fast-mode.test.ts
- pnpm vitest run --testTimeout=15000
- pnpm exec tsc --noEmit && pnpm build
