### PR TITLE
feat(sync): add /sumo:sync and /sumo:bootstrap for config repo symlinks

### DIFF
--- a/src/commands/sync.test.ts
+++ b/src/commands/sync.test.ts
@@ -1,5 +1,8 @@
+import { existsSync, lstatSync, mkdirSync, mkdtempSync, readlinkSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { executeSumoSync, formatSyncResults, registerSumoSyncCommand } from "./sync.js";
+import { executeSumoBootstrap, executeSumoSync, formatSyncResults, registerSumoSyncCommand } from "./sync.js";
 
 function ctx() {
 	return {
@@ -7,34 +10,37 @@ function ctx() {
 	};
 }
 
+function sumocodeRepoExists(path: string): boolean {
+	return ["/repo/sumocode/package.json", "/repo/sumocode/src/extension.ts", "/repo/sumocode/.git"].includes(path);
+}
+
 describe("/sumo:sync", () => {
-	it("registers the slash command", () => {
+	it("registers both slash commands", () => {
 		const registerCommand = vi.fn();
 		registerSumoSyncCommand({ registerCommand } as never);
 		expect(registerCommand).toHaveBeenCalledWith(
 			"sumo:sync",
 			expect.objectContaining({ description: expect.stringContaining("Pull SumoCode") }),
 		);
+		expect(registerCommand).toHaveBeenCalledWith(
+			"sumo:bootstrap",
+			expect.objectContaining({ description: expect.stringContaining("First-time") }),
+		);
 	});
 
-	it("pulls config, pulls source, then runs bootstrap", async () => {
+	it("pulls config repo, refreshes symlinks, and pulls source", async () => {
 		const calls: Array<{ file: string; args: readonly string[]; cwd?: string }> = [];
+		const linkConfig = vi.fn(() => ({ label: "config symlinks", ok: true, output: "linked" }));
 		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 		const context = ctx();
 		const results = await executeSumoSync(context as never, {
-			env: {},
+			env: { SUMOCODE_CONFIG_DIR: "/config" },
 			homeDir: "/Users/test",
 			cwd: "/repo/sumocode/src",
 			moduleUrl: "file:///repo/sumocode/src/commands/sync.ts",
-			exists: (path) =>
-				[
-					"/Users/test/.pi/agent/settings.json",
-					"/repo/sumocode/package.json",
-					"/repo/sumocode/src/extension.ts",
-					"/repo/sumocode/.git",
-				].includes(path),
+			exists: (path) => path === "/config/.git" || sumocodeRepoExists(path),
 			readFile: () => JSON.stringify({ name: "@dhruvkelawala/sumocode" }),
-			realpath: () => "/Users/test/sumocode-config/pi-agent/settings.json",
+			linkConfig,
 			exec: async (file, args, options) => {
 				calls.push({ file, args, cwd: options.cwd });
 				return { stdout: "done", stderr: "" };
@@ -42,46 +48,244 @@ describe("/sumo:sync", () => {
 		});
 
 		expect(results.map((step) => step.label)).toEqual([
-			"sumocode-config git pull",
+			"config repo git pull",
+			"config symlinks",
 			"sumocode source git pull",
-			"sumocode-config bootstrap",
 		]);
 		expect(calls).toEqual([
-			{ file: "git", args: ["pull", "--ff-only"], cwd: "/Users/test/sumocode-config" },
+			{ file: "git", args: ["pull", "--ff-only"], cwd: "/config" },
 			{ file: "git", args: ["pull", "--ff-only"], cwd: "/repo/sumocode" },
-			{ file: "/Users/test/sumocode-config/bootstrap.sh", args: [], cwd: "/Users/test/sumocode-config" },
 		]);
-		expect(context.ui.notify).toHaveBeenLastCalledWith("SumoCode sync complete — run /sumo:reload if source changed", "info");
+		expect(linkConfig).toHaveBeenCalledWith("/config", "/Users/test/.pi/agent");
+		expect(context.ui.notify).toHaveBeenLastCalledWith(
+			"SumoCode sync complete — run /sumo:reload if source changed",
+			"info",
+		);
+		expect(stdout).not.toHaveBeenCalled();
 		stdout.mockRestore();
 	});
 
-	it("reports the first failed step", async () => {
+	it("defaults config repo to ~/.config/sumocode", async () => {
+		const calls: Array<{ file: string; args: readonly string[]; cwd?: string }> = [];
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const context = ctx();
+		await executeSumoSync(context as never, {
+			env: {},
+			homeDir: "/Users/test",
+			cwd: "/repo/sumocode",
+			moduleUrl: "file:///repo/sumocode/src/commands/sync.ts",
+			exists: (path) => path === "/Users/test/.config/sumocode/.git" || sumocodeRepoExists(path),
+			readFile: () => JSON.stringify({ name: "@dhruvkelawala/sumocode" }),
+			linkConfig: () => ({ label: "config symlinks", ok: true, output: "linked" }),
+			exec: async (file, args, options) => {
+				calls.push({ file, args, cwd: options.cwd });
+				return { stdout: "done", stderr: "" };
+			},
+		});
+
+		expect(calls[0]?.cwd).toBe("/Users/test/.config/sumocode");
+		stdout.mockRestore();
+	});
+
+	it("reports error when config repo is not present", async () => {
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const context = ctx();
+		const results = await executeSumoSync(context as never, {
+			env: {},
+			homeDir: "/Users/test",
+			cwd: "/repo/sumocode",
+			moduleUrl: "file:///repo/sumocode/src/commands/sync.ts",
+			exists: (path) => !path.includes(".config/sumocode/.git") && sumocodeRepoExists(path),
+			readFile: () => JSON.stringify({ name: "@dhruvkelawala/sumocode" }),
+			exec: async () => ({ stdout: "", stderr: "" }),
+		});
+
+		expect(results[0]?.ok).toBe(false);
+		expect(results[0]?.label).toBe("config repo git pull");
+		expect(results[0]?.output).toContain("No git repo");
+		expect(context.ui.notify).toHaveBeenLastCalledWith("/sumo:sync failed at config repo git pull", "warning");
+		expect(stdout).not.toHaveBeenCalled();
+		stdout.mockRestore();
+	});
+
+	it("reports the first failed git step and stops", async () => {
 		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
 		const context = ctx();
 		const exec = vi.fn(async (file: string) => {
 			if (file === "git") throw Object.assign(new Error("dirty tree"), { stderr: "local changes" });
 			return { stdout: "", stderr: "" };
 		});
+		const linkConfig = vi.fn(() => ({ label: "config symlinks", ok: true, output: "linked" }));
 		const results = await executeSumoSync(context as never, {
 			env: { SUMOCODE_CONFIG_DIR: "/config" },
 			cwd: "/tmp",
 			moduleUrl: "file:///repo/sumocode/src/commands/sync.ts",
-			exists: () => false,
+			exists: (path) => path === "/config/.git",
+			linkConfig,
 			exec,
 		});
 
 		expect(results).toHaveLength(1);
+		expect(results[0]?.ok).toBe(false);
+		expect(results[0]?.label).toBe("config repo git pull");
 		expect(exec).toHaveBeenCalledTimes(1);
-		expect(context.ui.notify).toHaveBeenLastCalledWith(
-			"/sumo:sync failed at sumocode-config git pull; inspect terminal output",
-			"warning",
-		);
+		expect(linkConfig).not.toHaveBeenCalled();
+		expect(context.ui.notify).toHaveBeenLastCalledWith("/sumo:sync failed at config repo git pull", "warning");
+		expect(stdout).not.toHaveBeenCalled();
 		stdout.mockRestore();
 	});
 
+	it("does not rewrite config files when ~/.pi/agent itself points at the config repo", async () => {
+		const home = mkdtempSync(join(tmpdir(), "sumocode-sync-"));
+		const configRepo = join(home, ".config", "sumocode");
+		const piDir = join(home, ".pi");
+		const agentDir = join(piDir, "agent");
+		mkdirSync(join(configRepo, ".git"), { recursive: true });
+		mkdirSync(piDir, { recursive: true });
+		writeFileSync(join(configRepo, "settings.json"), "{}\n");
+		symlinkSync(configRepo, agentDir);
+
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const context = ctx();
+		const results = await executeSumoSync(context as never, {
+			env: {},
+			homeDir: home,
+			cwd: "/repo/sumocode",
+			moduleUrl: "file:///repo/sumocode/src/commands/sync.ts",
+			exists: existsSync,
+			readFile: () => JSON.stringify({ name: "@dhruvkelawala/sumocode" }),
+			exec: async () => ({ stdout: "", stderr: "" }),
+		});
+
+		expect(results.map((step) => step.label)).toEqual([
+			"config repo git pull",
+			"config symlinks",
+			"sumocode source git pull",
+		]);
+		expect(lstatSync(agentDir).isSymbolicLink()).toBe(true);
+		expect(readlinkSync(agentDir)).toBe(configRepo);
+		expect(lstatSync(join(configRepo, "settings.json")).isSymbolicLink()).toBe(false);
+		expect(stdout).not.toHaveBeenCalled();
+		stdout.mockRestore();
+	});
+
+	it("reports symlink refresh failure and stops before source pull", async () => {
+		const calls: Array<{ file: string; cwd?: string }> = [];
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const context = ctx();
+		const results = await executeSumoSync(context as never, {
+			env: { SUMOCODE_CONFIG_DIR: "/config" },
+			cwd: "/repo/sumocode",
+			moduleUrl: "file:///repo/sumocode/src/commands/sync.ts",
+			exists: (path) => path === "/config/.git" || sumocodeRepoExists(path),
+			readFile: () => JSON.stringify({ name: "@dhruvkelawala/sumocode" }),
+			linkConfig: () => ({ label: "config symlinks", ok: false, output: "permission denied" }),
+			exec: async (file, _args, options) => {
+				calls.push({ file, cwd: options.cwd });
+				return { stdout: "", stderr: "" };
+			},
+		});
+
+		expect(results.map((step) => step.label)).toEqual(["config repo git pull", "config symlinks"]);
+		expect(calls).toEqual([{ file: "git", cwd: "/config" }]);
+		expect(context.ui.notify).toHaveBeenLastCalledWith("/sumo:sync failed at config symlinks", "warning");
+		expect(stdout).not.toHaveBeenCalled();
+		stdout.mockRestore();
+	});
+});
+
+describe("/sumo:bootstrap", () => {
+	it("clones config repo, pulls, links, then prints next step", async () => {
+		const calls: Array<{ file: string; args: readonly string[]; cwd?: string }> = [];
+		const linkConfig = vi.fn(() => ({ label: "config symlinks", ok: true, output: "linked" }));
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const context = ctx();
+		const results = await executeSumoBootstrap(context as never, {
+			env: {},
+			homeDir: "/Users/test",
+			cwd: "/repo/sumocode",
+			exists: () => false,
+			linkConfig,
+			exec: async (file, args, options) => {
+				calls.push({ file, args, cwd: options.cwd });
+				return { stdout: "ok", stderr: "" };
+			},
+		});
+
+		expect(calls).toEqual([
+			{ file: "git", args: ["clone", "git@github.com:dhruvkelawala/sumocode-config.git", "/Users/test/.config/sumocode"], cwd: undefined },
+			{ file: "git", args: ["pull", "--ff-only"], cwd: "/Users/test/.config/sumocode" },
+		]);
+		expect(linkConfig).toHaveBeenCalledWith("/Users/test/.config/sumocode", "/Users/test/.pi/agent");
+		expect(results.map((r) => r.label)).toEqual([
+			"clone sumocode-config",
+			"pull latest config",
+			"config symlinks",
+			"next step",
+		]);
+		expect(results[3]?.output).toContain("Keep PI_CODING_AGENT_DIR unset");
+		expect(context.ui.notify).toHaveBeenLastCalledWith(
+			"SumoCode bootstrap complete — restart; keep PI_CODING_AGENT_DIR unset",
+			"info",
+		);
+		expect(stdout).not.toHaveBeenCalled();
+		stdout.mockRestore();
+	});
+
+	it("fails clearly when config path exists but is not a git repo", async () => {
+		const exec = vi.fn(async () => ({ stdout: "", stderr: "" }));
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const context = ctx();
+		const results = await executeSumoBootstrap(context as never, {
+			env: {},
+			homeDir: "/Users/test",
+			cwd: "/repo/sumocode",
+			exists: (path) => path === "/Users/test/.config/sumocode",
+			exec,
+		});
+
+		expect(results).toHaveLength(1);
+		expect(results[0]?.ok).toBe(false);
+		expect(results[0]?.label).toBe("clone sumocode-config");
+		expect(results[0]?.output).toContain("already exists but is not a git repo");
+		expect(exec).not.toHaveBeenCalled();
+		expect(context.ui.notify).toHaveBeenLastCalledWith("/sumo:bootstrap failed at clone sumocode-config", "warning");
+		expect(stdout).not.toHaveBeenCalled();
+		stdout.mockRestore();
+	});
+
+	it("skips clone when config repo is already present", async () => {
+		const calls: Array<{ file: string }> = [];
+		const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+		const context = ctx();
+		await executeSumoBootstrap(context as never, {
+			env: {},
+			homeDir: "/Users/test",
+			cwd: "/repo/sumocode",
+			exists: (path) => path === "/Users/test/.config/sumocode/.git",
+			linkConfig: () => ({ label: "config symlinks", ok: true, output: "linked" }),
+			exec: async (file) => {
+				calls.push({ file });
+				return { stdout: "", stderr: "" };
+			},
+		});
+
+		expect(calls).toEqual([{ file: "git" }]); // git pull, not clone
+		expect(stdout).not.toHaveBeenCalled();
+		stdout.mockRestore();
+	});
+});
+
+describe("formatSyncResults", () => {
 	it("formats sync results for terminal output", () => {
 		expect(formatSyncResults([{ label: "step", ok: true, output: "Already up to date." }])).toBe(
 			"[ok] step\nAlready up to date.\n",
+		);
+	});
+
+	it("marks failed steps", () => {
+		expect(formatSyncResults([{ label: "fail", ok: false, output: "error msg" }])).toBe(
+			"[failed] fail\nerror msg\n",
 		);
 	});
 });

--- a/src/commands/sync.ts
+++ b/src/commands/sync.ts
@@ -1,5 +1,5 @@
 import { execFile as execFileCallback } from "node:child_process";
-import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readFileSync, realpathSync, renameSync, rmSync, symlinkSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -8,6 +8,20 @@ import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-c
 
 const execFile = promisify(execFileCallback);
 const DEFAULT_TIMEOUT_MS = 120_000;
+const CONFIG_REPO_NAME = "sumocode";
+const CONFIG_REPO_URL = "git@github.com:dhruvkelawala/sumocode-config.git";
+const MANAGED_CONFIG_ITEMS = [
+	"APPEND_SYSTEM.md",
+	"settings.json",
+	"mcp.json",
+	"models.json",
+	"sumocode.json",
+	"xl0-pi-lovely-web.json",
+	"extensions",
+	"themes",
+	"prompts",
+	"skills",
+] as const;
 
 export interface SyncStepResult {
 	readonly label: string;
@@ -22,7 +36,7 @@ export interface SumoSyncDeps {
 	readonly moduleUrl?: string;
 	readonly exists?: (path: string) => boolean;
 	readonly readFile?: (path: string, encoding: BufferEncoding) => string;
-	readonly realpath?: (path: string) => string;
+	readonly linkConfig?: (configRepo: string, agentDir: string) => SyncStepResult;
 	readonly exec?: (file: string, args: readonly string[], options: { cwd?: string; timeout: number }) => Promise<{ stdout: string; stderr: string }>;
 }
 
@@ -35,25 +49,24 @@ function packageRootFromModule(moduleUrl: string): string {
 	return resolve(dirname(moduleUrlToPath(moduleUrl)), "..", "..");
 }
 
+/** Resolve the private config repo that backs SumoCode's ~/.pi/agent symlinks. */
 function resolveConfigRepo(deps: SumoSyncDeps): string {
 	const env = deps.env ?? process.env;
-	const homeDir = deps.homeDir ?? homedir();
-	const exists = deps.exists ?? existsSync;
-	const realpath = deps.realpath ?? realpathSync;
 	if (env.SUMOCODE_CONFIG_DIR) return resolve(env.SUMOCODE_CONFIG_DIR);
 
-	const linkedSettings = join(homeDir, ".pi", "agent", "settings.json");
-	if (exists(linkedSettings)) {
-		try {
-			const resolvedSettings = realpath(linkedSettings);
-			return resolve(dirname(resolvedSettings), "..");
-		} catch {
-			// Fall through to conventional locations.
-		}
-	}
+	const homeDir = deps.homeDir ?? homedir();
+	return join(homeDir, ".config", CONFIG_REPO_NAME);
+}
 
-	const candidates = [join(homeDir, "sumocode-config"), join(homeDir, "development", "sumocode-config")];
-	return candidates.find((candidate) => exists(join(candidate, "bootstrap.sh"))) ?? candidates[0];
+function resolvePiAgentDir(deps: SumoSyncDeps): string {
+	const homeDir = deps.homeDir ?? homedir();
+	return join(homeDir, ".pi", "agent");
+}
+
+/** Check if a directory is inside a git repo */
+function isGitRepo(dir: string, deps: SumoSyncDeps): boolean {
+	const exists = deps.exists ?? existsSync;
+	return exists(join(dir, ".git"));
 }
 
 function packageNameAt(dir: string, deps: SumoSyncDeps): string | undefined {
@@ -88,6 +101,78 @@ function resolveSumoCodeRepo(deps: SumoSyncDeps): string {
 	return packageRootFromModule(deps.moduleUrl ?? import.meta.url);
 }
 
+function pathExists(path: string): boolean {
+	try {
+		lstatSync(path);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function resolvesToSamePath(left: string, right: string): boolean {
+	try {
+		return realpathSync(left) === realpathSync(right);
+	} catch {
+		return false;
+	}
+}
+
+function ensureConfigSymlinks(configRepo: string, agentDir: string): SyncStepResult {
+	mkdirSync(agentDir, { recursive: true });
+	let backupDir: string | undefined;
+	let linked = 0;
+	let backedUp = 0;
+
+	for (const item of MANAGED_CONFIG_ITEMS) {
+		const source = join(configRepo, item);
+		if (!pathExists(source)) continue;
+
+		const target = join(agentDir, item);
+		if (pathExists(target)) {
+			if (resolvesToSamePath(source, target)) {
+				linked += 1;
+				continue;
+			}
+			const targetStat = lstatSync(target);
+			if (targetStat.isSymbolicLink()) {
+				rmSync(target);
+			} else {
+				backupDir ??= join(
+					agentDir,
+					"pre-sumocode-backup",
+					`sync-${new Date().toISOString().replace(/[:.]/g, "-")}`,
+				);
+				mkdirSync(backupDir, { recursive: true });
+				renameSync(target, join(backupDir, item));
+				backedUp += 1;
+			}
+		}
+
+		symlinkSync(source, target);
+		linked += 1;
+	}
+
+	return {
+		label: "config symlinks",
+		ok: true,
+		output: `Linked ${linked} config item(s) into ${agentDir}${backedUp > 0 ? `; backed up ${backedUp} existing item(s) to ${backupDir}` : ""}`,
+	};
+}
+
+function runConfigLinkStep(configRepo: string, agentDir: string, deps: SumoSyncDeps): SyncStepResult {
+	const linkConfig = deps.linkConfig ?? ensureConfigSymlinks;
+	try {
+		return linkConfig(configRepo, agentDir);
+	} catch (error) {
+		return {
+			label: "config symlinks",
+			ok: false,
+			output: error instanceof Error ? error.message : String(error),
+		};
+	}
+}
+
 async function runStep(
 	label: string,
 	file: string,
@@ -109,40 +194,45 @@ async function runStep(
 	}
 }
 
+function notifyFailure(command: "sync" | "bootstrap", ctx: ExtensionCommandContext, step: SyncStepResult): void {
+	ctx.ui.notify(`/sumo:${command} failed at ${step.label}`, "warning");
+}
+
 export async function executeSumoSync(ctx: ExtensionCommandContext, deps: SumoSyncDeps = {}): Promise<readonly SyncStepResult[]> {
 	const configRepo = resolveConfigRepo(deps);
+	const agentDir = resolvePiAgentDir(deps);
 	const sumocodeRepo = resolveSumoCodeRepo(deps);
 	const steps: SyncStepResult[] = [];
 
-	ctx.ui.notify("syncing SumoCode config + extensions…", "info");
+	ctx.ui.notify("syncing SumoCode config + source…", "info");
 
-	const plannedSteps = [
-		{ label: "sumocode-config git pull", file: "git", args: ["pull", "--ff-only"] as const, cwd: configRepo },
-		{ label: "sumocode source git pull", file: "git", args: ["pull", "--ff-only"] as const, cwd: sumocodeRepo },
-		{
-			label: "sumocode-config bootstrap",
-			file: join(configRepo, "bootstrap.sh"),
-			args: [] as const,
-			cwd: configRepo,
-			timeout: 240_000,
-		},
-	];
-
-	for (const step of plannedSteps) {
-		const result = await runStep(step.label, step.file, step.args, { cwd: step.cwd, timeout: step.timeout }, deps);
-		steps.push(result);
-		if (!result.ok) break;
+	if (isGitRepo(configRepo, deps)) {
+		steps.push(await runStep("config repo git pull", "git", ["pull", "--ff-only"], { cwd: configRepo }, deps));
+	} else {
+		steps.push({
+			label: "config repo git pull",
+			ok: false,
+			output: `No git repo at ${configRepo}. Run /sumo:bootstrap first.`,
+		});
+	}
+	if (!steps[steps.length - 1]!.ok) {
+		notifyFailure("sync", ctx, steps[steps.length - 1]!);
+		return steps;
 	}
 
-	const failed = steps.filter((step) => !step.ok);
-	if (failed.length > 0) {
-		ctx.ui.notify(`/sumo:sync failed at ${failed[0]?.label}; inspect terminal output`, "warning");
-		process.stdout.write(formatSyncResults(steps));
+	steps.push(runConfigLinkStep(configRepo, agentDir, deps));
+	if (!steps[steps.length - 1]!.ok) {
+		notifyFailure("sync", ctx, steps[steps.length - 1]!);
+		return steps;
+	}
+
+	steps.push(await runStep("sumocode source git pull", "git", ["pull", "--ff-only"], { cwd: sumocodeRepo }, deps));
+	if (!steps[steps.length - 1]!.ok) {
+		notifyFailure("sync", ctx, steps[steps.length - 1]!);
 		return steps;
 	}
 
 	ctx.ui.notify("SumoCode sync complete — run /sumo:reload if source changed", "info");
-	process.stdout.write(formatSyncResults(steps));
 	return steps;
 }
 
@@ -156,11 +246,66 @@ export function formatSyncResults(results: readonly SyncStepResult[]): string {
 		.join("\n\n")}\n`;
 }
 
+export async function executeSumoBootstrap(ctx: ExtensionCommandContext, deps: SumoSyncDeps = {}): Promise<readonly SyncStepResult[]> {
+	const configRepo = resolveConfigRepo(deps);
+	const agentDir = resolvePiAgentDir(deps);
+	const steps: SyncStepResult[] = [];
+
+	ctx.ui.notify("bootstrapping SumoCode on this machine…", "info");
+
+	if (!isGitRepo(configRepo, deps)) {
+		const exists = deps.exists ?? existsSync;
+		if (exists(configRepo)) {
+			steps.push({
+				label: "clone sumocode-config",
+				ok: false,
+				output: `${configRepo} already exists but is not a git repo. Move it aside or set SUMOCODE_CONFIG_DIR to a valid sumocode-config checkout.`,
+			});
+		} else {
+			steps.push(await runStep("clone sumocode-config", "git", ["clone", CONFIG_REPO_URL, configRepo], {}, deps));
+		}
+	} else {
+		steps.push({ label: "clone sumocode-config", ok: true, output: `Already exists at ${configRepo}` });
+	}
+	if (!steps[steps.length - 1]!.ok) {
+		notifyFailure("bootstrap", ctx, steps[steps.length - 1]!);
+		return steps;
+	}
+
+	steps.push(await runStep("pull latest config", "git", ["pull", "--ff-only"], { cwd: configRepo }, deps));
+	if (!steps[steps.length - 1]!.ok) {
+		notifyFailure("bootstrap", ctx, steps[steps.length - 1]!);
+		return steps;
+	}
+
+	steps.push(runConfigLinkStep(configRepo, agentDir, deps));
+	if (!steps[steps.length - 1]!.ok) {
+		notifyFailure("bootstrap", ctx, steps[steps.length - 1]!);
+		return steps;
+	}
+
+	steps.push({
+		label: "next step",
+		ok: true,
+		output: "Restart SumoCode. Keep PI_CODING_AGENT_DIR unset so Pi sessions and package caches remain under ~/.pi/agent.",
+	});
+
+	ctx.ui.notify("SumoCode bootstrap complete — restart; keep PI_CODING_AGENT_DIR unset", "info");
+	return steps;
+}
+
 export function registerSumoSyncCommand(pi: ExtensionAPI, deps: SumoSyncDeps = {}): void {
 	pi.registerCommand("sumo:sync", {
-		description: "Pull SumoCode config/source, hydrate extensions, and update Pi packages",
+		description: "Pull SumoCode config/source and refresh ~/.pi/agent symlinks",
 		handler: async (_args: string, ctx: ExtensionCommandContext) => {
 			await executeSumoSync(ctx, deps);
+		},
+	});
+
+	pi.registerCommand("sumo:bootstrap", {
+		description: "First-time SumoCode setup: clone config repo and link it into ~/.pi/agent",
+		handler: async (_args: string, ctx: ExtensionCommandContext) => {
+			await executeSumoBootstrap(ctx, deps);
 		},
 	});
 }

--- a/src/interaction-registry.test.ts
+++ b/src/interaction-registry.test.ts
@@ -77,6 +77,7 @@ describe("InteractionRegistry", () => {
 			"exit",
 			"slate",
 			"sumo:approval",
+		"sumo:bootstrap",
 			"sumo:cursor",
 			"sumo:diff",
 			"sumo:memory",
@@ -90,7 +91,7 @@ describe("InteractionRegistry", () => {
 			"sumo:theme-check",
 		]);
 		expect(snapshot.shortcuts.map(([id]) => id).sort()).toEqual(["alt+t", "ctrl+/", "ctrl+1", "ctrl+2", "ctrl+shift+t"]);
-		expect(pi.registerCommand).toHaveBeenCalledTimes(14);
+		expect(pi.registerCommand).toHaveBeenCalledTimes(15);
 		expect(pi.registerShortcut).toHaveBeenCalledTimes(5);
 	});
 });

--- a/src/spike/cmux-background/INTEGRATION-PLAN.md
+++ b/src/spike/cmux-background/INTEGRATION-PLAN.md
@@ -1,0 +1,133 @@
+# Integration plan: `@sumocode/pi-background-cmux`
+
+Follow-on implementation plan after spike approval. This spike does **not** implement the fork — it validates the cmux adapter and documents the seam.
+
+## Phase 0 — Spike (this PR)
+
+- [x] Research matrix (pi-subagents, pi-cmux, opencode-cmux, pi-background-tasks)
+- [x] Portable `cmux-adapter.ts` + tests
+- [x] `visible-spawn.ts` wrapper builder + tests
+- [x] Visual explainer HTML
+
+## Phase 1 — Fork package (estimated 2–3 days)
+
+1. Vendor or fork `vanillagreencom/vstack/pi-extensions/pi-background-tasks` into `packages/pi-background-cmux/` (or private sumocode-config extension path — prefer **public sumocode repo** under `packages/` if we want MIT propagation).
+
+2. Add settings schema:
+
+```json
+{
+  "cmux": {
+    "enabled": true,
+    "defaultVisible": false,
+    "direction": "right",
+    "focusSplit": false,
+    "closeSurfaceOnExit": false,
+    "statusKey": "sumocode-bg",
+    "notifyOnComplete": true
+  }
+}
+```
+
+3. Extend `SpawnTaskOptions`:
+
+```typescript
+interface SpawnTaskOptions {
+  // existing fields…
+  visible?: boolean;
+  cmuxDirection?: "right" | "down";
+  cmuxFocus?: boolean;
+}
+```
+
+4. Extend `ManagedTask` / snapshot:
+
+```typescript
+interface ManagedTask {
+  // existing…
+  cmux?: {
+    workspaceRef: string;
+    surfaceRef: string;
+    mode: "visible" | "invisible";
+  };
+}
+```
+
+5. Branch `spawnTask()`:
+
+```typescript
+if (options.visible && cmuxSettings.enabled && isInCmux()) {
+  return spawnVisibleTask(options); // cmux split + log tail watcher
+}
+return spawnInvisibleTask(options); // current spawn path unchanged
+```
+
+6. `spawnVisibleTask` flow:
+
+   - Build paths via `buildVisibleTaskPaths(taskId, startedAt)`
+   - Build command via `buildVisibleTaskCommand({ cwd, command, logFile, exitFile, markerFile })`
+   - Call `openVisibleTaskInSplit({ direction, command, execCmux })`
+   - Store `cmux.surfaceRef` on task
+   - Start log tail watcher (fs.watch or interval) instead of child stdout pipes
+   - On exit marker read → `finalizeTask()`
+
+7. Register in `sumocode-config/pi-agent/settings.json`:
+
+```json
+"packages": ["npm:@sumocode/pi-background-cmux"]
+```
+
+## Phase 2 — SumoCode UX (estimated 1–2 days)
+
+1. **Transcript renderer** — add `bg_task` / `bg_status` to tool pill pipeline (mirror `task` delegation styling or lighter variant).
+
+2. **Footer hint** — when running visible bg tasks, show `cmux split · bg-3` in hint row.
+
+3. **Command palette** — entries:
+   - `background: list tasks`
+   - `background: open split for task`
+
+4. **Disable duplicate UI** — when SumoTUI active, set pi-background widget to hidden via extension settings.
+
+5. **Orchestrator prompt** — append to Zeus system block:
+
+```
+Use bg_task for long shell work. Pass visible=true when the user wants a cmux split.
+Use task for Pi subagent delegation with structured tools.
+```
+
+## Phase 3 — Validation
+
+| Test | Lane |
+|---|---|
+| `cmux-adapter.test.ts` | unit (mock exec) |
+| spawn visible + invisible in cmux | manual cmux session |
+| wake on exit after parent reload | integration |
+| fallback outside cmux | `pi --print` smoke |
+| SumoTUI tool pill snapshot | fixture lane (optional) |
+
+Manual smoke script (document in fork README):
+
+```bash
+# inside cmux, sumocode session
+# ask: "run pnpm test in a visible background split"
+# expect: right split with test output, parent continues, wake on exit
+```
+
+## Phase 4 — Upstream
+
+- Propose `visible` + `cmuxSurfaceRef` upstream to `@vanillagreen/pi-background-tasks`
+- Optionally propose shared `cmux-adapter` module to `pi-cmux` to avoid duplication
+
+## Non-goals
+
+- Replacing SumoCode native `task` tool
+- cmux grid layout from opencode-cmux (YAGNI until >3 concurrent visible tasks)
+- `pi-subagents` removal (orthogonal)
+
+## Open questions for Dhruv
+
+1. Package name: `@sumocode/pi-background-cmux` vs extend sumocode extension inline?
+2. Default `visible`: false (safe) or true when `CMUX_SURFACE_ID` set?
+3. Close split on task exit or leave pane open for inspection?
+4. Install fork globally via settings or only in sumocode-config?

--- a/src/spike/cmux-background/README.md
+++ b/src/spike/cmux-background/README.md
@@ -1,0 +1,30 @@
+# Spike: cmux-visible background tasks
+
+Research spike for SumoCode orchestrator-visible background work via cmux splits, built on a fork of `@vanillagreen/pi-background-tasks`.
+
+## Contents
+
+| File | Purpose |
+|---|---|
+| [RESEARCH.md](./RESEARCH.md) | Deep comparison of pi-subagents, pi-cmux, opencode-cmux, pi-background-tasks |
+| [INTEGRATION-PLAN.md](./INTEGRATION-PLAN.md) | Proposed fork + SumoCode wiring plan |
+| [cmux-adapter.ts](./cmux-adapter.ts) | Portable cmux CLI adapter (PoC) |
+| [visible-spawn.ts](./visible-spawn.ts) | Log-tee wrapper command builder for visible tasks |
+| [visual-explainer.html](./visual-explainer.html) | Architecture diagram + decision matrix |
+
+## Status
+
+**Spike only** — nothing in this directory is imported by SumoCode production code. Promote by moving the adapter into a real package and forking `pi-background-tasks`.
+
+## Quick validation
+
+```bash
+pnpm vitest run src/spike/cmux-background
+pnpm exec tsc --noEmit
+```
+
+Open the visual explainer:
+
+```bash
+open src/spike/cmux-background/visual-explainer.html
+```

--- a/src/spike/cmux-background/RESEARCH.md
+++ b/src/spike/cmux-background/RESEARCH.md
@@ -1,0 +1,172 @@
+# Research: cmux-visible background tasks for SumoCode
+
+Spike date: 2026-05-25  
+Author: Zeus (SumoCode)  
+Status: proposal — not production
+
+## Problem statement
+
+Dhruv wants the SumoCode orchestrator to start long-running work **without blocking the main session**, while still letting him **watch it live** in cmux (split/tab). `pi-subagents` solves multi-agent delegation but is heavier than needed for “run `pnpm test` in the background and let me peek”.
+
+Requirements distilled from conversation:
+
+1. Orchestrator-callable tool (not slash-command-only)
+2. Visible execution surface in cmux when requested
+3. Persistent logs + completion wakeups (existing bg_task semantics)
+4. Cathedral/SumoTUI rendering in the parent session
+5. No cmux/tmux orchestration bolted outside Pi’s tool loop
+
+## Candidates evaluated
+
+### 1. `pi-subagents` (npm:pi-subagents@0.25.0)
+
+| Aspect | Assessment |
+|---|---|
+| Tool | `subagent` — no clash with SumoCode `task` |
+| Strength | Role library (scout/reviewer/oracle), chains, parallel, async |
+| Weakness | Full child Pi sessions; overkill for shell background jobs |
+| cmux | No first-class visible split integration |
+| SumoCode fit | Complementary for review/scout, not the background-process primitive |
+
+**Verdict:** Keep installed optionally; do not use as the primary background-process layer.
+
+### 2. `pi-cmux` (npm:pi-cmux@0.1.8)
+
+| Aspect | Assessment |
+|---|---|
+| Surface | Slash commands only (`/cmv`, `/cmo`, `/cmrv`, …) |
+| cmux API | `new-split` → poll panes → `respawn-pane --command` |
+| Strength | Battle-tested split creation in cmux; already in Dhruv’s settings |
+| Weakness | **Not orchestrator-callable** — no `registerTool` |
+| SumoCode fit | Reuse `cmux-core.ts` patterns, not the package wholesale |
+
+**Verdict:** Extract the cmux CLI sequence; wrap in a SumoCode/`bg_task` tool.
+
+### 3. `opencode-cmux` ([0xCaso/opencode-cmux](https://github.com/0xCaso/opencode-cmux) v0.2.4)
+
+| Aspect | Assessment |
+|---|---|
+| Model | OpenCode plugin listening to `session.created` with `parentID` |
+| Visible subagents | `cmux new-split` + `cmux send` + `opencode attach <url> --session <id>` |
+| Notifications | `cmux rpc notification.create`, `set-status`, `log`, `clear-status` |
+| cmux hooks | Does **not** use `cmux set-hook` for splits — direct CLI |
+| Server discovery | `lsof` on listening port; requires `opencode --port` |
+
+**Key insight:** Attach-model works when the child is a **resumable agent session**. For shell commands, attach is wrong — use `respawn-pane` with a wrapped command (pi-cmux pattern).
+
+**Verdict:** Best reference for event-driven cmux side effects + split grid layout; adapt spawn path for shell tasks.
+
+### 4. `@vanillagreen/pi-background-tasks` (v1.5.0)
+
+| Aspect | Assessment |
+|---|---|
+| Tool | `bg_task` + `bg_status` |
+| Spawn | `child_process.spawn` detached, stdout/stderr piped to log |
+| Wakeups | Exit + output match, budget caps, session-resumable sidecar |
+| UI | Own widget/dashboard (vstack stack) |
+| cmux | None today |
+
+**Verdict:** **Best fork base.** Hard problems (PGID, PID reuse, wake budgets, auto-background bash) already solved.
+
+### 5. SumoCode native `task` tool
+
+| Aspect | Assessment |
+|---|---|
+| Model | Subprocess `pi` with scoped tools |
+| Strength | SumoTUI delegation blocks already wired |
+| Weakness | Invisible by default; not optimized for `pnpm test` style jobs |
+| cmux | None |
+
+**Verdict:** Keep for structured Pi delegation; pair with visible `bg_task` for shell monitors.
+
+## cmux hook surface (what it is / isn’t)
+
+`cmux hooks pi install` writes `~/.pi/agent/extensions/cmux-session.ts` for **session restore + lifecycle metadata** — not for opening splits on tool calls.
+
+Relevant cmux CLI for this spike:
+
+| Command | Use |
+|---|---|
+| `cmux --json identify` | Resolve caller workspace/surface |
+| `cmux --json list-panes --workspace <ref>` | Diff panes before/after split |
+| `cmux new-split right\|down --workspace --surface` | Create split |
+| `cmux respawn-pane --workspace --surface --command <cmd>` | Start command in split |
+| `cmux set-status / clear-status` | Sidebar working/idle |
+| `cmux rpc notification.create` | Desktop notify on completion |
+| `cmux log` | Workspace log feed |
+| `cmux close-surface` | Cleanup finished visible tasks |
+| `cmux read-screen` | Optional snapshot for orchestrator (expensive) |
+
+`cmux set-hook` is tmux-compat and **not** how opencode-cmux or pi-cmux operate.
+
+## Architectural fork: two spawn modes
+
+```
+┌─────────────────────┐     bg_task spawn (visible=false)
+│  SumoCode parent    │ ──► child_process.spawn (current pi-background-tasks)
+│  orchestrator       │     pipe stdout → log, wake on exit
+└─────────────────────┘
+
+┌─────────────────────┐     bg_task spawn (visible=true)
+│  SumoCode parent    │ ──► cmux new-split + respawn-pane
+│  orchestrator       │     wrapper: command 2>&1 | tee -a log; write exit file
+└─────────────────────┘     tail log file for wakeups (no stdout pipe to Pi)
+         │
+         ▼
+┌─────────────────────┐
+│  cmux split surface │  human watches live terminal output
+└─────────────────────┘
+```
+
+### Why log-tee wrapper for visible mode
+
+When Pi spawns with piped stdio, output is invisible in the cmux pane. Visible mode must run **inside** the cmux surface. Pi tracks completion by:
+
+1. Wrapper writes `[sumocode-bg] exit:<code>` and `<code>` to sidecar files
+2. Parent polls log mtime + exit marker (same orphan-watcher patterns as today)
+3. Optional: `cmux read-screen` for snapshots (not on hot path)
+
+See `visible-spawn.ts` for the wrapper builder.
+
+## opencode-cmux vs our fork (mapping)
+
+| opencode-cmux | SumoCode fork |
+|---|---|
+| `session.created` + `parentID` | `bg_task` spawn with `visible: true` |
+| `createSplit()` | `openVisibleTaskInSplit()` in cmux-adapter |
+| `opencode attach …` | `respawn-pane` with `buildVisibleTaskCommand()` |
+| `activeSplits` Map | `ManagedTask.cmuxSurfaceRef` on task snapshot |
+| `removeAndClose()` on idle | Optional `closeSurfaceOnExit` setting |
+| `setStatus("working")` | Map to SumoCode footer state or cmux status key `sumocode-bg` |
+
+## Recommended package shape
+
+```
+@sumocode/pi-background-cmux   (fork of pi-background-tasks)
+├── extensions/background-tasks.ts   (+ visible spawn branch)
+├── extensions/cmux-adapter.ts         (from spike)
+├── extensions/visible-spawn.ts
+└── settings: { cmux: { enabled, direction, focus, closeOnExit } }
+```
+
+SumoCode changes (follow-on PR, not this spike):
+
+- Render `bg_task` / `bg_status` in SumoTUI transcript pipeline
+- Command palette: “background tasks dashboard”
+- Disable vstack widget when SumoTUI retained renderer active
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Not inside cmux → visible spawn fails | Graceful fallback to invisible spawn + notify |
+| Log tail polling latency | Reuse existing output wake debounce |
+| Duplicate packages (`pi-cmux` + fork) | Fork calls cmux CLI directly; deprecate overlapping `/cmo` usage in docs |
+| Cursor SDK shell-exec warnings | Unrelated; visible tasks bypass Cursor shell bridge |
+| Maintaining upstream fork | Start as thin adapter layer; contribute `visible` upstream to vstack |
+
+## Decision
+
+**Proceed with fork of `@vanillagreen/pi-background-tasks` + cmux adapter from this spike.** Do not build cmux orchestration in tmux. Do not use `pi-subagents` as the background shell primitive.
+
+Next PR after spike: implement fork package + SumoTUI `bg_task` renderer + smoke test in cmux.

--- a/src/spike/cmux-background/cmux-adapter.test.ts
+++ b/src/spike/cmux-background/cmux-adapter.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+	buildShellCommand,
+	identifyCmuxCaller,
+	openVisibleTaskInSplit,
+	shellEscape,
+	waitForNewCmuxSurface,
+	type CmuxExecFn,
+	type CmuxPaneInfo,
+} from "./cmux-adapter.js";
+
+function mockExec(responses: Record<string, CmuxExecResult>): CmuxExecFn {
+	return vi.fn(async (args: string[]) => {
+		const key = args.join(" ");
+		const response = responses[key];
+		if (!response) {
+			throw new Error(`unexpected cmux args: ${key}`);
+		}
+		return response;
+	});
+}
+
+type CmuxExecResult = Awaited<ReturnType<CmuxExecFn>>;
+
+describe("cmux-adapter spike", () => {
+	it("shellEscape wraps single quotes", () => {
+		expect(shellEscape("it's fine")).toBe("'it'\\''s fine'");
+	});
+
+	it("buildShellCommand cd + exec sh -lc", () => {
+		expect(buildShellCommand("/repo", "pnpm test")).toContain("cd '/repo'");
+		expect(buildShellCommand("/repo", "pnpm test")).toContain("exec sh -lc 'pnpm test'");
+	});
+
+	it("identifyCmuxCaller parses workspace and surface refs", async () => {
+		const execCmux = mockExec({
+			"--json identify": {
+				ok: true,
+				stdout: JSON.stringify({
+					caller: { workspace_ref: "workspace:1", surface_ref: "surface:1" },
+				}),
+				stderr: "",
+			},
+		});
+
+		const result = await identifyCmuxCaller(execCmux);
+		expect(result).toEqual({
+			ok: true,
+			caller: { workspaceRef: "workspace:1", surfaceRef: "surface:1" },
+		});
+	});
+
+	it("identifyCmuxCaller fails outside cmux", async () => {
+		const execCmux = mockExec({
+			"--json identify": { ok: true, stdout: "{}", stderr: "" },
+		});
+		const result = await identifyCmuxCaller(execCmux);
+		expect(result.ok).toBe(false);
+		if (!result.ok) {
+			expect(result.error).toContain("cmux surface");
+		}
+	});
+
+	it("waitForNewCmuxSurface detects new surface ref", async () => {
+		const before: CmuxPaneInfo[] = [{ ref: "pane:1", surface_refs: ["surface:1"] }];
+		const after: CmuxPaneInfo[] = [
+			{ ref: "pane:1", surface_refs: ["surface:1"] },
+			{ ref: "pane:2", selected_surface_ref: "surface:2", surface_refs: ["surface:2"] },
+		];
+
+		let listed = 0;
+		const execCmux: CmuxExecFn = vi.fn(async (args) => {
+			if (args[0] === "--json" && args[1] === "list-panes") {
+				listed += 1;
+				return {
+					ok: true,
+					stdout: JSON.stringify({ panes: listed === 1 ? before : after }),
+					stderr: "",
+				};
+			}
+			throw new Error(`unexpected: ${args.join(" ")}`);
+		});
+
+		const surface = await waitForNewCmuxSurface(execCmux, "workspace:1", before, 3, 0);
+		expect(surface).toBe("surface:2");
+	});
+
+	it("openVisibleTaskInSplit runs new-split then respawn-pane", async () => {
+		const calls: string[] = [];
+		const execCmux: CmuxExecFn = vi.fn(async (args) => {
+			calls.push(args.join(" "));
+			if (args.join(" ") === "--json identify") {
+				return {
+					ok: true,
+					stdout: JSON.stringify({
+						caller: { workspace_ref: "workspace:1", surface_ref: "surface:1" },
+					}),
+					stderr: "",
+				};
+			}
+			if (args.join(" ").startsWith("--json list-panes")) {
+				const panes =
+					calls.filter((c) => c.startsWith("new-split")).length === 0
+						? [{ ref: "pane:1", surface_refs: ["surface:1"] }]
+						: [
+								{ ref: "pane:1", surface_refs: ["surface:1"] },
+								{ ref: "pane:2", selected_surface_ref: "surface:2", surface_refs: ["surface:2"] },
+							];
+				return { ok: true, stdout: JSON.stringify({ panes }), stderr: "" };
+			}
+			if (args.join(" ").startsWith("new-split")) {
+				return { ok: true, stdout: "OK surface:2 workspace:1", stderr: "" };
+			}
+			if (args.join(" ").startsWith("respawn-pane")) {
+				return { ok: true, stdout: "", stderr: "" };
+			}
+			throw new Error(`unexpected: ${args.join(" ")}`);
+		});
+
+		const result = await openVisibleTaskInSplit({
+			direction: "right",
+			command: "cd '/repo' && exec sh -lc 'pnpm test'",
+			execCmux,
+			surfaceBootDelayMs: 0,
+			splitReadyDelayMs: 0,
+		});
+
+		expect(result).toEqual({ ok: true, workspaceRef: "workspace:1", surfaceRef: "surface:2" });
+		expect(calls.some((c) => c.startsWith("new-split right"))).toBe(true);
+		expect(calls.some((c) => c.startsWith("respawn-pane"))).toBe(true);
+	});
+});

--- a/src/spike/cmux-background/cmux-adapter.test.ts
+++ b/src/spike/cmux-background/cmux-adapter.test.ts
@@ -85,6 +85,21 @@ describe("cmux-adapter spike", () => {
 		expect(surface).toBe("surface:2");
 	});
 
+	it("waitForNewCmuxSurface ignores new surfaces on existing panes", async () => {
+		const before: CmuxPaneInfo[] = [{ ref: "pane:1", surface_refs: ["surface:1"] }];
+		const after: CmuxPaneInfo[] = [{ ref: "pane:1", surface_refs: ["surface:1", "surface:other"] }];
+
+		const execCmux: CmuxExecFn = vi.fn(async (args) => {
+			if (args[0] === "--json" && args[1] === "list-panes") {
+				return { ok: true, stdout: JSON.stringify({ panes: after }), stderr: "" };
+			}
+			throw new Error(`unexpected: ${args.join(" ")}`);
+		});
+
+		const surface = await waitForNewCmuxSurface(execCmux, "workspace:1", before, 1, 0);
+		expect(surface).toBeUndefined();
+	});
+
 	it("openVisibleTaskInSplit runs new-split then respawn-pane", async () => {
 		const calls: string[] = [];
 		const execCmux: CmuxExecFn = vi.fn(async (args) => {

--- a/src/spike/cmux-background/cmux-adapter.ts
+++ b/src/spike/cmux-background/cmux-adapter.ts
@@ -173,14 +173,6 @@ export async function waitForNewCmuxSurface(
 			}
 		}
 
-		for (const pane of panesResult.panes) {
-			for (const surfaceRef of pane.surface_refs ?? []) {
-				if (!previousSurfaceRefs.has(surfaceRef)) {
-					return surfaceRef;
-				}
-			}
-		}
-
 		await delay(delayMs);
 	}
 

--- a/src/spike/cmux-background/cmux-adapter.ts
+++ b/src/spike/cmux-background/cmux-adapter.ts
@@ -1,0 +1,296 @@
+/**
+ * Portable cmux CLI adapter for visible background tasks.
+ *
+ * Spike extracted from pi-cmux (respawn-pane split flow) and opencode-cmux
+ * (status/notify helpers). No Pi extension dependency — inject execCmux for tests.
+ */
+
+import { existsSync } from "node:fs";
+
+export type SplitDirection = "right" | "down";
+
+export interface CmuxExecResult {
+	ok: boolean;
+	stdout: string;
+	stderr: string;
+	error?: string;
+	killed?: boolean;
+}
+
+export type CmuxExecFn = (args: string[], options?: { timeoutMs?: number }) => Promise<CmuxExecResult>;
+
+export interface CmuxCallerContext {
+	workspaceRef: string;
+	surfaceRef: string;
+}
+
+export interface CmuxPaneInfo {
+	ref?: string;
+	selected_surface_ref?: string;
+	surface_refs?: string[];
+}
+
+export interface OpenVisibleTaskOptions {
+	direction: SplitDirection;
+	command: string;
+	execCmux: CmuxExecFn;
+	timeoutMs?: number;
+	splitReadyAttempts?: number;
+	splitReadyDelayMs?: number;
+	surfaceBootDelayMs?: number;
+}
+
+export type OpenVisibleTaskResult =
+	| { ok: true; workspaceRef: string; surfaceRef: string }
+	| { ok: false; error: string };
+
+const DEFAULT_TIMEOUT_MS = 5000;
+const DEFAULT_SPLIT_READY_ATTEMPTS = 20;
+const DEFAULT_SPLIT_READY_DELAY_MS = 150;
+const DEFAULT_SURFACE_BOOT_DELAY_MS = 250;
+
+export function resolveCmuxBinary(): string {
+	const bundled = process.env.CMUX_BUNDLED_CLI_PATH;
+	if (bundled && existsSync(bundled)) {
+		return bundled;
+	}
+	return "cmux";
+}
+
+export function isInCmux(): boolean {
+	return Boolean(process.env.CMUX_WORKSPACE_ID || process.env.CMUX_SURFACE_ID);
+}
+
+export function shellEscape(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function buildShellCommand(cwd: string, command: string): string {
+	return ["cd", shellEscape(cwd), "&&", "exec", "sh", "-lc", shellEscape(command)].join(" ");
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, ms);
+	});
+}
+
+function parseJson<T>(text: string): T | undefined {
+	try {
+		return JSON.parse(text) as T;
+	} catch {
+		return undefined;
+	}
+}
+
+function collectSurfaceRefs(panes: CmuxPaneInfo[]): Set<string> {
+	const refs = new Set<string>();
+	for (const pane of panes) {
+		if (pane.selected_surface_ref) {
+			refs.add(pane.selected_surface_ref);
+		}
+		for (const surfaceRef of pane.surface_refs ?? []) {
+			refs.add(surfaceRef);
+		}
+	}
+	return refs;
+}
+
+export async function execCmuxCommand(
+	execCmux: CmuxExecFn,
+	args: string[],
+	timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<CmuxExecResult> {
+	const result = await execCmux(args, { timeoutMs });
+	if (result.killed) {
+		return { ...result, ok: false, error: "cmux command timed out" };
+	}
+	if (!result.ok) {
+		return {
+			...result,
+			error: result.stderr.trim() || result.stdout.trim() || "cmux command failed",
+		};
+	}
+	return result;
+}
+
+export async function identifyCmuxCaller(execCmux: CmuxExecFn): Promise<
+	{ ok: true; caller: CmuxCallerContext } | { ok: false; error: string }
+> {
+	const result = await execCmuxCommand(execCmux, ["--json", "identify"]);
+	if (!result.ok) {
+		return { ok: false, error: result.error ?? "Failed to identify cmux caller" };
+	}
+
+	const parsed = parseJson<{ caller?: { workspace_ref?: string; surface_ref?: string } }>(result.stdout);
+	const workspaceRef = parsed?.caller?.workspace_ref;
+	const surfaceRef = parsed?.caller?.surface_ref;
+	if (!workspaceRef || !surfaceRef) {
+		return { ok: false, error: "Must run inside a cmux surface (missing workspace/surface refs)" };
+	}
+
+	return { ok: true, caller: { workspaceRef, surfaceRef } };
+}
+
+export async function listCmuxPanes(
+	execCmux: CmuxExecFn,
+	workspaceRef: string,
+): Promise<{ ok: true; panes: CmuxPaneInfo[] } | { ok: false; error: string }> {
+	const result = await execCmuxCommand(execCmux, ["--json", "list-panes", "--workspace", workspaceRef]);
+	if (!result.ok) {
+		return { ok: false, error: result.error ?? "Failed to list cmux panes" };
+	}
+
+	const parsed = parseJson<{ panes?: CmuxPaneInfo[] }>(result.stdout);
+	return { ok: true, panes: parsed?.panes ?? [] };
+}
+
+export async function waitForNewCmuxSurface(
+	execCmux: CmuxExecFn,
+	workspaceRef: string,
+	previousPanes: CmuxPaneInfo[],
+	attempts = DEFAULT_SPLIT_READY_ATTEMPTS,
+	delayMs = DEFAULT_SPLIT_READY_DELAY_MS,
+): Promise<string | undefined> {
+	const previousPaneRefs = new Set(previousPanes.map((pane) => pane.ref).filter((ref): ref is string => Boolean(ref)));
+	const previousSurfaceRefs = collectSurfaceRefs(previousPanes);
+
+	for (let attempt = 0; attempt < attempts; attempt += 1) {
+		const panesResult = await listCmuxPanes(execCmux, workspaceRef);
+		if (!panesResult.ok) {
+			return undefined;
+		}
+
+		for (const pane of panesResult.panes) {
+			if (pane.ref && !previousPaneRefs.has(pane.ref)) {
+				if (pane.selected_surface_ref) {
+					return pane.selected_surface_ref;
+				}
+				const firstSurfaceRef = pane.surface_refs?.find((ref) => !previousSurfaceRefs.has(ref));
+				if (firstSurfaceRef) {
+					return firstSurfaceRef;
+				}
+			}
+		}
+
+		for (const pane of panesResult.panes) {
+			for (const surfaceRef of pane.surface_refs ?? []) {
+				if (!previousSurfaceRefs.has(surfaceRef)) {
+					return surfaceRef;
+				}
+			}
+		}
+
+		await delay(delayMs);
+	}
+
+	return undefined;
+}
+
+export async function openVisibleTaskInSplit(options: OpenVisibleTaskOptions): Promise<OpenVisibleTaskResult> {
+	const {
+		direction,
+		command,
+		execCmux,
+		timeoutMs = DEFAULT_TIMEOUT_MS,
+		splitReadyAttempts = DEFAULT_SPLIT_READY_ATTEMPTS,
+		splitReadyDelayMs = DEFAULT_SPLIT_READY_DELAY_MS,
+		surfaceBootDelayMs = DEFAULT_SURFACE_BOOT_DELAY_MS,
+	} = options;
+
+	const callerResult = await identifyCmuxCaller(execCmux);
+	if (!callerResult.ok) {
+		return callerResult;
+	}
+
+	const { workspaceRef, surfaceRef } = callerResult.caller;
+	const beforePanesResult = await listCmuxPanes(execCmux, workspaceRef);
+	if (!beforePanesResult.ok) {
+		return beforePanesResult;
+	}
+
+	const splitResult = await execCmuxCommand(
+		execCmux,
+		["new-split", direction, "--workspace", workspaceRef, "--surface", surfaceRef],
+		timeoutMs,
+	);
+	if (!splitResult.ok) {
+		return { ok: false, error: splitResult.error ?? "Failed to create cmux split" };
+	}
+
+	const newSurfaceRef = await waitForNewCmuxSurface(
+		execCmux,
+		workspaceRef,
+		beforePanesResult.panes,
+		splitReadyAttempts,
+		splitReadyDelayMs,
+	);
+	if (!newSurfaceRef) {
+		return { ok: false, error: "Created split, but could not find the new cmux surface" };
+	}
+
+	await delay(surfaceBootDelayMs);
+
+	const respawnResult = await execCmuxCommand(
+		execCmux,
+		["respawn-pane", "--workspace", workspaceRef, "--surface", newSurfaceRef, "--command", command],
+		timeoutMs,
+	);
+	if (!respawnResult.ok) {
+		return { ok: false, error: respawnResult.error ?? "Failed to start command in cmux split" };
+	}
+
+	return { ok: true, workspaceRef, surfaceRef: newSurfaceRef };
+}
+
+export async function setCmuxStatus(
+	execCmux: CmuxExecFn,
+	key: string,
+	text: string,
+	opts?: { icon?: string; color?: string },
+): Promise<void> {
+	if (!isInCmux()) {
+		return;
+	}
+	const args = [key, text];
+	if (opts?.icon) {
+		args.push("--icon", opts.icon);
+	}
+	if (opts?.color) {
+		args.push("--color", opts.color);
+	}
+	await execCmuxCommand(execCmux, ["set-status", ...args]);
+}
+
+export async function clearCmuxStatus(execCmux: CmuxExecFn, key: string): Promise<void> {
+	if (!isInCmux()) {
+		return;
+	}
+	await execCmuxCommand(execCmux, ["clear-status", key]);
+}
+
+export async function notifyCmux(
+	execCmux: CmuxExecFn,
+	opts: { title: string; subtitle?: string; body?: string },
+): Promise<void> {
+	if (!isInCmux()) {
+		return;
+	}
+	const bodyParts: string[] = [];
+	if (opts.subtitle) {
+		bodyParts.push(opts.subtitle);
+	}
+	if (opts.body) {
+		bodyParts.push(opts.body);
+	}
+	const payload = JSON.stringify({ title: opts.title, body: bodyParts.join(" — ") });
+	await execCmuxCommand(execCmux, ["rpc", "notification.create", payload]);
+}
+
+export async function closeCmuxSurface(
+	execCmux: CmuxExecFn,
+	workspaceRef: string,
+	surfaceRef: string,
+): Promise<void> {
+	await execCmuxCommand(execCmux, ["close-surface", "--workspace", workspaceRef, "--surface", surfaceRef]);
+}

--- a/src/spike/cmux-background/visible-spawn.test.ts
+++ b/src/spike/cmux-background/visible-spawn.test.ts
@@ -24,6 +24,8 @@ describe("visible-spawn spike", () => {
 		});
 
 		expect(cmd).toContain("cd '/Volumes/SumoDeus NVMe/code/sumocode'");
+		expect(cmd).toContain("exec bash -lc");
+		expect(cmd).toContain("set -o pipefail");
 		expect(cmd).toContain("pnpm test");
 		expect(cmd).toContain("tee -a");
 		expect(cmd).toContain("exit.code");

--- a/src/spike/cmux-background/visible-spawn.test.ts
+++ b/src/spike/cmux-background/visible-spawn.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildVisibleTaskCommand,
+	buildVisibleTaskPaths,
+	parseExitMarkerLine,
+	readExitCodeFromFile,
+} from "./visible-spawn.js";
+
+describe("visible-spawn spike", () => {
+	it("buildVisibleTaskPaths uses task id and timestamp", () => {
+		const paths = buildVisibleTaskPaths("bg-1", 1_700_000_000_000, "/tmp/test-bg");
+		expect(paths.logFile).toBe("/tmp/test-bg/bg-1-1700000000000/output.log");
+		expect(paths.exitFile).toBe("/tmp/test-bg/bg-1-1700000000000/exit.code");
+		expect(paths.markerFile).toBe("/tmp/test-bg/bg-1-1700000000000/started.marker");
+	});
+
+	it("buildVisibleTaskCommand wraps command with tee and exit marker", () => {
+		const paths = buildVisibleTaskPaths("bg-2", 123, "/tmp/test-bg");
+		const cmd = buildVisibleTaskCommand({
+			cwd: "/Volumes/SumoDeus NVMe/code/sumocode",
+			command: "pnpm test",
+			paths,
+			taskId: "bg-2",
+		});
+
+		expect(cmd).toContain("cd '/Volumes/SumoDeus NVMe/code/sumocode'");
+		expect(cmd).toContain("pnpm test");
+		expect(cmd).toContain("tee -a");
+		expect(cmd).toContain("exit.code");
+		expect(cmd).toContain("[sumocode-bg] task=bg-2 started");
+		expect(cmd).toContain("[sumocode-bg] task=bg-2 exit:$code");
+	});
+
+	it("readExitCodeFromFile parses numeric exit codes", () => {
+		expect(readExitCodeFromFile("0\n")).toBe(0);
+		expect(readExitCodeFromFile("127")).toBe(127);
+		expect(readExitCodeFromFile("nope")).toBeNull();
+	});
+
+	it("parseExitMarkerLine extracts task id and exit code", () => {
+		expect(parseExitMarkerLine("[sumocode-bg] task=bg-3 exit:1")).toEqual({
+			taskId: "bg-3",
+			exitCode: 1,
+		});
+		expect(parseExitMarkerLine("[sumocode-bg] task=bg-3 started")).toBeNull();
+	});
+});

--- a/src/spike/cmux-background/visible-spawn.ts
+++ b/src/spike/cmux-background/visible-spawn.ts
@@ -1,0 +1,81 @@
+/**
+ * Builds shell wrapper commands for visible cmux background tasks.
+ *
+ * Pi cannot pipe stdout and show live terminal output simultaneously. Visible
+ * tasks run inside cmux via respawn-pane; Pi tracks via log + exit marker files.
+ */
+
+import { dirname, join } from "node:path";
+
+export interface VisibleTaskPaths {
+	logFile: string;
+	exitFile: string;
+	markerFile: string;
+}
+
+export interface VisibleTaskCommandOptions {
+	cwd: string;
+	command: string;
+	paths: VisibleTaskPaths;
+	taskId: string;
+}
+
+export function buildVisibleTaskPaths(taskId: string, startedAtMs: number, baseDir?: string): VisibleTaskPaths {
+	const root = baseDir ?? join(process.env.TMPDIR ?? "/tmp", "sumocode-bg");
+	const dir = join(root, `${taskId}-${startedAtMs}`);
+	return {
+		logFile: join(dir, "output.log"),
+		exitFile: join(dir, "exit.code"),
+		markerFile: join(dir, "started.marker"),
+	};
+}
+
+export function shellEscape(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/**
+ * Returns a single sh -lc command suitable for cmux respawn-pane --command.
+ *
+ * Writes:
+ * - full combined stdout/stderr to logFile via tee
+ * - numeric exit code to exitFile
+ * - sentinel lines [sumocode-bg] for log parsers
+ */
+export function buildVisibleTaskCommand(options: VisibleTaskCommandOptions): string {
+	const { cwd, command, paths, taskId } = options;
+	const { logFile, exitFile, markerFile } = paths;
+	const dir = dirname(logFile);
+
+	const inner = [
+		`mkdir -p ${shellEscape(dir)}`,
+		`touch ${shellEscape(markerFile)}`,
+		`echo "[sumocode-bg] task=${taskId} started" | tee -a ${shellEscape(logFile)}`,
+		`(`,
+		`  set -o pipefail`,
+		`  ${command}`,
+		`) 2>&1 | tee -a ${shellEscape(logFile)}`,
+		`code=$?`,
+		`printf '%s' "$code" > ${shellEscape(exitFile)}`,
+		`echo "[sumocode-bg] task=${taskId} exit:$code" | tee -a ${shellEscape(logFile)}`,
+		`exit "$code"`,
+	].join("\n");
+
+	return ["cd", shellEscape(cwd), "&&", "exec", "sh", "-lc", shellEscape(inner)].join(" ");
+}
+
+export function readExitCodeFromFile(contents: string): number | null {
+	const trimmed = contents.trim();
+	if (!/^\d+$/.test(trimmed)) {
+		return null;
+	}
+	return Number.parseInt(trimmed, 10);
+}
+
+export function parseExitMarkerLine(line: string): { taskId: string; exitCode: number } | null {
+	const match = line.match(/^\[sumocode-bg\] task=([^\s]+) exit:(\d+)$/);
+	if (!match) {
+		return null;
+	}
+	return { taskId: match[1], exitCode: Number.parseInt(match[2], 10) };
+}

--- a/src/spike/cmux-background/visible-spawn.ts
+++ b/src/spike/cmux-background/visible-spawn.ts
@@ -35,7 +35,7 @@ export function shellEscape(value: string): string {
 }
 
 /**
- * Returns a single sh -lc command suitable for cmux respawn-pane --command.
+ * Returns a single bash -lc command suitable for cmux respawn-pane --command.
  *
  * Writes:
  * - full combined stdout/stderr to logFile via tee
@@ -48,11 +48,11 @@ export function buildVisibleTaskCommand(options: VisibleTaskCommandOptions): str
 	const dir = dirname(logFile);
 
 	const inner = [
+		`set -o pipefail`,
 		`mkdir -p ${shellEscape(dir)}`,
 		`touch ${shellEscape(markerFile)}`,
 		`echo "[sumocode-bg] task=${taskId} started" | tee -a ${shellEscape(logFile)}`,
 		`(`,
-		`  set -o pipefail`,
 		`  ${command}`,
 		`) 2>&1 | tee -a ${shellEscape(logFile)}`,
 		`code=$?`,
@@ -61,7 +61,7 @@ export function buildVisibleTaskCommand(options: VisibleTaskCommandOptions): str
 		`exit "$code"`,
 	].join("\n");
 
-	return ["cd", shellEscape(cwd), "&&", "exec", "sh", "-lc", shellEscape(inner)].join(" ");
+	return ["cd", shellEscape(cwd), "&&", "exec", "bash", "-lc", shellEscape(inner)].join(" ");
 }
 
 export function readExitCodeFromFile(contents: string): number | null {

--- a/src/spike/cmux-background/visual-explainer.html
+++ b/src/spike/cmux-background/visual-explainer.html
@@ -1,0 +1,370 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SumoCode × cmux background tasks — spike</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600&family=IBM+Plex+Mono:wght@400;500&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet">
+<style>
+:root {
+	--bg: #f4f1ea;
+	--surface: #fffdf8;
+	--grid: rgba(30, 58, 95, 0.08);
+	--text: #1e293b;
+	--muted: #64748b;
+	--accent: #1e3a5f;
+	--accent-2: #c45c26;
+	--accent-3: #2d6a4f;
+	--line: rgba(30, 58, 95, 0.18);
+	--mono: "IBM Plex Mono", ui-monospace, monospace;
+	--sans: "IBM Plex Sans", system-ui, sans-serif;
+	--serif: "Instrument Serif", Georgia, serif;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body {
+	font-family: var(--sans);
+	background-color: var(--bg);
+	background-image:
+		linear-gradient(var(--grid) 1px, transparent 1px),
+		linear-gradient(90deg, var(--grid) 1px, transparent 1px);
+	background-size: 24px 24px;
+	color: var(--text);
+	line-height: 1.55;
+	padding: 48px 24px 80px;
+}
+.wrap { max-width: 1080px; margin: 0 auto; }
+.hero {
+	border: 1px solid var(--line);
+	background: var(--surface);
+	padding: 40px 36px;
+	margin-bottom: 28px;
+	position: relative;
+}
+.hero::before {
+	content: "SPIKE / RESEARCH";
+	position: absolute;
+	top: 12px; right: 16px;
+	font: 500 11px/1 var(--mono);
+	letter-spacing: 0.12em;
+	color: var(--accent-2);
+}
+.hero h1 {
+	font-family: var(--serif);
+	font-size: clamp(2rem, 4vw, 2.8rem);
+	font-weight: 400;
+	margin-bottom: 10px;
+	color: var(--accent);
+}
+.hero p { max-width: 70ch; color: var(--muted); }
+.meta {
+	display: flex; flex-wrap: wrap; gap: 12px;
+	margin-top: 20px;
+	font: 500 12px/1 var(--mono);
+	color: var(--accent);
+}
+.meta span {
+	border: 1px solid var(--line);
+	padding: 6px 10px;
+	background: rgba(30, 58, 95, 0.04);
+}
+section {
+	border: 1px solid var(--line);
+	background: var(--surface);
+	padding: 28px 32px;
+	margin-bottom: 24px;
+}
+section h2 {
+	font-family: var(--serif);
+	font-size: 1.6rem;
+	font-weight: 400;
+	margin-bottom: 14px;
+	color: var(--accent);
+}
+section h3 {
+	font-size: 0.95rem;
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	color: var(--accent-2);
+	margin: 22px 0 10px;
+}
+p, li { color: var(--text); }
+ul { padding-left: 1.2rem; margin: 8px 0 0; }
+li { margin: 6px 0; }
+.grid-2 {
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+	gap: 16px;
+	margin-top: 16px;
+}
+.card {
+	border: 1px solid var(--line);
+	padding: 18px;
+	background: rgba(255,255,255,0.6);
+}
+.card strong { display: block; margin-bottom: 6px; color: var(--accent); }
+.card code, .mono { font-family: var(--mono); font-size: 0.88em; }
+.verdict {
+	border-left: 4px solid var(--accent-3);
+	padding-left: 14px;
+	margin-top: 12px;
+}
+.verdict.warn { border-color: var(--accent-2); }
+table {
+	width: 100%;
+	border-collapse: collapse;
+	margin-top: 12px;
+	font-size: 0.92rem;
+}
+th, td {
+	border: 1px solid var(--line);
+	padding: 10px 12px;
+	text-align: left;
+	vertical-align: top;
+}
+th {
+	background: rgba(30, 58, 95, 0.06);
+	font-weight: 600;
+	color: var(--accent);
+}
+.tag {
+	display: inline-block;
+	font: 500 10px/1 var(--mono);
+	padding: 3px 6px;
+	border: 1px solid var(--line);
+	margin-right: 4px;
+}
+.tag.yes { color: var(--accent-3); border-color: rgba(45,106,79,0.35); }
+.tag.no { color: var(--accent-2); border-color: rgba(196,92,38,0.35); }
+.tag.partial { color: var(--accent); }
+.mermaid-wrap {
+	border: 1px dashed var(--line);
+	padding: 20px;
+	margin-top: 16px;
+	overflow-x: auto;
+	background: rgba(255,255,255,0.5);
+}
+.flow-row {
+	display: flex; flex-wrap: wrap; align-items: stretch; gap: 10px; margin-top: 16px;
+}
+.flow-box {
+	flex: 1 1 180px;
+	border: 1px solid var(--line);
+	padding: 14px;
+	background: #fff;
+	position: relative;
+}
+.flow-box .label {
+	font: 500 10px/1 var(--mono);
+	color: var(--accent-2);
+	margin-bottom: 8px;
+}
+.arrow {
+	align-self: center;
+	font: 600 18px/1 var(--mono);
+	color: var(--muted);
+}
+footer {
+	margin-top: 32px;
+	font: 12px/1.5 var(--mono);
+	color: var(--muted);
+	text-align: center;
+}
+</style>
+</head>
+<body>
+<div class="wrap">
+	<header class="hero">
+		<h1>cmux-visible background tasks</h1>
+		<p>
+			Research spike for SumoCode: let the orchestrator spawn long shell work via
+			<code class="mono">bg_task</code>, track logs and wakeups in the parent session,
+			and optionally mirror execution into a live cmux split — without pi-subagents overhead.
+		</p>
+		<div class="meta">
+			<span>branch: spike/cmux-background-tasks</span>
+			<span>base: pi-background-tasks v1.5.0</span>
+			<span>cmux ref: pi-cmux + opencode-cmux</span>
+		</div>
+	</header>
+
+	<section>
+		<h2>Problem → proposal</h2>
+		<div class="grid-2">
+			<div class="card">
+				<strong>What Dhruv wants</strong>
+				Orchestrator starts background shell work. Parent keeps chatting. Optional visible cmux split/tab to watch live output.
+			</div>
+			<div class="card">
+				<strong>What we reject</strong>
+				pi-subagents for every test run. External tmux orchestration outside Pi tools. Slash-only pi-cmux without model access.
+			</div>
+		</div>
+		<p class="verdict" style="margin-top:18px">
+			<strong>Proposal:</strong> fork <code class="mono">@vanillagreen/pi-background-tasks</code>, add
+			<code class="mono">visible: true</code> spawn path using cmux split + log-tee wrapper (this spike’s PoC).
+		</p>
+	</section>
+
+	<section>
+		<h2>Candidate matrix</h2>
+		<table>
+			<thead>
+				<tr>
+					<th>Package</th>
+					<th>Orchestrator tool</th>
+					<th>Visible cmux</th>
+					<th>Logs + wake</th>
+					<th>Verdict</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td><code class="mono">pi-subagents</code></td>
+					<td><span class="tag yes">subagent</span></td>
+					<td><span class="tag no">no</span></td>
+					<td><span class="tag partial">async Pi child</span></td>
+					<td>Keep for reviewer/scout roles — not shell bg primitive</td>
+				</tr>
+				<tr>
+					<td><code class="mono">pi-cmux</code></td>
+					<td><span class="tag no">slash only</span></td>
+					<td><span class="tag yes">/cmo /cmv</span></td>
+					<td><span class="tag no">no</span></td>
+					<td>Reuse cmux CLI sequence; wrap in bg_task</td>
+				</tr>
+				<tr>
+					<td><code class="mono">opencode-cmux</code></td>
+					<td><span class="tag partial">events</span></td>
+					<td><span class="tag yes">attach split</span></td>
+					<td><span class="tag partial">notify/status</span></td>
+					<td>Reference for split grid + notifications; attach ≠ shell</td>
+				</tr>
+				<tr>
+					<td><code class="mono">pi-background-tasks</code></td>
+					<td><span class="tag yes">bg_task</span></td>
+					<td><span class="tag no">no</span></td>
+					<td><span class="tag yes">full</span></td>
+					<td><strong>Fork base</strong></td>
+				</tr>
+				<tr>
+					<td><code class="mono">SumoCode task</code></td>
+					<td><span class="tag yes">task</span></td>
+					<td><span class="tag no">no</span></td>
+					<td><span class="tag partial">Pi child</span></td>
+					<td>Keep for structured delegation blocks</td>
+				</tr>
+			</tbody>
+		</table>
+	</section>
+
+	<section>
+		<h2>Two spawn modes</h2>
+		<div class="flow-row">
+			<div class="flow-box">
+				<div class="label">invisible (today)</div>
+				<strong>child_process.spawn</strong>
+				<p style="margin-top:8px;font-size:0.92rem;color:var(--muted)">stdout piped → log file. Detached PGID. Wake on exit/output match.</p>
+			</div>
+			<div class="arrow">→</div>
+			<div class="flow-box">
+				<div class="label">visible (fork)</div>
+				<strong>cmux respawn-pane</strong>
+				<p style="margin-top:8px;font-size:0.92rem;color:var(--muted)">Command runs in split. Wrapper tees to log. Parent tails log + exit marker.</p>
+			</div>
+		</div>
+
+		<h3>Sequence — visible spawn</h3>
+		<div class="mermaid-wrap">
+			<pre class="mermaid">
+sequenceDiagram
+  participant O as SumoCode orchestrator
+  participant B as bg_task fork
+  participant C as cmux CLI
+  participant S as cmux split surface
+  participant L as log + exit files
+
+  O->>B: spawn(visible=true, command)
+  B->>C: identify + list-panes
+  B->>C: new-split right
+  B->>C: respawn-pane (wrapper cmd)
+  C->>S: live terminal output
+  S->>L: tee stdout/stderr
+  B->>L: tail log / read exit.code
+  B->>O: wake on completion
+			</pre>
+		</div>
+	</section>
+
+	<section>
+		<h2>opencode-cmux vs our fork</h2>
+		<div class="grid-2">
+			<div class="card">
+				<strong>opencode-cmux pattern</strong>
+				Listens for <code class="mono">session.created</code> with <code class="mono">parentID</code>.
+				Opens split, types <code class="mono">opencode attach … --session</code>.
+				Works because child is a resumable agent session.
+			</div>
+			<div class="card">
+				<strong>SumoCode shell pattern</strong>
+				No attach target. Use pi-cmux’s <code class="mono">respawn-pane --command</code> with
+				<code class="mono">buildVisibleTaskCommand()</code> (tee + exit marker).
+				Store <code class="mono">surfaceRef</code> on task snapshot.
+			</div>
+		</div>
+		<p class="verdict warn" style="margin-top:16px">
+			cmux <code class="mono">hooks pi install</code> is for session restore — not split creation. Both opencode-cmux and pi-cmux call the cmux CLI directly.
+		</p>
+	</section>
+
+	<section>
+		<h2>Spike artifacts</h2>
+		<ul>
+			<li><code class="mono">cmux-adapter.ts</code> — identify, split, respawn, notify/status helpers</li>
+			<li><code class="mono">visible-spawn.ts</code> — log-tee wrapper builder + exit marker parser</li>
+			<li><code class="mono">cmux-adapter.test.ts</code> — mocked cmux exec flow</li>
+			<li><code class="mono">RESEARCH.md</code> + <code class="mono">INTEGRATION-PLAN.md</code></li>
+		</ul>
+		<h3>Proposed bg_task API extension</h3>
+		<pre class="mono" style="background:rgba(30,58,95,0.05);border:1px solid var(--line);padding:14px;overflow:auto;margin-top:10px;font-size:0.85rem">{
+  "action": "spawn",
+  "command": "pnpm test",
+  "visible": true,
+  "cmuxDirection": "right",
+  "notifyOnExit": true
+}</pre>
+	</section>
+
+	<section>
+		<h2>Phased rollout</h2>
+		<ol style="padding-left:1.2rem">
+			<li><strong>Phase 0 (this PR):</strong> spike + tests + visual explainer</li>
+			<li><strong>Phase 1:</strong> fork package, wire visible spawn + settings</li>
+			<li><strong>Phase 2:</strong> SumoTUI <code class="mono">bg_task</code> renderer + palette hints</li>
+			<li><strong>Phase 3:</strong> manual cmux smoke + optional fixture capture</li>
+		</ol>
+	</section>
+
+	<footer>SumoCode spike · open in browser: src/spike/cmux-background/visual-explainer.html</footer>
+</div>
+<script type="module">
+import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+mermaid.initialize({
+	startOnLoad: true,
+	theme: "base",
+	themeVariables: {
+		fontFamily: "IBM Plex Sans, sans-serif",
+		fontSize: "15px",
+		primaryColor: "#fffdf8",
+		primaryBorderColor: "#1e3a5f",
+		lineColor: "#64748b",
+		actorBkg: "#fffdf8",
+		actorBorder: "#1e3a5f",
+		noteBkgColor: "#f4f1ea",
+		noteTextColor: "#1e293b",
+	},
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds/updates SumoCode sync commands for the corrected config architecture:

- Pi runtime stays at `~/.pi/agent` (sessions, git package cache, npm installs, auth/cache files)
- Private config repo lives at `~/.config/sumocode`
- `~/.pi/agent` config files/directories are symlinks into `~/.config/sumocode`
- No `PI_CODING_AGENT_DIR` override

## Commands

**`/sumo:sync`** — daily sync, fail-fast:
1. `git pull --ff-only` in `~/.config/sumocode`
2. Refresh symlinks from `~/.pi/agent` to `~/.config/sumocode`
3. `git pull --ff-only` in the SumoCode source checkout

**`/sumo:bootstrap`** — first-time machine setup:
1. Clone `sumocode-config` to `~/.config/sumocode` if missing
2. Refuse to clone over an existing non-git config directory with a clear recovery message
3. Pull latest config
4. Create/refresh `~/.pi/agent` symlinks
5. Notify the user to restart SumoCode and keep `PI_CODING_AGENT_DIR` unset

## Regression fixes

- Removed `PI_CODING_AGENT_DIR=~/.config/sumocode` from the launcher. That env var is too broad: it moves sessions and package clone/install caches and breaks both session discovery and package installs.
- Removed interactive `pi update` from slash commands. Pi self-update can write raw terminal output and corrupt retained UI.
- Removed all raw `process.stdout.write(...)` calls from slash commands.
- Added fail-fast coverage for git pull and symlink refresh failures.
- Added bootstrap guard for existing non-git `~/.config/sumocode`.
- Bootstrap success notification now includes the actionable `PI_CODING_AGENT_DIR` guidance.
- Symlink refresh now skips already-correct targets by realpath, avoiding self-referential links if `~/.pi/agent` itself is symlinked in a legacy setup.
- Visible cmux spike wrapper now uses `bash -lc` for `pipefail` support and records the wrapped command failure, not just `tee` success.
- Cmux new-surface polling no longer selects unrelated surfaces from existing panes.

## Related config cleanup

Removed unused `git:github.com/richardgill/pi-extensions` from `sumocode-config` because it had `extensions: []` and its workspace root crashes npm installs with `workspace:*`.

## Verification

- `pnpm exec tsc --noEmit` ✅
- `pnpm vitest run src/commands/sync.test.ts src/spike/cmux-background/visible-spawn.test.ts src/spike/cmux-background/cmux-adapter.test.ts` — 23/23 ✅
- `pnpm test` — 100 files, 900/900 ✅
- `./bin/sumocode.sh --dry-run --no-session` shows no `PI_CODING_AGENT_DIR` export ✅
- `pi list` succeeds after removing unused richardgill package ✅