### PR TITLE
docs(research): add v0.4 roadmap for worktree fan-out

### DIFF
--- a/docs/research/codex-t3code-feature-audit.html
+++ b/docs/research/codex-t3code-feature-audit.html
@@ -1,0 +1,534 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Codex App + T3 Code · Feature Audit for SumoCode</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@300;400;500;600;700&family=IBM+Plex+Mono:wght@300;400;500;600&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --font-body: 'IBM Plex Sans', system-ui, -apple-system, sans-serif;
+    --font-mono: 'IBM Plex Mono', 'SF Mono', 'JetBrains Mono', Consolas, monospace;
+
+    --bg: #0a1929;
+    --bg-deep: #060f1c;
+    --surface: #0f1f33;
+    --surface-elevated: #14283f;
+    --surface-recessed: #0c1a2b;
+    --border: rgba(140, 190, 230, 0.10);
+    --border-bright: rgba(140, 190, 230, 0.22);
+    --grid: rgba(140, 190, 230, 0.045);
+    --text: #e6edf6;
+    --text-dim: #8ea4be;
+    --text-faint: #5a6e88;
+
+    --cyan: #4ab3d9;
+    --cyan-dim: rgba(74, 179, 217, 0.14);
+    --gold: #d4a73a;
+    --gold-dim: rgba(212, 167, 58, 0.14);
+    --rust: #d07b5a;
+    --rust-dim: rgba(208, 123, 90, 0.14);
+    --sage: #87b58e;
+    --sage-dim: rgba(135, 181, 142, 0.14);
+
+    --max: 1240px;
+    --pad: clamp(20px, 4vw, 48px);
+    --radius: 4px;
+  }
+
+  @media (prefers-color-scheme: light) {
+    :root {
+      --bg: #f4ede0;
+      --bg-deep: #ebe1cd;
+      --surface: #f9f2e4;
+      --surface-elevated: #ffffff;
+      --surface-recessed: #ede2cd;
+      --border: rgba(30, 55, 80, 0.12);
+      --border-bright: rgba(30, 55, 80, 0.28);
+      --grid: rgba(30, 55, 80, 0.06);
+      --text: #18334d;
+      --text-dim: #4d6580;
+      --text-faint: #7a8d9f;
+      --cyan: #185e7d;
+      --cyan-dim: rgba(24, 94, 125, 0.12);
+      --gold: #99761b;
+      --gold-dim: rgba(153, 118, 27, 0.12);
+      --rust: #a4502d;
+      --rust-dim: rgba(164, 80, 45, 0.12);
+      --sage: #3e6a47;
+      --sage-dim: rgba(62, 106, 71, 0.12);
+    }
+  }
+
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+
+  body {
+    font-family: var(--font-body);
+    color: var(--text);
+    background: var(--bg);
+    background-image:
+      linear-gradient(var(--grid) 1px, transparent 1px),
+      linear-gradient(90deg, var(--grid) 1px, transparent 1px),
+      radial-gradient(ellipse at 20% 0%, var(--cyan-dim) 0%, transparent 55%),
+      radial-gradient(ellipse at 90% 80%, var(--gold-dim) 0%, transparent 55%);
+    background-size: 32px 32px, 32px 32px, 100% 100%, 100% 100%;
+    background-attachment: fixed;
+    line-height: 1.55;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+    min-height: 100vh;
+  }
+
+  .shell {
+    max-width: var(--max);
+    margin: 0 auto;
+    padding: clamp(28px, 5vw, 56px) var(--pad);
+    display: grid;
+    grid-template-columns: 200px minmax(0, 1fr);
+    gap: clamp(32px, 5vw, 64px);
+  }
+  @media (max-width: 880px) { .shell { grid-template-columns: 1fr; gap: 24px; } }
+
+  nav.toc {
+    position: sticky; top: 32px; align-self: start;
+    font-family: var(--font-mono); font-size: 11px;
+    letter-spacing: 0.06em; text-transform: uppercase;
+    color: var(--text-dim); border-left: 1px solid var(--border-bright);
+    padding-left: 16px; line-height: 2;
+  }
+  nav.toc ol { list-style: none; margin: 0; padding: 0; counter-reset: tocnum; }
+  nav.toc li { counter-increment: tocnum; }
+  nav.toc li::before { content: counter(tocnum, decimal-leading-zero) "  "; color: var(--cyan); font-weight: 500; }
+  nav.toc a { color: var(--text-dim); text-decoration: none; transition: color 120ms ease; }
+  nav.toc a:hover { color: var(--text); }
+  nav.toc .label { color: var(--gold); font-weight: 600; margin-bottom: 8px; display: block; border-bottom: 1px solid var(--border); padding-bottom: 8px; }
+  @media (max-width: 880px) {
+    nav.toc { position: relative; top: 0; border-left: 0; border-top: 1px solid var(--border-bright); border-bottom: 1px solid var(--border-bright); padding: 12px 0; overflow-x: auto; white-space: nowrap; }
+    nav.toc ol { display: inline-flex; gap: 24px; }
+    nav.toc .label { display: none; }
+  }
+
+  main { min-width: 0; }
+
+  .stamp {
+    font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.18em;
+    text-transform: uppercase; color: var(--gold); display: inline-flex;
+    align-items: center; gap: 10px; padding: 6px 12px; border: 1px solid var(--gold);
+    border-radius: 2px; margin-bottom: 24px;
+  }
+  .stamp::before { content: ''; width: 6px; height: 6px; background: var(--gold); border-radius: 50%; }
+
+  h1 { font-family: var(--font-body); font-weight: 600; font-size: clamp(36px, 5.5vw, 60px); line-height: 1.05; letter-spacing: -0.02em; margin: 0 0 16px; color: var(--text); }
+  h1 .hl { font-family: var(--font-mono); font-weight: 500; color: var(--cyan); font-size: 0.78em; letter-spacing: -0.01em; }
+
+  .lede { font-size: clamp(17px, 1.4vw, 19px); color: var(--text-dim); max-width: 62ch; margin: 0 0 32px; line-height: 1.55; }
+  .lede strong { color: var(--text); font-weight: 600; }
+
+  .meta { display: flex; flex-wrap: wrap; gap: 12px 24px; font-family: var(--font-mono); font-size: 11px; color: var(--text-faint); padding: 12px 0; border-top: 1px solid var(--border); border-bottom: 1px solid var(--border); margin-bottom: 56px; }
+  .meta span b { color: var(--text-dim); font-weight: 500; }
+
+  section { margin-bottom: 64px; scroll-margin-top: 24px; }
+
+  .section-label { display: flex; align-items: center; gap: 12px; font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--cyan); margin-bottom: 14px; }
+  .section-label .dot { width: 7px; height: 7px; background: var(--cyan); border-radius: 50%; flex-shrink: 0; }
+  .section-label .num { font-weight: 500; color: var(--gold); }
+  .section-label .rule { flex: 1; height: 1px; background: var(--border-bright); }
+
+  h2 { font-family: var(--font-body); font-weight: 500; font-size: clamp(26px, 3vw, 34px); line-height: 1.15; letter-spacing: -0.015em; margin: 0 0 12px; color: var(--text); }
+  .subhead { color: var(--text-dim); font-size: 15px; margin: 0 0 28px; max-width: 72ch; line-height: 1.55; }
+  p.body { color: var(--text-dim); font-size: 14.5px; max-width: 72ch; line-height: 1.6; }
+  p.body strong { color: var(--text); font-weight: 600; }
+  p.body code, li code { font-family: var(--font-mono); font-size: 12px; background: var(--surface-recessed); color: var(--cyan); padding: 1px 6px; border-radius: 2px; border: 1px solid var(--border); }
+
+  .boundary { background: var(--surface); border: 1px solid var(--border-bright); border-radius: var(--radius); padding: clamp(24px, 3vw, 36px); margin-bottom: 56px; position: relative; }
+  .boundary::before { content: 'AXIOM'; position: absolute; top: -10px; left: 20px; font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.2em; color: var(--gold); background: var(--bg); padding: 0 8px; }
+  .boundary p { font-family: var(--font-body); font-size: clamp(18px, 2vw, 22px); line-height: 1.5; color: var(--text); margin: 0; max-width: 72ch; }
+  .boundary .accent { color: var(--gold); font-weight: 500; }
+  .boundary .accent-2 { color: var(--cyan); font-weight: 500; }
+
+  /* Two-tool diptych */
+  .diptych { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 32px; }
+  @media (max-width: 760px) { .diptych { grid-template-columns: 1fr; } }
+  .tool-card { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 24px; display: flex; flex-direction: column; gap: 14px; }
+  .tool-card.codex { border-top: 2px solid var(--cyan); }
+  .tool-card.t3 { border-top: 2px solid var(--gold); }
+  .tool-card .role { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.18em; text-transform: uppercase; color: var(--text-faint); }
+  .tool-card .role .runner { color: var(--cyan); }
+  .tool-card.t3 .role .runner { color: var(--gold); }
+  .tool-card h3 { font-family: var(--font-mono); font-weight: 500; font-size: 18px; margin: 0; color: var(--text); letter-spacing: -0.01em; }
+  .tool-card .pitch { color: var(--text-dim); font-size: 14px; line-height: 1.55; margin: 0; }
+  .tool-card ul { list-style: none; padding: 0; margin: 4px 0 0; display: flex; flex-direction: column; gap: 8px; }
+  .tool-card li { color: var(--text); font-size: 13px; line-height: 1.5; padding-left: 18px; position: relative; }
+  .tool-card li::before { content: ''; position: absolute; left: 0; top: 9px; width: 8px; height: 1px; background: var(--cyan); }
+  .tool-card.t3 li::before { background: var(--gold); }
+
+  /* Layer / verdict rows */
+  .layers { display: grid; grid-template-columns: 1fr; gap: 8px; }
+  .layer { display: grid; grid-template-columns: 150px 1fr 132px; align-items: center; gap: 20px; padding: 16px 20px; background: var(--surface); border: 1px solid var(--border); border-left: 3px solid var(--border-bright); border-radius: var(--radius); }
+  @media (max-width: 680px) { .layer { grid-template-columns: 1fr; gap: 6px; } .layer .owner { text-align: left; } }
+  .layer .id { font-family: var(--font-mono); font-size: 14px; font-weight: 500; color: var(--cyan); letter-spacing: -0.01em; }
+  .layer .who { font-family: var(--font-body); font-weight: 500; color: var(--text); font-size: 14.5px; margin: 0 0 4px; }
+  .layer .what { color: var(--text-dim); font-size: 13px; margin: 0; }
+  .layer .owner { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase; text-align: right; color: var(--text-faint); }
+  .layer .owner .own-have { color: var(--sage); }
+  .layer .owner .own-partial { color: var(--gold); }
+  .layer .owner .own-gap { color: var(--rust); }
+  .layer.have { border-left-color: var(--sage); background: linear-gradient(to right, var(--sage-dim) 0%, var(--surface) 30%); }
+  .layer.partial { border-left-color: var(--gold); background: linear-gradient(to right, var(--gold-dim) 0%, var(--surface) 30%); }
+  .layer.gap { border-left-color: var(--rust); background: linear-gradient(to right, var(--rust-dim) 0%, var(--surface) 30%); }
+
+  /* Tables */
+  .tbl-wrap { border: 1px solid var(--border-bright); border-radius: var(--radius); overflow: hidden; background: var(--surface); margin-bottom: 12px; }
+  table { width: 100%; border-collapse: collapse; font-size: 13px; }
+  thead th { background: var(--surface-recessed); font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--text-dim); text-align: left; padding: 12px 16px; border-bottom: 1px solid var(--border-bright); font-weight: 500; position: sticky; top: 0; }
+  tbody td { padding: 14px 16px; border-bottom: 1px solid var(--border); vertical-align: top; color: var(--text); line-height: 1.5; }
+  tbody tr:last-child td { border-bottom: 0; }
+  tbody tr:hover td { background: var(--surface-elevated); }
+  td code, th code { font-family: var(--font-mono); font-size: 11.5px; background: var(--surface-recessed); color: var(--cyan); padding: 2px 6px; border-radius: 2px; border: 1px solid var(--border); white-space: nowrap; }
+  .pill { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; padding: 2px 8px; border-radius: 2px; white-space: nowrap; }
+  .pill.have { color: var(--sage); border: 1px solid var(--sage); background: var(--sage-dim); }
+  .pill.partial { color: var(--gold); border: 1px solid var(--gold); background: var(--gold-dim); }
+  .pill.gap { color: var(--rust); border: 1px solid var(--rust); background: var(--rust-dim); }
+
+  /* Priority cards */
+  .prio { display: grid; grid-template-columns: 1fr; gap: 14px; }
+  .pcard { background: var(--surface); border: 1px solid var(--border); border-radius: var(--radius); padding: 22px 24px; position: relative; }
+  .pcard.p1 { border-top: 2px solid var(--gold); background: linear-gradient(to bottom, var(--gold-dim) 0%, var(--surface) 40%); }
+  .pcard.p2 { border-top: 2px solid var(--cyan); }
+  .pcard.p3 { border-top: 2px solid var(--border-bright); background: var(--surface-recessed); }
+  .pcard .ptag { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.16em; text-transform: uppercase; color: var(--text-faint); display: flex; gap: 12px; align-items: center; margin-bottom: 10px; }
+  .pcard.p1 .ptag .rank { color: var(--gold); }
+  .pcard.p2 .ptag .rank { color: var(--cyan); }
+  .pcard h3 { font-family: var(--font-body); font-weight: 600; font-size: 19px; margin: 0 0 8px; color: var(--text); letter-spacing: -0.01em; }
+  .pcard p { color: var(--text-dim); font-size: 14px; line-height: 1.6; margin: 0 0 10px; max-width: 74ch; }
+  .pcard p:last-child { margin-bottom: 0; }
+  .pcard .why { font-family: var(--font-mono); font-size: 11.5px; color: var(--text-faint); }
+  .pcard .why b { color: var(--cyan); font-weight: 500; }
+  .pcard code { font-family: var(--font-mono); font-size: 12px; background: var(--surface-recessed); color: var(--cyan); padding: 1px 6px; border-radius: 2px; border: 1px solid var(--border); }
+  .pcard.p1 code { color: var(--gold); }
+
+  .signoff { margin-top: 64px; padding-top: 24px; border-top: 1px solid var(--border-bright); display: flex; justify-content: space-between; align-items: baseline; font-family: var(--font-mono); font-size: 11px; letter-spacing: 0.06em; color: var(--text-faint); flex-wrap: wrap; gap: 12px; }
+  .signoff .lhs b { color: var(--gold); }
+  .signoff .rhs { color: var(--text-dim); }
+
+  @media (prefers-reduced-motion: no-preference) {
+    section, .boundary, .meta { animation: rise 600ms ease both; }
+    section:nth-of-type(2) { animation-delay: 100ms; }
+    section:nth-of-type(3) { animation-delay: 200ms; }
+    section:nth-of-type(4) { animation-delay: 300ms; }
+    section:nth-of-type(5) { animation-delay: 400ms; }
+    section:nth-of-type(6) { animation-delay: 500ms; }
+    section:nth-of-type(7) { animation-delay: 600ms; }
+    @keyframes rise { from { opacity: 0; transform: translateY(12px); } to { opacity: 1; transform: translateY(0); } }
+  }
+</style>
+</head>
+<body>
+
+<div class="shell">
+
+  <nav class="toc" aria-label="Table of contents">
+    <span class="label">Contents</span>
+    <ol>
+      <li><a href="#thesis">The thesis</a></li>
+      <li><a href="#tools">The two tools</a></li>
+      <li><a href="#matrix">Feature matrix</a></li>
+      <li><a href="#worktree">Worktree + review</a></li>
+      <li><a href="#sleepers">Sleeper features</a></li>
+      <li><a href="#adopt">What to adopt</a></li>
+      <li><a href="#skip">What to skip</a></li>
+    </ol>
+  </nav>
+
+  <main>
+
+    <header>
+      <span class="stamp">SumoCode · Competitive Feature Audit</span>
+      <h1>
+        Codex App &amp; T3 Code,<br>
+        read through a <span class="hl">terminal-native</span> lens.
+      </h1>
+      <p class="lede">
+        Both apps are <strong>GUI orchestration shells</strong> wrapped around agent backends.
+        SumoCode is a retained <strong>TUI</strong> inside a cmux surface. The features that
+        translate are the <em>workflow primitives</em> — worktree isolation, turn-scoped review,
+        one-shot ship — not the Electron chrome. This audit maps every notable feature to what
+        SumoCode already has, what's partial, and what's worth building.
+      </p>
+      <div class="meta">
+        <span><b>Sources</b> developers.openai.com/codex · github.com/t3-oss/t3-code</span>
+        <span><b>Reviewed</b> Codex app, T3 Code v0.x</span>
+        <span><b>SumoCode</b> v0.3.0 · Pi 0.75.3</span>
+        <span><b>Date</b> 2026-05-28</span>
+      </div>
+    </header>
+
+    <section id="thesis">
+      <div class="section-label"><span class="dot"></span><span class="num">01</span> The thesis <span class="rule"></span></div>
+      <div class="boundary">
+        <p>
+          Codex and T3 Code both solve the same friction: <span class="accent-2">run agents in parallel
+          without them stomping each other, then review and ship the result without leaving the app.</span>
+          SumoCode already owns the hard part — a real retained renderer and a background-task tool.
+          What's missing is the <span class="accent">git-isolation + structured-review loop</span> that
+          turns "an agent edited my files" into "an agent worked in its own worktree and I shipped its
+          diff in one keystroke."
+        </p>
+      </div>
+      <p class="body">
+        Read the two products differently. <strong>Codex app</strong> is the mature reference design — its
+        worktree handoff model, review pane with inline comments, and automations are the canonical spec.
+        <strong>T3 Code</strong> is the lean OSS take — it proves the same primitives (worktree-per-task,
+        one-click commit→push→PR, per-turn diff) ship in a small surface. SumoCode should borrow Codex's
+        <em>model</em> and T3's <em>scope discipline</em>.
+      </p>
+    </section>
+
+    <section id="tools">
+      <div class="section-label"><span class="dot"></span><span class="num">02</span> The two tools <span class="rule"></span></div>
+      <div class="diptych">
+        <div class="tool-card codex">
+          <div class="role">REFERENCE · <span class="runner">OpenAI Codex app</span></div>
+          <h3>codex.app</h3>
+          <p class="pitch">Electron desktop "command center for agentic coding." Mature, broad, ChatGPT-account gated. The feature spec everyone copies.</p>
+          <ul>
+            <li>Three thread modes: <b>Local / Worktree / Cloud</b></li>
+            <li>Worktree handoff between background &amp; foreground</li>
+            <li>Review pane: inline comments, stage/revert per hunk</li>
+            <li><code>/review</code> code review → inline findings</li>
+            <li>Commit / push / open PR in-app</li>
+            <li>Automations + thread automations (cron + heartbeat)</li>
+            <li>Integrated terminal scoped per thread (Cmd+J)</li>
+            <li>In-app browser w/ element comments; computer use</li>
+            <li>Voice dictation, image gen/input, pop-out window</li>
+            <li>Skills, MCP, memories shared across app/CLI/IDE</li>
+          </ul>
+        </div>
+        <div class="tool-card t3">
+          <div class="role">LEAN OSS · <span class="runner">T3 Code (Theo / t3-oss)</span></div>
+          <h3>t3-oss/t3-code</h3>
+          <p class="pitch">Free, open-source, BYOK GUI front-end for existing agents (Codex now; Claude Code, Cursor, Gemini planned). Proves the primitives in a small surface.</p>
+          <ul>
+            <li>Three-panel layout: projects · threads · chat</li>
+            <li>Multi-repo, multi-agent parallelism</li>
+            <li>Native <b>git worktree</b> per task</li>
+            <li>One-click <b>commit → push → create PR</b></li>
+            <li>Per-turn diff viewer (unified + split)</li>
+            <li>Thread sidebar reflects PR status (open/merged/closed)</li>
+            <li>Custom quick actions (project-scoped shell buttons)</li>
+            <li>Auto-run setup actions on new worktree (<code>npm install</code>)</li>
+            <li>Chat vs plan mode; supervised vs full-access</li>
+            <li>Integrated terminal; skills + headless mode planned</li>
+          </ul>
+        </div>
+      </div>
+      <p class="body">
+        The overlap is the signal. Both independently shipped <strong>worktree-per-task</strong>,
+        <strong>one-shot ship</strong>, and <strong>structured diff review</strong> as their headline
+        features. That convergence is the strongest argument for adopting those three in SumoCode.
+      </p>
+    </section>
+
+    <section id="matrix">
+      <div class="section-label"><span class="dot"></span><span class="num">03</span> Feature matrix vs SumoCode <span class="rule"></span></div>
+      <p class="subhead">Every notable feature from both products, scored against what SumoCode ships today (v0.3.0). <span style="color:var(--sage)">HAVE</span> = exists · <span style="color:var(--gold)">PARTIAL</span> = adjacent primitive exists · <span style="color:var(--rust)">GAP</span> = not present.</p>
+      <div class="tbl-wrap">
+        <table>
+          <thead>
+            <tr><th>Feature</th><th>Codex</th><th>T3</th><th>SumoCode today</th><th style="text-align:right">Status</th></tr>
+          </thead>
+          <tbody>
+            <tr><td><b>Worktree-per-task isolation</b></td><td>✓</td><td>✓</td><td>No git worktree mgmt; bg_task runs in cwd</td><td style="text-align:right"><span class="pill gap">Gap</span></td></tr>
+            <tr><td><b>Handoff (worktree ⇄ local)</b></td><td>✓</td><td>—</td><td>No branch-relocation flow yet</td><td style="text-align:right"><span class="pill gap">Gap</span></td></tr>
+            <tr><td><b>Structured diff review</b></td><td>✓ pane</td><td>✓ per-turn</td><td><code>/sumo:diff</code> opens hunkdiff in split</td><td style="text-align:right"><span class="pill partial">Partial</span></td></tr>
+            <tr><td><b>Agent-driven code review</b></td><td><code>/review</code></td><td>—</td><td><code>/sumo:review</code> scribe loop until GREEN</td><td style="text-align:right"><span class="pill have">Have+</span></td></tr>
+            <tr><td><b>Inline review comments → agent</b></td><td>✓</td><td>—</td><td>None — review is text findings only</td><td style="text-align:right"><span class="pill gap">Gap</span></td></tr>
+            <tr><td><b>Commit / push / open PR in-app</b></td><td>✓</td><td>✓ 1-click</td><td>Agent can run <code>gh</code> via bash; no UI flow</td><td style="text-align:right"><span class="pill partial">Partial</span></td></tr>
+            <tr><td><b>PR status on thread sidebar</b></td><td>✓</td><td>✓</td><td>Sidebar has no PR/git surface</td><td style="text-align:right"><span class="pill gap">Gap</span></td></tr>
+            <tr><td><b>Parallel agents / projects</b></td><td>✓</td><td>✓</td><td>bg_task sumocode panes + pi-subagents</td><td style="text-align:right"><span class="pill have">Have</span></td></tr>
+            <tr><td><b>Integrated terminal per task</b></td><td>✓</td><td>✓</td><td>cmux splits already are this</td><td style="text-align:right"><span class="pill have">Have</span></td></tr>
+            <tr><td><b>Quick actions (shell buttons)</b></td><td>✓ actions</td><td>✓</td><td>Slash commands; no per-project buttons</td><td style="text-align:right"><span class="pill partial">Partial</span></td></tr>
+            <tr><td><b>Auto-run setup on new env</b></td><td>✓ local env</td><td>✓</td><td>None (no worktree lifecycle)</td><td style="text-align:right"><span class="pill gap">Gap</span></td></tr>
+            <tr><td><b>Scheduled automations (cron)</b></td><td>✓</td><td>—</td><td>None</td><td style="text-align:right"><span class="pill gap">Gap</span></td></tr>
+            <tr><td><b>Thread automations (heartbeat)</b></td><td>✓</td><td>—</td><td>bg_task wakeups are completion-only</td><td style="text-align:right"><span class="pill gap">Gap</span></td></tr>
+            <tr><td><b>Plan vs chat mode</b></td><td>—</td><td>✓</td><td>fast-mode + task-mode toggles exist</td><td style="text-align:right"><span class="pill have">Have</span></td></tr>
+            <tr><td><b>Supervised vs full-access</b></td><td>✓ sandbox</td><td>✓</td><td>Pi approvals + Divine Query modal</td><td style="text-align:right"><span class="pill have">Have</span></td></tr>
+            <tr><td><b>Skills</b></td><td>✓</td><td>planned</td><td>Pi skills surfaced in SumoCode</td><td style="text-align:right"><span class="pill have">Have</span></td></tr>
+            <tr><td><b>MCP shared config</b></td><td>✓</td><td>—</td><td>mcp-config-reader + gateway</td><td style="text-align:right"><span class="pill have">Have</span></td></tr>
+            <tr><td><b>Memories across threads</b></td><td>✓</td><td>—</td><td>Memory surface + categorization</td><td style="text-align:right"><span class="pill have">Have+</span></td></tr>
+            <tr><td><b>Voice dictation</b></td><td>✓</td><td>—</td><td>None</td><td style="text-align:right"><span class="pill gap">Gap</span></td></tr>
+            <tr><td><b>In-app browser + element comments</b></td><td>✓</td><td>—</td><td>agent_browser tool (no comment loop)</td><td style="text-align:right"><span class="pill partial">Partial</span></td></tr>
+            <tr><td><b>Image gen / input</b></td><td>✓</td><td>—</td><td>Pi handles image input</td><td style="text-align:right"><span class="pill partial">Partial</span></td></tr>
+            <tr><td><b>Inline image rendering in chat</b></td><td>✓</td><td>—</td><td>SumoTUI drops image content parts — no block type</td><td style="text-align:right"><span class="pill gap">Gap</span></td></tr>
+            <tr><td><b>Image paste placeholder in editor</b></td><td>✓</td><td>—</td><td>Pastes raw temp file path as literal text</td><td style="text-align:right"><span class="pill gap">Gap</span></td></tr>
+            <tr><td><b>Pop-out / always-on-top window</b></td><td>✓</td><td>—</td><td>N/A — terminal-native</td><td style="text-align:right"><span class="pill gap">N/A</span></td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="body">
+        SumoCode is already strong on <strong>parallelism, review intelligence, memory, and approvals</strong>.
+        The clustered red is all one theme: <strong>git-isolation and the diff-to-ship loop</strong>. That's the
+        seam worth investing in.
+      </p>
+    </section>
+
+    <section id="worktree">
+      <div class="section-label"><span class="dot"></span><span class="num">04</span> The feature you liked: worktree + review <span class="rule"></span></div>
+      <h2>Codex's worktree model, decoded</h2>
+      <p class="subhead">This is the mechanic you responded to. Here's exactly how Codex implements it — and what maps cleanly onto SumoCode's cmux foundation. The default is a <em>plain interactive pane</em>, not a delegated task.</p>
+      <div class="layers">
+        <div class="layer have">
+          <div class="id">Modes</div>
+          <div><p class="who">Local / Worktree / Cloud at thread start</p><p class="what">Worktree creates a 2nd checkout in <code>$CODEX_HOME/worktrees</code>, detached HEAD, so branches stay clean.</p></div>
+          <div class="owner"><span class="own-have">cmux fits</span></div>
+        </div>
+        <div class="layer have">
+          <div class="id">Isolation</div>
+          <div><p class="who">Each worktree = own files, shared <code>.git</code></p><p class="what">A second sumocode session edits a feature branch while you keep working on main. No conflicts.</p></div>
+          <div class="owner"><span class="own-have">cmux pane fits</span></div>
+        </div>
+        <div class="layer partial">
+          <div class="id">Handoff</div>
+          <div><p class="who">Move a thread between Worktree ⇄ Local</p><p class="what">Codex runs the git plumbing to relocate work safely (one branch per worktree). SumoCode has no relocation flow yet.</p></div>
+          <div class="owner"><span class="own-partial">net-new git glue</span></div>
+        </div>
+        <div class="layer have">
+          <div class="id">Review</div>
+          <div><p class="who">Diff pane: uncommitted / branch / last-turn scopes</p><p class="what">Toggle staged/unstaged. Stage, unstage, revert per file or per hunk.</p></div>
+          <div class="owner"><span class="own-have">hunkdiff fits</span></div>
+        </div>
+        <div class="layer gap">
+          <div class="id">Inline</div>
+          <div><p class="who">+ button on any diff line → comment → agent fixes it</p><p class="what">Line-specific guidance beats a general instruction. <code>/review</code> findings land inline too.</p></div>
+          <div class="owner"><span class="own-gap">net-new</span></div>
+        </div>
+        <div class="layer gap">
+          <div class="id">Cleanup</div>
+          <div><p class="who">Keeps 15 most-recent worktrees; snapshots before delete</p><p class="what">Auto-prunes disposable worktrees, restores on demand. Permanent worktrees opt out.</p></div>
+          <div class="owner"><span class="own-gap">net-new</span></div>
+        </div>
+      </div>
+      <div class="boundary" style="margin-top:28px;margin-bottom:0">
+        <p>
+          <strong>bg_task is not required here.</strong> The default <code>/sumo:worktree &lt;task&gt;</code> just opens
+          a <span class="accent-2">plain interactive cmux pane</span> running sumocode inside a fresh git worktree —
+          the same <code>openCommandInNewSplit</code> plumbing <code>/sumo:diff</code> already uses. You drive that
+          session directly. bg_task only earns its place when you want to <span class="accent">dispatch-and-walk-away</span>
+          and have the orchestrator harvest the result.
+        </p>
+      </div>
+      <p class="body" style="margin-top:24px">
+        <strong>The win for SumoCode:</strong> <code>/sumo:worktree &lt;task&gt;</code> creates a git worktree under a
+        managed dir, opens a cmux split running sumocode in it, and auto-runs a configured setup action. You review
+        with the existing <code>/sumo:diff</code> + <code>/sumo:review</code>, then <code>/sumo:ship</code> does
+        commit→push→PR. Every piece is plumbing you already own — no delegation layer needed for the interactive path.
+      </p>
+    </section>
+
+    <section id="sleepers">
+      <div class="section-label"><span class="dot"></span><span class="num">05</span> Sleeper features you didn't ask about <span class="rule"></span></div>
+      <p class="subhead">Things buried in the docs that are quietly the most interesting for a power user.</p>
+      <div class="diptych">
+        <div class="tool-card codex">
+          <div class="role">CODEX · <span class="runner">underrated</span></div>
+          <h3>Thread automations</h3>
+          <p class="pitch">Recurring "wake-up calls" that <b>preserve a thread's context</b> — heartbeat polling, long-running follow-up loops, "check on this every hour and continue." This is more than cron: it's stateful resumption. SumoCode's bg_task only wakes on completion; a scheduled context-preserving wake is genuinely new.</p>
+        </div>
+        <div class="tool-card codex">
+          <div class="role">CODEX · <span class="runner">underrated</span></div>
+          <h3>Terminal output as context</h3>
+          <p class="pitch">Codex can <b>read the integrated terminal's live output</b> — check a dev server's status, refer back to a failed build — without you pasting it. cmux already hosts the terminal; piping a pane's scrollback into the agent's context on request is a small, high-leverage bridge.</p>
+        </div>
+        <div class="tool-card t3">
+          <div class="role">T3 · <span class="runner">underrated</span></div>
+          <h3>Quick actions on worktree create</h3>
+          <p class="pitch">Project-scoped shell buttons (<code>npm run dev</code>) with optional keybindings, and crucially <b>auto-run on new worktree</b>. This is the setup-script primitive that makes worktrees actually usable — a fresh checkout needs <code>install</code> before the agent can build.</p>
+        </div>
+        <div class="tool-card t3">
+          <div class="role">T3 · <span class="runner">underrated</span></div>
+          <h3>PR status on the thread list</h3>
+          <p class="pitch">The thread's sidebar icon reflects <b>open / merged / closed</b> PR state. Tiny touch, big orientation win when juggling several parallel agents. SumoCode's sidebar could surface a git/PR badge per session with one <code>gh</code> poll.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="adopt">
+      <div class="section-label"><span class="dot"></span><span class="num">06</span> Recommended: what to adopt <span class="rule"></span></div>
+      <p class="subhead">Ranked by leverage-to-effort, scoped to SumoCode's terminal-native reality. Each builds on primitives you already ship.</p>
+      <div class="prio">
+        <div class="pcard p1">
+          <div class="ptag"><span class="rank">PRIORITY 01</span> · highest leverage</div>
+          <h3>The worktree → review → ship loop</h3>
+          <p><code>/sumo:worktree &lt;task&gt;</code> creates a git worktree under a managed dir, opens a <b>plain interactive sumocode pane</b> inside it via a cmux split, and auto-runs a configured setup action. You drive that session directly. Review with the existing <code>/sumo:diff</code> + <code>/sumo:review</code>, then <code>/sumo:ship</code> commits, pushes, and opens the PR.</p>
+          <p class="why"><b>Why first:</b> it's the convergent feature both products lead with, it's exactly what you flagged, and every piece (cmux splits via <code>openCommandInNewSplit</code>, hunkdiff, review scribe, gh) already exists. <b>No bg_task needed</b> — the interactive pane is the same plumbing <code>/sumo:diff</code> uses. This is assembly, not invention.</p>
+        </div>
+        <div class="pcard p2">
+          <div class="ptag"><span class="rank">PRIORITY 02</span> · strong follow-up</div>
+          <h3>Handoff + an optional detached flavor</h3>
+          <p>Two things here. (a) <b>Handoff</b>: git glue to relocate a worktree's branch into the main session for inspection, or push a foreground thread into a background worktree — Codex's value is the safe one-branch-per-worktree enforcement. (b) An opt-in <code>/sumo:worktree --detach</code> that routes through <b>bg_task's sumocode runner</b> for the genuine dispatch-and-walk-away / fan-out-N-agents case, where the orchestrator harvests results.</p>
+          <p class="why"><b>Why:</b> the interactive pane (P1) covers the common case; bg_task is the right tool only when you want programmatic result collection, not babysitting.</p>
+        </div>
+        <div class="pcard p2">
+          <div class="ptag"><span class="rank">PRIORITY 03</span> · self-contained quick win</div>
+          <h3>Inline image rendering in the transcript</h3>
+          <p>Pi ships an <code>Image</code> TUI component that renders in Kitty / iTerm2 / Ghostty / WezTerm — and cmux embeds libghostty, so it qualifies. SumoTUI's retained renderer never wired it up: <code>ChatBlock</code> has no image variant, and <code>blocksFromContentPart</code> hits its <code>default:</code> case for <code>type: "image"</code> parts and drops them. Add an <code>image</code> block type, carry the base64 + MIME through the view-model, and render via Pi's <code>Image</code> in the scroll-renderer.</p>
+          <p class="why"><b>Why:</b> pasted/generated images currently vanish in default mode — Pi's classic renderer would have shown them. No new dependency (the component is Pi's), no protocol work, no git surface. Pure assembly inside <code>src/sumo-tui/transcript</code>.</p>
+        </div>
+        <div class="pcard p2">
+          <div class="ptag"><span class="rank">PRIORITY 04</span> · editor polish · OpenCode-style</div>
+          <h3>Show <code>[Image 1]</code> in the editor on image paste</h3>
+          <p>Pi's <code>handleClipboardImagePaste()</code> writes the clipboard image to a temp file and does <code>insertTextAtCursor(filePath)</code> — so the composer shows a raw <code>/var/folders/…/pi-clipboard-&lt;uuid&gt;.png</code> path as literal text. OpenCode instead inserts a readable <code>[Image #1]</code> token, keeps a side-map of token→path, and expands tokens back into real attachments on submit.</p>
+          <p class="why"><b>Why · distinct from P3:</b> P3 renders a <em>sent</em> image in the transcript; this keeps the <em>input</em> legible while composing and lets you stack several. Touches three points — intercept <code>onPasteImage</code>, hold token→path in <code>editor-draft-state.ts</code>, expand on submit. Medium effort: it overrides Pi-default behavior, so the non-SumoTUI path must stay intact.</p>
+        </div>
+        <div class="pcard p2">
+          <div class="ptag"><span class="rank">PRIORITY 05</span> · cheap, high-orientation</div>
+          <h3>Git/PR badge in the sidebar + quick actions</h3>
+          <p>Surface per-session branch + PR status (open/merged/closed) in the sidebar via a cached <code>gh</code> poll. Add project-scoped quick actions (configurable shell buttons, auto-run on worktree create) — the T3 setup-script primitive.</p>
+          <p class="why"><b>Why:</b> small surface, big day-to-day clarity when several agents run in parallel.</p>
+        </div>
+        <div class="pcard p3">
+          <div class="ptag"><span class="rank">PRIORITY 06</span> · exploratory</div>
+          <h3>Stateful scheduled automations</h3>
+          <p>Context-preserving thread wake-ups (cron + heartbeat) on top of bg_task. Plus a "read this cmux pane's output into context" bridge. Genuinely new capability, but heavier and less requested — stage it after the core loop proves out.</p>
+          <p class="why"><b>Why last:</b> highest novelty, lowest certainty of payoff; revisit once the worktree loop is daily-driven.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="skip">
+      <div class="section-label"><span class="dot"></span><span class="num">07</span> What to skip <span class="rule"></span></div>
+      <p class="subhead">Features that don't translate to a terminal-native tool, or that SumoCode already covers better elsewhere.</p>
+      <div class="tbl-wrap">
+        <table>
+          <thead><tr><th>Feature</th><th>Why skip</th></tr></thead>
+          <tbody>
+            <tr><td><b>Pop-out / always-on-top window</b></td><td>GUI-only affordance. cmux/tmux pane management already covers spatial arrangement.</td></tr>
+            <tr><td><b>In-app browser + element comments</b></td><td>Heavy. <code>agent_browser</code> + <code>chrome-devtools</code> MCP already give SumoCode real browser control; element-comment UX isn't worth a custom renderer.</td></tr>
+            <tr><td><b>Computer use (drive macOS apps)</b></td><td>Large surface, narrow payoff, region-restricted even in Codex. Out of scope for a coding TUI.</td></tr>
+            <tr><td><b>Image generation in-thread</b></td><td>Nice-to-have, not workflow-critical. Pi handles image input already; generation is a model/provider concern.</td></tr>
+            <tr><td><b>Cloud thread mode</b></td><td>Requires hosted infra. SumoCode is local-first by design; bg_task + worktrees give the parallelism without a backend.</td></tr>
+            <tr><td><b>Voice dictation</b></td><td>OS-level dictation already exists; low marginal value inside the TUI.</td></tr>
+            <tr><td><b>Three-panel Electron layout</b></td><td>SumoTUI's sidebar + transcript + footer is the terminal-native equivalent and is already the house design.</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p class="body">
+        The discipline here mirrors T3's: don't rebuild Electron chrome in a terminal. Adopt the
+        <strong>workflow primitives</strong> that convergent products validated, lean on MCP for the
+        browser/vision surface, and keep SumoCode's identity — a fast, retained, cmux-native renderer.
+      </p>
+    </section>
+
+    <div class="signoff">
+      <div class="lhs"><b>SumoCode</b> · codex + t3code feature audit · v0.3.0</div>
+      <div class="rhs">zeus ⚡ · sumodeus temple · 2026-05-28</div>
+    </div>
+
+  </main>
+</div>
+
+</body>
+</html>

--- a/docs/research/v0.4-roadmap.md
+++ b/docs/research/v0.4-roadmap.md
@@ -1,0 +1,155 @@
+# SumoCode v0.4 Roadmap
+
+Milestone: **v0.4** · Branch lineage: `spike/codex-t3code-features`
+Date: 2026-05-28
+
+Theme: **adopt the workflow + TUI primitives that Codex app and T3 Code
+validated**, scoped to SumoCode's terminal-native reality. Source of truth:
+
+- `docs/research/codex-t3code-feature-audit.html` — the competitive feature audit
+- `docs/research/worktree-fanout-grilling.md` — design decisions D1–D10
+
+Everything below ships in v0.4.
+
+---
+
+## The spine: worktree fan-out, built on a hardened bg_task
+
+The headline is the **worktree → review → ship** loop, plus the ability for the
+orchestrator to **fan out N subagents across N branches** and reconcile them.
+That ambition exposed real weaknesses in `bg_task`, so v0.4 sequences as:
+
+```
+PR1  harden bg_task   ──►  PR2  worktree fan-out  ──►  /sumo:ship
+(durable, liveness,        (worktree:true on the      (commit→push→PR,
+ cap, notify-gap)           stable base)               staged + gated)
+```
+
+Sequencing (D8): **harden first.** Bolting worktree ownership on today's
+reload-fragile manager would orphan panes AND worktrees on `/reload` and lose
+the branch↔subagent map. Durability is a prerequisite, not polish.
+
+---
+
+## Workstreams
+
+### A. bg_task hardening (PR1) — the foundation
+
+The audit found bg_task is careful internally but is a single-session,
+in-memory, poll-based system wearing the costume of a durable one (`meta.json`
+is written but never read back). PR1 makes the manager a **reconciler, not an
+owner**.
+
+- **Durable registry + recovery** (audit #1): read `meta.json` on startup,
+  rehydrate tasks, reconcile status from `exit.code` / `response.md` /
+  pane-liveness. Recovery stops being a "future feature."
+- **Stable IDs** (audit #2): not a per-process counter that collides after reload.
+- **Real-exit liveness** (audit #3/#4, D4): "completed" = agent loop actually
+  ended, not first `response.md`. Detection mechanism TBD in implementation
+  (child exit-marker mirroring the shell runner's `exit.code` is the leading
+  candidate; pane-liveness backstop later).
+- **Pane lifecycle = orchestrator-owned** (D5, model A): subagent is single-shot;
+  process exits but the cmux pane stays open as a preserved viewport; orchestrator
+  inspects then explicitly keeps/closes. Suppress the current 10s idle auto-close.
+- **The notify-gap fix** (must-fix): the agent **success** path sets
+  `status="completed"` then returns silently — never reaching `sendUserMessage` /
+  `fireCmuxNotify`. The **failure** path DOES notify. Route agent success through
+  the notify path so harvest-complete wakes the orchestrator (root of "I have to
+  prompt it to check").
+- **Concurrency cap** (audit #8, D9): conservative ceiling on `runner=sumocode`
+  panes (~3-4). Over-cap = cooperative backpressure: successful result with
+  `status="at_capacity"`, "this is expected, wait" prose, running set, next-action
+  line, structured details. Slot-free wakeup reuses the notify-gap fix. No queue
+  yet.
+- **Lifecycle GC + log cap** (audit #6/#7): prune task dirs on clear / age-out on
+  startup; cap log file size.
+
+### B. Worktree fan-out (PR2) — on the hardened base
+
+- **`worktree: true` param** on `bg_task spawn` (D2): bg_task creates the worktree
+  and tracks its ref in the task record (next to the cmux ref); recovery rehydrates
+  both.
+- **Named branch up front** (D1): worktree on `sumo/<slug>` from current HEAD —
+  not detached HEAD. Makes ship trivial and the pane label readable.
+- **Never auto-remove** (D3): worktree tracked but pruned only by explicit action
+  (`bg_task clear` flag or `/sumo:worktree prune`). Pane close ≠ worktree removal.
+  Protects uncommitted subagent work. Commit-gated removal is a later refinement.
+- **Shared git module** (D6): `src/git/worktree.ts`, typed-result surface mirroring
+  `cmux-split.ts`, `execFile`-based (no shell-string git, matching
+  `session-cache.ts`). Exposes create / list / remove + pure `isClean` /
+  `headAdvanced` helpers (for future commit-gated prune). Both `/sumo:worktree`
+  (interactive) and `bg_task` depend on `git/`; neither depends on the other.
+- **`/sumo:worktree <task>`** (interactive): creates a worktree, opens a plain
+  interactive sumocode pane in it (NOT bg_task — same `openCommandInNewSplit`
+  plumbing as `/sumo:diff`), auto-runs a configured setup action.
+
+### C. /sumo:ship — the ship leg (D10)
+
+Full **commit → push → open PR** capability, but **staged + human-gated**:
+
+- Generate commit message + show file summary → **commit locally** (safe) →
+  **confirm before push** → **confirm before `gh pr create`** (title/body
+  pre-filled, optionally open in browser).
+- AGENTS.md forbids unattended push/merge/PR — one-shot ship is off the table.
+- D1's named branch means ship just pushes + PRs (no branch creation).
+- Reuse `review.ts` gh patterns. Fan-out never auto-ships N PRs — per-branch, gated.
+
+### D. hunk diff portrait geometry (D7) — independent quick win
+
+`/sumo:diff` split direction by **orientation**, not width:
+
+- portrait (rows > cols) → **down** (full width preserved); landscape → right;
+  `--down` / `--right` override.
+- Aspect not width: the portrait monitor is >120 cols, so the sidebar policy's
+  width rule would wrongly pick right. Confirmed against two portrait screenshots
+  (registry open / closed) — user wants down in both.
+- Keep hunk in its own pane; no native in-transcript diff in V1.
+
+### E. Image features — independent of the worktree track
+
+Two distinct gaps, both traced to exact Pi code paths in the audit:
+
+- **Inline image rendering in transcript** (P3): `ChatBlock` has no image variant;
+  `blocksFromContentPart` drops `type:"image"` parts at its `default:` case. Pi
+  ships an `Image` TUI component (Kitty/iTerm2/Ghostty/WezTerm — cmux qualifies).
+  Add an `image` block, carry base64+MIME through the view-model, render via Pi's
+  `Image` in the scroll-renderer. Pure assembly in `src/sumo-tui/transcript`.
+- **Editor `[Image 1]` placeholder on paste** (P4, OpenCode-style): Pi's
+  `handleClipboardImagePaste()` does `insertTextAtCursor(filePath)` — the composer
+  shows a raw temp path. Insert a readable `[Image N]` token, hold token→path in
+  `editor-draft-state.ts`, expand on submit. Medium effort — overrides Pi-default
+  behavior; the non-SumoTUI path must stay intact.
+
+---
+
+## Issue map
+
+| # | Title | Workstream |
+|---|---|---|
+| 267 | feat(diff): aspect-based split direction (portrait → down) | D |
+| 268 | fix(bg_task): wake orchestrator on agent success (notify gap) | A |
+| 269 | feat(bg_task): durable registry + recovery across reload | A |
+| 270 | feat(bg_task): real-exit liveness + orchestrator-owned pane lifecycle | A |
+| 271 | feat(bg_task): concurrency cap as cooperative backpressure | A |
+| 272 | feat(bg_task): lifecycle GC + log-size cap | A |
+| 273 | feat(git): shared worktree module (src/git/worktree.ts) | B |
+| 274 | feat(worktree): worktree:true on bg_task spawn + never-auto-remove | B |
+| 275 | feat(worktree): /sumo:worktree interactive pane + setup action | B |
+| 276 | feat(ship): /sumo:ship staged commit→push→PR, human-gated | C |
+| 277 | feat(transcript): inline image rendering via Pi Image component | E |
+| 278 | feat(editor): [Image N] placeholder on image paste | E |
+
+**Dependency order (A → B → C; D, E independent):**
+`268 → 269 → 270 → 271 → 272` (PR1 hardening), then
+`273 → 274 → 275 → 276` (PR2 fan-out + ship). `267`, `277`, `278` parallelizable anytime.
+
+## Out of scope (parked for later)
+
+- **Idea B** — alive-and-re-promptable subagents (prompt injection into a running
+  child pane, per-turn harvest). Documented in the grilling doc. Revisit only if
+  single-shot model A proves insufficient.
+- Native in-transcript diff surface (fights the V1 overlay-seam caution).
+- Task queue for the concurrency cap (promote from reject-with-state only if needed).
+- Commit-gated auto-removal of worktrees.
+- Codex features deliberately skipped: pop-out window, in-app browser comments,
+  computer use, image generation, cloud thread mode, voice dictation.

--- a/docs/research/v0.4-roadmap.md
+++ b/docs/research/v0.4-roadmap.md
@@ -13,6 +13,12 @@ validated**, scoped to SumoCode's terminal-native reality.
 > are combined into one answer (audits, review, research). They co-exist cleanly
 > (no tool-name clash, different substrates). Workstream F (#279) decides the
 > boundary and the synthesis path; it does NOT block the production track.
+>
+> **cmux prior art, but not SumoCode-safe yet.** `pi-cmux` already has useful
+> split/worktree/review helpers, but its commands hardcode `exec pi`. Workstream
+> G (#280) decides the upstream-first compatibility seam (configurable agent
+> command/label) so SumoCode never loads a command path that accidentally launches
+> classic Pi.
 
 Source of truth:
 
@@ -149,10 +155,11 @@ Two distinct gaps, both traced to exact Pi code paths in the audit:
 | 277 | feat(transcript): inline image rendering via Pi Image component | E |
 | 278 | feat(editor): [Image N] placeholder on image paste | E |
 | 279 | feat(workflows): how pi-dynamic-workflows (synthesis) co-exists with worktree fan-out (production) | F |
+| 280 | feat(cmux): evaluate/upstream configurable pi-cmux agent command for SumoCode | G |
 
-**Dependency order (A → B → C; D, E independent):**
+**Dependency order (A → B → C; D, E, F, G independent):**
 `268 → 269 → 270 → 271 → 272` (PR1 hardening), then
-`273 → 274 → 275 → 276` (PR2 fan-out + ship). `267`, `277`, `278` parallelizable anytime.
+`273 → 274 → 275 → 276` (PR2 fan-out + ship). `267`, `277`, `278`, `279`, `280` parallelizable anytime.
 
 ### F. Synthesis fan-out co-existence (#279) — decision-only
 
@@ -165,6 +172,26 @@ expressed as a workflow script (likely poor fit — visible panes + durability).
 Mine its determinism rules + compact progress UX for the concurrency-cap work
 (#271). Outputs a decision doc/ADR; does not implement and does not change the
 production track.
+
+### G. pi-cmux compatibility / upstream-first boundary (#280) — decision + optional upstream patch
+
+`pi-cmux` is valuable prior art for cmux splits, worktree continuation, review
+splits, tab titles, and notifications. But today its `buildPiCommand()` hardcodes
+`exec pi`, so loading its commands inside SumoCode would launch classic Pi and
+bypass `bin/sumocode.sh`, `SUMO_TUI=1`, diagnostics, and retained rendering.
+
+Resolve whether to upstream a small compatibility seam such as:
+
+```bash
+PI_CMUX_AGENT_COMMAND="sumocode"
+PI_CMUX_AGENT_LABEL="SumoCode"
+PI_CMUX_NOTIFY_TITLE="SumoCode"
+```
+
+Default behavior remains Pi (`exec pi`), while SumoCode's launcher opts into the
+SumoCode command/label. Until that seam exists, `pi-cmux` remains prior art only;
+SumoCode keeps its local cmux layer (`src/commands/cmux-split.ts`) for product
+commands.
 
 ## Out of scope (parked for later)
 

--- a/docs/research/v0.4-roadmap.md
+++ b/docs/research/v0.4-roadmap.md
@@ -19,6 +19,12 @@ validated**, scoped to SumoCode's terminal-native reality.
 > G (#280) decides the upstream-first compatibility seam (configurable agent
 > command/label) so SumoCode never loads a command path that accidentally launches
 > classic Pi.
+>
+> **Startup performance is in scope.** PR #257 is included in v0.4, but not as a
+> blind merge. Its first-frame speedups currently make startup visually weird by
+> deferring/replaying too much UI registration. Workstream H (#281 + PR #257)
+> stabilizes startup as an explicit phased boot contract: fast first frame,
+> stable chrome, no progressive UI glitches.
 
 Source of truth:
 
@@ -156,10 +162,12 @@ Two distinct gaps, both traced to exact Pi code paths in the audit:
 | 278 | feat(editor): [Image N] placeholder on image paste | E |
 | 279 | feat(workflows): how pi-dynamic-workflows (synthesis) co-exists with worktree fan-out (production) | F |
 | 280 | feat(cmux): evaluate/upstream configurable pi-cmux agent command for SumoCode | G |
+| PR 257 | perf(startup): speed up sumocode launcher | H |
+| 281 | perf(startup): stabilize PR #257 startup speedup without UI glitches | H |
 
-**Dependency order (A → B → C; D, E, F, G independent):**
+**Dependency order (A → B → C; D, E, F, G, H independent):**
 `268 → 269 → 270 → 271 → 272` (PR1 hardening), then
-`273 → 274 → 275 → 276` (PR2 fan-out + ship). `267`, `277`, `278`, `279`, `280` parallelizable anytime.
+`273 → 274 → 275 → 276` (PR2 fan-out + ship). `267`, `277`, `278`, `279`, `280`, `257/281` parallelizable anytime.
 
 ### F. Synthesis fan-out co-existence (#279) — decision-only
 
@@ -192,6 +200,29 @@ Default behavior remains Pi (`exec pi`), while SumoCode's launcher opts into the
 SumoCode command/label. Until that seam exists, `pi-cmux` remains prior art only;
 SumoCode keeps its local cmux layer (`src/commands/cmux-split.ts`) for product
 commands.
+
+### H. Startup performance without UI glitches (PR #257 + #281)
+
+PR #257 has real wins (launcher fast path, benchmark cleanup, early diagnostics,
+Node compile cache, import splitting), but the merge blocker is visual stability.
+The late commits make first splash faster by deferring most chrome/tool
+registration past `session_start` and replaying lifecycle handlers into dynamic
+imports. That means the user can see splash, owned shell, top chrome, footer,
+editor, sidebar, and tools appear in separate async ticks.
+
+v0.4 includes the PR, but requires a disciplined stabilization pass:
+
+- rebase #257 onto current `main` without losing helper-subprocess/task-mode/bg_task
+  guards (`PI_CMUX_CHILD`, `SUMOCODE_BG_CHILD`, `SUMOCODE_TASK_MODE`, bg_task,
+  task-mode auto-exit, fast-mode/footer wiring)
+- replace broad `session_start` replay with explicit phased startup APIs where
+  possible
+- keep a **critical synchronous shell** that renders a complete lightweight frame
+  (not a half-built one)
+- hydrate heavy internals after first frame behind already-mounted surfaces
+- add an `app-ready` / `stable-chrome` metric next to `first-frame`
+- produce visual/runtime evidence that startup does not glitch in portrait or
+  landscape
 
 ## Out of scope (parked for later)
 

--- a/docs/research/v0.4-roadmap.md
+++ b/docs/research/v0.4-roadmap.md
@@ -4,7 +4,17 @@ Milestone: **v0.4** · Branch lineage: `spike/codex-t3code-features`
 Date: 2026-05-28
 
 Theme: **adopt the workflow + TUI primitives that Codex app and T3 Code
-validated**, scoped to SumoCode's terminal-native reality. Source of truth:
+validated**, scoped to SumoCode's terminal-native reality.
+
+> **Two fan-out models, two halves.** SumoCode's worktree work (workstream B) is
+> *production* fan-out: N agents committing on N isolated git branches you
+> reconcile and ship. [pi-dynamic-workflows](https://github.com/Michaelliv/pi-dynamic-workflows)
+> (released 2026-05-28) is *synthesis* fan-out: in-memory subagents whose results
+> are combined into one answer (audits, review, research). They co-exist cleanly
+> (no tool-name clash, different substrates). Workstream F (#279) decides the
+> boundary and the synthesis path; it does NOT block the production track.
+
+Source of truth:
 
 - `docs/research/codex-t3code-feature-audit.html` — the competitive feature audit
 - `docs/research/worktree-fanout-grilling.md` — design decisions D1–D10
@@ -138,10 +148,23 @@ Two distinct gaps, both traced to exact Pi code paths in the audit:
 | 276 | feat(ship): /sumo:ship staged commit→push→PR, human-gated | C |
 | 277 | feat(transcript): inline image rendering via Pi Image component | E |
 | 278 | feat(editor): [Image N] placeholder on image paste | E |
+| 279 | feat(workflows): how pi-dynamic-workflows (synthesis) co-exists with worktree fan-out (production) | F |
 
 **Dependency order (A → B → C; D, E independent):**
 `268 → 269 → 270 → 271 → 272` (PR1 hardening), then
 `273 → 274 → 275 → 276` (PR2 fan-out + ship). `267`, `277`, `278` parallelizable anytime.
+
+### F. Synthesis fan-out co-existence (#279) — decision-only
+
+Define how `pi-dynamic-workflows`-style **synthesis** fan-out (in-memory
+subagents, model-authored JS DAG, deterministic vm sandbox, structured output)
+co-exists with SumoCode's **production** worktree fan-out (workstream B). Resolve:
+routing (`workflow` synthesis vs `bg_task worktree` production), adopt-vs-native
+vs relationship to `pi-subagents`, and whether worktree fan-out could ever be
+expressed as a workflow script (likely poor fit — visible panes + durability).
+Mine its determinism rules + compact progress UX for the concurrency-cap work
+(#271). Outputs a decision doc/ADR; does not implement and does not change the
+production track.
 
 ## Out of scope (parked for later)
 

--- a/docs/research/v0.4-roadmap.md
+++ b/docs/research/v0.4-roadmap.md
@@ -23,8 +23,8 @@ validated**, scoped to SumoCode's terminal-native reality.
 > **Startup performance is in scope.** PR #257 is included in v0.4, but not as a
 > blind merge. Its first-frame speedups currently make startup visually weird by
 > deferring/replaying too much UI registration. Workstream H (#281 + PR #257)
-> stabilizes startup as an explicit phased boot contract: fast first frame,
-> stable chrome, no progressive UI glitches.
+> stabilizes startup as an explicit boot contract: intentional animated loading
+> screen first, then a fully ready shell — never progressive partial chrome.
 
 Source of truth:
 
@@ -217,12 +217,13 @@ v0.4 includes the PR, but requires a disciplined stabilization pass:
   task-mode auto-exit, fast-mode/footer wiring)
 - replace broad `session_start` replay with explicit phased startup APIs where
   possible
-- keep a **critical synchronous shell** that renders a complete lightweight frame
-  (not a half-built one)
-- hydrate heavy internals after first frame behind already-mounted surfaces
+- **do not show a lightweight/partial shell**; show a deliberate Cathedral/Blueprint
+  boot screen with animation/status while SumoCode hydrates
+- hydrate heavy internals behind the boot screen
+- atomically reveal the real shell once app-ready/stable-chrome is reached
 - add an `app-ready` / `stable-chrome` metric next to `first-frame`
-- produce visual/runtime evidence that startup does not glitch in portrait or
-  landscape
+- produce visual/runtime evidence that startup transitions boot screen → full shell
+  with no progressive chrome/sidebar/footer glitches in portrait or landscape
 
 ## Out of scope (parked for later)
 

--- a/docs/research/v0.4-roadmap.md
+++ b/docs/research/v0.4-roadmap.md
@@ -20,11 +20,12 @@ validated**, scoped to SumoCode's terminal-native reality.
 > command/label) so SumoCode never loads a command path that accidentally launches
 > classic Pi.
 >
-> **Startup performance is in scope.** PR #257 is included in v0.4, but not as a
-> blind merge. Its first-frame speedups currently make startup visually weird by
-> deferring/replaying too much UI registration. Workstream H (#281 + PR #257)
-> stabilizes startup as an explicit boot contract: intentional animated loading
-> screen first, then a fully ready shell — never progressive partial chrome.
+> **Startup performance is in scope.** PR #257 was closed and superseded by
+> #282. The PR's diagnostics/benchmarks/import-splitting experiments remain
+> valuable, but its UX tradeoff was wrong: first-frame speedups caused progressive
+> partial chrome. Workstream H (#282) redesigns startup around an explicit boot
+> contract: intentional animated loading screen first, then a fully ready shell —
+> never progressive partial chrome.
 
 Source of truth:
 
@@ -162,12 +163,11 @@ Two distinct gaps, both traced to exact Pi code paths in the audit:
 | 278 | feat(editor): [Image N] placeholder on image paste | E |
 | 279 | feat(workflows): how pi-dynamic-workflows (synthesis) co-exists with worktree fan-out (production) | F |
 | 280 | feat(cmux): evaluate/upstream configurable pi-cmux agent command for SumoCode | G |
-| PR 257 | perf(startup): speed up sumocode launcher | H |
-| 281 | perf(startup): stabilize PR #257 startup speedup without UI glitches | H |
+| 282 | perf(startup): redesign boot flow with intentional loading screen (supersedes PR #257) | H |
 
 **Dependency order (A → B → C; D, E, F, G, H independent):**
 `268 → 269 → 270 → 271 → 272` (PR1 hardening), then
-`273 → 274 → 275 → 276` (PR2 fan-out + ship). `267`, `277`, `278`, `279`, `280`, `257/281` parallelizable anytime.
+`273 → 274 → 275 → 276` (PR2 fan-out + ship). `267`, `277`, `278`, `279`, `280`, `282` parallelizable anytime.
 
 ### F. Synthesis fan-out co-existence (#279) — decision-only
 
@@ -201,20 +201,23 @@ SumoCode command/label. Until that seam exists, `pi-cmux` remains prior art only
 SumoCode keeps its local cmux layer (`src/commands/cmux-split.ts`) for product
 commands.
 
-### H. Startup performance without UI glitches (PR #257 + #281)
+### H. Startup boot flow redesign (#282; supersedes closed PR #257)
 
-PR #257 has real wins (launcher fast path, benchmark cleanup, early diagnostics,
-Node compile cache, import splitting), but the merge blocker is visual stability.
-The late commits make first splash faster by deferring most chrome/tool
-registration past `session_start` and replaying lifecycle handlers into dynamic
-imports. That means the user can see splash, owned shell, top chrome, footer,
-editor, sidebar, and tools appear in separate async ticks.
+PR #257 had real wins (launcher fast path, benchmark cleanup, early diagnostics,
+Node compile cache, resume/chat hydration work, and import-splitting experiments),
+but the final UX tradeoff was wrong. The late commits made first splash faster by
+deferring most chrome/tool registration past `session_start` and replaying
+lifecycle handlers into dynamic imports. That means the user can see splash,
+owned shell, top chrome, footer, editor, sidebar, and tools appear in separate
+async ticks.
 
-v0.4 includes the PR, but requires a disciplined stabilization pass:
+v0.4 keeps the lessons from PR #257, but the implementation source of truth is
+#282:
 
-- rebase #257 onto current `main` without losing helper-subprocess/task-mode/bg_task
-  guards (`PI_CMUX_CHILD`, `SUMOCODE_BG_CHILD`, `SUMOCODE_TASK_MODE`, bg_task,
-  task-mode auto-exit, fast-mode/footer wiring)
+- mine/cherry-pick safe pieces from #257 onto current `main` without losing
+  helper-subprocess/task-mode/bg_task guards (`PI_CMUX_CHILD`,
+  `SUMOCODE_BG_CHILD`, `SUMOCODE_TASK_MODE`, bg_task, task-mode auto-exit,
+  fast-mode/footer wiring)
 - replace broad `session_start` replay with explicit phased startup APIs where
   possible
 - **do not show a lightweight/partial shell**; show a deliberate Cathedral/Blueprint

--- a/docs/research/worktree-fanout-grilling.md
+++ b/docs/research/worktree-fanout-grilling.md
@@ -1,0 +1,282 @@
+# Worktree fan-out + bg_task hardening — grilling decisions
+
+Branch: `spike/codex-t3code-features`
+Date: 2026-05-28
+Status: design notes from a grill-me session. Not yet implemented.
+
+Companion to `docs/research/codex-t3code-feature-audit.html` (the Codex/T3 feature
+audit). This file records the design decisions reached while grilling the
+adoption plan, focused on the P1 worktree loop and the bg_task changes it
+depends on.
+
+---
+
+## Context
+
+The audit recommended a P1 "worktree → review → ship" loop. During grilling the
+scope expanded: the orchestrator should be able to **fan out N subagents across
+N branches** (each in its own git worktree) and reconcile their work. That
+ambition exposed real weaknesses in the current `bg_task` implementation, so the
+plan now has two layers: harden `bg_task`, then build worktree fan-out on it.
+
+---
+
+## Decisions reached
+
+### D1 — Worktree git state: named branch up front
+
+`/sumo:worktree <task>` creates the worktree on a **named branch** (e.g.
+`sumo/<slug>`) from current HEAD — not Codex's detached-HEAD model.
+
+- Rationale: detached HEAD only pays off at Codex's fleet scale (15+ disposable
+  worktrees with snapshot/restore). We're not building a fleet manager. A named
+  branch makes `/sumo:ship` trivial (already on a branch → push + PR), makes the
+  pane label readable, and matches how a human drives one or two worktrees.
+- Cost accepted: every worktree leaves a branch behind; git forbids the same
+  branch checked out in two worktrees at once (the handoff/branch-lock rule).
+
+### D2 — Fan-out integration: `worktree: true` param on `bg_task` spawn
+
+`bg_task` itself creates the worktree before spawning the child in it, and
+**tracks the worktree ref in the task record** (next to the cmux ref), so
+stop/cleanup can find it.
+
+- One tool call per subagent: `bg_task spawn runner=sumocode worktree=true …`.
+- The worktree create/list/remove logic lives in a shared module that BOTH
+  `/sumo:worktree` (interactive, D-future) and `bg_task` (fan-out) call.
+
+### D3 — Worktree teardown: never auto-remove
+
+When a worktree-backed task ends, the **worktree folder is NOT auto-removed**.
+It is tracked so it CAN be pruned, but removal is a separate explicit action
+(`bg_task clear` with a flag, or a `/sumo:worktree prune` command).
+
+- Rationale: the fan-out's value is the surviving branches the orchestrator
+  reconciles. `git worktree remove` deletes the folder; committed branches
+  survive in the shared `.git`, but **uncommitted** changes are lost. Auto-remove
+  risks silently destroying a subagent's unsaved work.
+- Pane close ≠ worktree removal. Disk leak is acceptable; silent data loss is not.
+- Commit-gated removal (auto-remove only if HEAD advanced and no uncommitted
+  changes) is the PR-grade behavior later — it needs real git-state tests.
+
+### D4 — Completion trigger: real pane/agent EXIT, not first response.md
+
+"Completed" must mean the subagent's **agent loop actually ended**, not "first
+`agent_end` / first assistant message written." Today the manager marks a task
+`completed` the moment `response.md` appears (first turn), which is wrong for a
+multi-turn subagent that keeps working.
+
+- This forces audit finding #4 (manager has no liveness signal for the agent
+  child) to the front. Detection mechanism is parked behind D6 below.
+
+### D5 — Pane lifecycle: orchestrator owns keep/close (model A: dead-but-preserved)
+
+The pane/worktree is a **resource the orchestrator owns**. Nothing auto-closes.
+The subagent is **single-shot**: it finishes its task, writes its harvest, and
+the process exits — but the **cmux pane stays open** as a preserved viewport
+showing the final transcript. The orchestrator then wakes, inspects harvest +
+diff, and **explicitly decides keep or close** (and separately the worktree's
+fate per D3).
+
+- This dissolves the need for elaborate process-exit detection as the
+  *completion* trigger: we only need a **wake signal** (subagent idle / harvest
+  ready), then the orchestrator drives.
+- Re-engaging a finished subagent = spawn a NEW subagent.
+- Tiny child change: suppress the current 10s idle auto-close so the pane
+  persists after exit.
+
+### The notify gap (must-fix, independent of everything above)
+
+The agent **success** path (`armResponseWatcher`, task-manager.ts ~L431) sets
+`status="completed"` and writes meta — then **returns silently**. It never calls
+`finalizeTask`, so it never reaches `sendUserMessage` / `fireCmuxNotify`. The
+**failure** path (watchdog timeout) DOES notify. So a subagent that *succeeds*
+tells the orchestrator nothing; one that *times out* pings it — exactly backwards.
+
+This is the root of "I have to prompt the orchestrator to check." The shell
+runner already finalizes through the notify path correctly; the agent success
+branch just bypasses the wakeup that's already built. Fixing this is the
+concrete first step (route agent success through the notify path).
+
+---
+
+## Sequencing (proposed, not yet ratified)
+
+1. **Spike (this branch):** wire the notify gap + prove orchestrator-owns-close
+   ergonomics on top of today's bg_task, accepting reload-fragility. Throwaway.
+2. **Hardening PR:** durable registry (read meta.json on startup, reconcile),
+   stable IDs (not per-process counter), real liveness (D4 detection), pane
+   persistence (D5), GC + log-size cap + concurrency cap.
+3. **Worktree PR:** `worktree: true` (D2) + never-auto-remove (D3) on the now
+   stable base.
+
+The image features (P3 inline render, P4 editor `[Image 1]` placeholder) are
+implementation tasks, not spikes — they go straight to `to-issues`, independent
+of this track.
+
+---
+
+## bg_task audit findings (reference)
+
+The grilling was driven by an audit of `src/background-tasks/`. Findings, by tier:
+
+**Tier 1 — architecture gaps (the "half-assed" feel)**
+
+1. **No recovery across reload.** `session_shutdown` with reason ≠ `quit`
+   (`/reload`, `/new`, `/resume`, `/fork`) leaves children running but the new
+   manager starts empty. `meta.json` is **written but never read back** — recovery
+   is an admitted "future feature." After a reload, running tasks are orphaned:
+   `list` shows nothing, you can't `log` or `stop` them.
+2. **Counter IDs reset to 0 per manager** (`this.counter = 0` in the constructor).
+   A fresh `bg-1` collides with an on-disk `bg-1` from before the reload.
+3. **"completed" = response.md exists, not "agent done"** (see D4). First
+   `agent_end` marks a still-working multi-turn subagent as finished.
+4. **Agent child has no pid.** The sumocode child is `exec`'d inside the cmux
+   pane; the manager never learns its pid. `stop` = `cmux close-surface` and hope
+   SIGHUP lands. No process-level kill, no liveness check.
+
+**Tier 2 — stability/correctness**
+
+5. **Fixed 10-min watchdog, deadline not heartbeat.** A legitimately long agent
+   task is marked `failed` at minute 10 even while actively producing tokens.
+   Not per-task configurable.
+6. **No disk GC.** `$TMPDIR/sumocode-bg/<id>-<ts>/` dirs accumulate forever.
+   `clearFinishedTasks` only drops in-memory entries.
+7. **Unbounded log growth.** Tail-*reads* are bounded; the log *file* is not. A
+   watcher/dev-server writes forever.
+8. **No concurrency cap.** Directly blocks safe fan-out: N subagents = N panes
+   with no ceiling.
+
+**Tier 3 — polish**
+
+9. Per-task poll timers (500ms shell / 750ms response) — acknowledged "simplest
+   reliable" hack.
+10. `meta.json` has no schema version, so recovery can't safely evolve the format.
+11. Failure reason isn't structured in the task record — only `status` + log tail.
+
+**What "full-featured and stable" means:** make the task store durable and the
+manager a **reconciler, not an owner** — read meta.json on startup, rehydrate,
+reconcile status from `exit.code` / `response.md` / pane-liveness; stable IDs;
+real liveness (pane-exit, not first response.md); lifecycle GC + log cap;
+concurrency cap with a queue.
+
+---
+
+## D8 — sequencing: harden bg_task first, then fan-out (both in v0.4)
+
+**Decision:** option A — harden `bg_task` first (PR1), then build `worktree:true`
+fan-out on the stable base (PR2). **Both ship in v0.4** (no slipping fan-out).
+
+- PR1 (hardening): durable registry (read meta.json on startup + reconcile),
+  stable IDs (not per-process counter), real-exit liveness (D4/D5), GC + log-size
+  cap, concurrency cap (D9), and the notify-gap fix.
+- PR2 (fan-out): `worktree: true` (D2) + never-auto-remove (D3) on the hardened base.
+- Rationale: bolting worktree ownership on today's reload-fragile manager means a
+  `/reload` orphans panes AND worktrees and the orchestrator loses the
+  branch↔subagent map — the fan-out's whole value evaporates. Durability is a
+  prerequisite, not polish. Don't build fan-out on a foundation already known broken.
+
+## D9 — concurrency cap: reject-with-state as cooperative backpressure
+
+**Decision:** option C — reject over-cap spawns, but the rejection is an
+**LLM-friendly backpressure signal, not an error**. Lands in PR1.
+
+- Governs the heavy `runner=sumocode` agent panes (conservative default, ~3-4,
+  each is a full sumocode process). Shell tasks get a separate/higher limit.
+- Over-cap spawn returns a **successful tool result** (NOT a thrown error) with:
+  - `status="at_capacity"`
+  - plain prose: "this is expected, not a failure — N/N agent slots in use, wait
+    for one to finish"
+  - the running set (id, title, status, age) so the orchestrator picks intelligently
+  - a concrete next-action line: "poll `bg_task log <id>` until one completes,
+    then retry this spawn" / "stop the stalest with `bg_task stop <id>` if unneeded"
+  - structured `details` mirroring the above for machine parsing
+- The slot-free wakeup **reuses the notify-gap fix** so the orchestrator is pinged
+  when a slot frees, rather than polling blind.
+- A real queue (accept + pending + auto-start on slot-free) is deferred: it couples
+  to liveness detection, and a liveness bug would silently stall queued tasks. The
+  orchestrator is the natural batch controller given it owns the N branches. Promote
+  to a queue only if the reject-loop proves annoying once fan-out is exercised.
+
+## D10 — /sumo:ship: full commit→push→PR, staged + human-gated
+
+**Decision:** option C capability (commit → push → open PR), but **STAGED with
+mandatory confirmation before any remote action** — never one-shot.
+
+- Flow: generate commit message + show file summary → **commit locally** (safe,
+  reversible) → **STOP, confirm before push** → **confirm before `gh pr create`**
+  (title/body pre-filled, optionally open in browser).
+- Hard constraint from `AGENTS.md`: never push/merge/PR without explicit approval.
+  The one-shot T3 "one-click ship" flow is off the table for SumoCode regardless
+  of convenience. Local commit is fine unattended; remote actions are human-gated.
+- D1 makes this simple: the worktree is already on a named branch (`sumo/<slug>`),
+  so ship just pushes + PRs — no branch creation.
+- Reuse `review.ts`'s `gh` patterns.
+- **Fan-out:** ship stays a per-branch human-gated action. We do NOT auto-ship N PRs.
+
+## D7 — hunk diff split geometry: aspect-based direction
+
+Separate track from the worktree work, but decided in the same session.
+
+**Problem:** `/sumo:diff` hardcodes a RIGHT split (`openCommandInNewSplit(pi, "right", …)`).
+On the Mac mini portrait monitor a right split halves the already-narrow chat
+column → diff is unreadable. hunk needs horizontal room for filenames, +/-
+gutters, and syntax.
+
+**Decision (option A — pure aspect):**
+
+- **portrait (rows > cols) → split DOWN** (full width preserved, abundant vertical space used)
+- **landscape → split RIGHT** (today's behavior, unchanged)
+- **`--down` / `--right` flag** overrides either way
+
+**Why aspect, not width:** the user's portrait monitor is >120 cols wide, so a
+width threshold (the sidebar policy's `W >= 120` rule) would wrongly pick RIGHT.
+The real signal is **orientation** — in portrait, horizontal is the scarce axis
+regardless of absolute column count. Confirmed against two screenshots of the
+same portrait session: one with SumoCode's registry sidebar open, one with it
+closed (cmux list open instead). The user wants DOWN in **both** — proving
+sidebar-visibility is the wrong trigger (it would flip to RIGHT when the sidebar
+is closed). Orientation alone captures the intent in both scenarios.
+
+**Note on the policy doc:** `SUMO_TUI_PORTRAIT_SIDEBAR_POLICY.md` deliberately
+avoids aspect ratio for *sidebar visibility* (uses hard `W >= 120`). That is a
+different decision — sidebar column-budget vs. split axis. Using aspect for the
+split direction does not contradict the width-first sidebar rule.
+
+**Scope:** keep hunk in its own cmux pane (option A from the framing question);
+do NOT build a native in-transcript diff surface in V1 — that fights the doc's
+overlay-seam caution and belongs in V2 with its own issue + Bible target +
+visual golden.
+
+---
+
+## Parked: Idea B — alive-and-re-promptable subagents
+
+Chosen model is A (dead-but-preserved). **Idea B is explicitly deferred, captured
+here so it is not lost.**
+
+In Idea B, a finished subagent's sumocode session **stays running and idle**
+rather than exiting. The orchestrator can then:
+
+- **Inject a follow-up prompt** into the running child pane — a true reverse
+  handoff INTO the child, continuing on the same branch/context without
+  re-establishing state.
+- Or **close** it to reclaim resources.
+
+Why it's powerful: persistent steerable workers. The orchestrator keeps a pool
+of live subagents on different branches and drives each across multiple turns
+(plan → review feedback → revise) without losing the child's in-memory context.
+
+Why it's deferred — Idea B requires real new machinery:
+
+- **Prompt injection into a running child pane** (today the prompt is only the
+  one-shot `--prompt-file` kickoff; no channel to send a 2nd message to a live
+  child).
+- **Per-turn harvest** — `response.md` rewritten on each idle, with versioning so
+  the orchestrator reads the latest turn, not the first.
+- **Concurrency / memory cap** — N live sumocode processes is real resource cost,
+  unlike N preserved-but-dead panes.
+- **Liveness semantics** — "idle and waiting" vs "working" vs "exited" become
+  three distinct states the manager must track.
+
+Revisit B only once model-A single-shot fan-out proves insufficient in practice.


### PR DESCRIPTION
## Summary

This is a **docs-only planning PR** that promotes the v0.4 roadmap/decision trail from the spike branch onto `main`, so implementation agents can branch from a single canonical source of truth.

It captures the Codex/T3Code feature audit, the worktree fan-out grilling decisions, and the final v0.4 issue map (#267–#282).

## What changed

Added three research/planning docs:

- `docs/research/codex-t3code-feature-audit.html`
  - Blueprint-style audit of Codex app + T3 Code features relevant to SumoCode.
  - Separates terminal-native opportunities from Electron/app-specific features we are not copying.
- `docs/research/worktree-fanout-grilling.md`
  - Grilling decisions D1–D10 for worktree fan-out, bg_task hardening, hunk diff geometry, and `/sumo:ship`.
  - Records the notify-gap root cause and the deferred “alive-and-re-promptable” subagent idea.
- `docs/research/v0.4-roadmap.md`
  - v0.4 workstreams A–H, dependency order, issue map, and out-of-scope list.

## Key decisions recorded

### Worktree / fan-out spine

- Worktrees use named branches up front: `sumo/<slug>`.
- `bg_task spawn` gets `worktree: true` for orchestrator fan-out.
- Worktrees are never auto-removed; pruning is explicit.
- Shared `src/git/worktree.ts` module is the planned seam.
- `/sumo:worktree` remains a plain interactive cmux pane, not bg_task.
- `/sumo:ship` supports commit → push → PR, but staged + human-gated before remote actions.

### bg_task hardening

- Harden bg_task first, then add worktree fan-out — both in v0.4.
- Fix the notify gap: agent success currently completes silently while failure notifies.
- Completion means real agent-loop exit, not first `response.md`.
- Pane lifecycle is orchestrator-owned: dead-but-preserved pane for now.
- Concurrency cap uses cooperative `status="at_capacity"` backpressure, not thrown errors or an invisible queue.

### UI / terminal tracks

- `/sumo:diff` should split by orientation: portrait → down, landscape → right, with overrides.
- Inline image rendering and `[Image N]` editor placeholders are separate v0.4 tracks.
- `pi-dynamic-workflows` co-exists as synthesis fan-out; worktree fan-out remains production fan-out.
- `pi-cmux` is prior art, but not SumoCode-safe while it hardcodes `exec pi`.
- Startup perf PR #257 was closed and superseded by #282: intentional animated boot screen first, then atomic full-shell reveal — never partial chrome.

## Issue map covered

v0.4 milestone now contains:

- #267 hunk diff split geometry
- #268 bg_task notify gap
- #269 bg_task durable registry/recovery
- #270 bg_task real-exit liveness + pane lifecycle
- #271 bg_task concurrency cap / `at_capacity`
- #272 bg_task GC + log cap
- #273 shared worktree module
- #274 `bg_task worktree:true`
- #275 `/sumo:worktree`
- #276 `/sumo:ship`
- #277 inline image rendering
- #278 editor `[Image N]` placeholders
- #279 synthesis workflow co-existence
- #280 pi-cmux configurable agent command boundary
- #282 startup boot-flow redesign

## Review notes

This PR intentionally does **not** implement runtime behavior. It should be reviewed for:

- whether the v0.4 ordering is sane
- whether the issue boundaries are independently grabbable
- whether any decision wording contradicts AGENTS.md / current architecture
- whether startup (#282) correctly supersedes closed PR #257 and closed #281
- whether the worktree/bg_task sequencing is clear enough for other agents

## Verification

- `pnpm exec tsc --noEmit && pnpm build` ✅

Docs-only; no runtime code changed.
