### PR TITLE
fix(bg-task): wake orchestrator on agent harvest

### DIFF
--- a/src/background-tasks/background-task-tool.ts
+++ b/src/background-tasks/background-task-tool.ts
@@ -1,7 +1,11 @@
 import { existsSync, readFileSync } from "node:fs";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
-import { BackgroundTaskManager } from "./task-manager.js";
+import {
+	BackgroundTaskManager,
+	DEFAULT_SUMOCODE_AGENT_MODEL,
+	DEFAULT_SUMOCODE_AGENT_THINKING,
+} from "./task-manager.js";
 import { type BackgroundTask, type BackgroundTaskThinking, toBackgroundTaskSnapshot } from "./task-types.js";
 
 /**
@@ -60,7 +64,7 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 			"",
 			"• SHELL (runner='shell', default) — spawn a managed shell command. Output is tee'd to a log file, exit code is captured, and completion wakes the orchestrator via a follow-up message and cmux notification. Use for builds, tests, deploys, watchers, anything you want to fire-and-forget.",
 			"",
-			"• AGENT (runner='sumocode', visible=true required) — spawn a child SumoCode agent in a new cmux split. The prompt is delivered as the kickoff message, the child opens straight into the agent loop (no splash). Optional model/thinking flags override the child's defaults. The child writes its FINAL assistant message to response.md; the orchestrator reads it via bg_task log. Task transitions to status='completed' as soon as response.md appears. After 10s idle, the pane auto-closes via cmux close-surface.",
+			`• AGENT (runner='sumocode', visible=true required) — spawn a child SumoCode agent in a new cmux split. The prompt is delivered as the kickoff message, the child opens straight into the agent loop (no splash). If model/thinking are omitted, SumoCode uses ${DEFAULT_SUMOCODE_AGENT_MODEL} with ${DEFAULT_SUMOCODE_AGENT_THINKING} thinking (override process-wide with SUMOCODE_BG_AGENT_MODEL / SUMOCODE_BG_AGENT_THINKING). Explicit model/thinking params override those defaults. The child writes its FINAL assistant message to response.md; the orchestrator reads it via bg_task log. Task transitions to status='completed' as soon as response.md appears. After 10s idle, the pane auto-closes via cmux close-surface.`,
 			"",
 			"Actions:",
 			"  spawn  — start a task. Returns task id + paths.",
@@ -74,8 +78,8 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 		promptGuidelines: [
 			"Use bg_task when the user wants long-running work to continue while the conversation stays usable.",
 			"For shell commands (build, test, deploy, watchers), use bg_task with runner='shell' (the default) — output is logged and the orchestrator is notified on exit.",
-			"To delegate a prompt to a child SumoCode agent, use bg_task with runner='sumocode' and visible=true. The child opens in a cmux split, runs the prompt, and writes its response back. Read it with bg_task action='log' once status='completed'.",
-			"Pass model and thinking to bg_task when delegating an agent task to override the child's defaults (e.g. model='openai/gpt-4o-mini' thinking='low' for a cheap quick task, or model='anthropic/claude-opus-4-6' thinking='xhigh' for deep work).",
+			`To delegate a prompt to a child SumoCode agent, use bg_task with runner='sumocode' and visible=true. If the user does not specify a model, omit model/thinking and let the child default to ${DEFAULT_SUMOCODE_AGENT_MODEL} with ${DEFAULT_SUMOCODE_AGENT_THINKING} thinking. The child opens in a cmux split, runs the prompt, and writes its response back. Read it with bg_task action='log' once status='completed'.`,
+			`Pass model and thinking to bg_task only when the user explicitly wants to override the agent defaults (${DEFAULT_SUMOCODE_AGENT_MODEL}, thinking=${DEFAULT_SUMOCODE_AGENT_THINKING}); process-wide defaults can be set with SUMOCODE_BG_AGENT_MODEL and SUMOCODE_BG_AGENT_THINKING.`,
 			"To read a delegated agent's response, call bg_task with action='log' and id='bg-N'. If the response isn't ready yet, the result will indicate 'still working' — poll again. List with bg_task action='list' to see which tasks have status='completed'.",
 			"Use bg_task action='stop' to cancel a task. For agent panes this closes the cmux surface, preserving any response that was already written.",
 		],
@@ -113,13 +117,13 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 			model: Type.Optional(
 				Type.String({
 					description:
-						"Pi model pattern for runner='sumocode'. Examples: 'openai/gpt-4o-mini', 'anthropic/claude-sonnet-4-5', 'cursor/composer-2.5'. Forwarded as --model to the child. Ignored for runner='shell'.",
+						`Pi model pattern for runner='sumocode'. Defaults to ${DEFAULT_SUMOCODE_AGENT_MODEL} when omitted (or SUMOCODE_BG_AGENT_MODEL if set). Forwarded as --model to the child. Ignored for runner='shell'.`,
 				}),
 			),
 			thinking: Type.Optional(
 				StringEnum(["off", "minimal", "low", "medium", "high", "xhigh"] as const, {
 					description:
-						"Pi thinking level for runner='sumocode'. Forwarded as --thinking to the child. Ignored for runner='shell'.",
+						`Pi thinking level for runner='sumocode'. Defaults to ${DEFAULT_SUMOCODE_AGENT_THINKING} when omitted (or SUMOCODE_BG_AGENT_THINKING if set). Forwarded as --thinking to the child. Ignored for runner='shell'.`,
 				}),
 			),
 			direction: Type.Optional(
@@ -133,7 +137,7 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 			notifyOnExit: Type.Optional(
 				Type.Boolean({
 					description:
-						"For runner='shell': wake the orchestrator with a follow-up message + cmux notification on exit. Defaults to true. Has no effect for agent runners (they always set status='completed' when response.md is harvested).",
+						"Wake the orchestrator with a follow-up message + cmux notification when the task reaches a terminal state. Defaults to true. For agent runners, this fires when response.md is harvested or the watchdog fails.",
 				}),
 			),
 		}),

--- a/src/background-tasks/task-manager.test.ts
+++ b/src/background-tasks/task-manager.test.ts
@@ -3,7 +3,11 @@ import { appendFileSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFil
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { BackgroundTaskManager } from "./task-manager.js";
+import {
+	BackgroundTaskManager,
+	DEFAULT_SUMOCODE_AGENT_MODEL,
+	DEFAULT_SUMOCODE_AGENT_THINKING,
+} from "./task-manager.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 
@@ -88,22 +92,34 @@ function mockLongLivedChild(opts: { unkillable?: boolean; pid?: number } = {}) {
 describe("BackgroundTaskManager", () => {
 	let baseDir: string;
 	let originalCmuxSurface: string | undefined;
+	let originalAgentModel: string | undefined;
+	let originalAgentThinking: string | undefined;
 
 	beforeEach(() => {
 		spawnMock.mockReset();
 		baseDir = mkdtempSync(join(tmpdir(), "sumocode-bg-test-"));
 		originalCmuxSurface = process.env.CMUX_SURFACE_ID;
+		originalAgentModel = process.env.SUMOCODE_BG_AGENT_MODEL;
+		originalAgentThinking = process.env.SUMOCODE_BG_AGENT_THINKING;
 		delete process.env.CMUX_WORKSPACE_ID;
+		delete process.env.SUMOCODE_BG_AGENT_MODEL;
+		delete process.env.SUMOCODE_BG_AGENT_THINKING;
 	});
+
+	function restoreEnv(name: "CMUX_SURFACE_ID" | "SUMOCODE_BG_AGENT_MODEL" | "SUMOCODE_BG_AGENT_THINKING", value: string | undefined): void {
+		if (value === undefined) {
+			delete process.env[name];
+		} else {
+			process.env[name] = value;
+		}
+	}
 
 	afterEach(() => {
 		vi.restoreAllMocks();
 		rmSync(baseDir, { recursive: true, force: true });
-		if (originalCmuxSurface === undefined) {
-			delete process.env.CMUX_SURFACE_ID;
-		} else {
-			process.env.CMUX_SURFACE_ID = originalCmuxSurface;
-		}
+		restoreEnv("CMUX_SURFACE_ID", originalCmuxSurface);
+		restoreEnv("SUMOCODE_BG_AGENT_MODEL", originalAgentModel);
+		restoreEnv("SUMOCODE_BG_AGENT_THINKING", originalAgentThinking);
 	});
 
 	it("spawns invisible tasks via shell-redirect to logFile (detached survives parent teardown)", async () => {
@@ -288,8 +304,10 @@ describe("BackgroundTaskManager", () => {
 		expect(respawnArg).toContain("cd '/repo with spaces' && ");
 		expect(respawnArg).toContain("SUMOCODE_TASK_RESPONSE_FILE=");
 		expect(respawnArg).toContain("SUMOCODE_TASK_DIAG_FILE=");
-		expect(respawnArg).toContain("exec sumocode task --prompt-file '");
+		expect(respawnArg).toContain(`exec sumocode task --model '${DEFAULT_SUMOCODE_AGENT_MODEL}' --thinking '${DEFAULT_SUMOCODE_AGENT_THINKING}' --prompt-file '`);
 		expect(respawnArg).toContain("/prompt.txt'");
+		expect(task.model).toBe(DEFAULT_SUMOCODE_AGENT_MODEL);
+		expect(task.thinking).toBe(DEFAULT_SUMOCODE_AGENT_THINKING);
 		expect(respawnArg).not.toContain("quotes");
 		expect(respawnArg).not.toContain("backticks");
 		expect(respawnArg).not.toContain("wall of text");
@@ -314,6 +332,38 @@ describe("BackgroundTaskManager", () => {
 		expect(task.responseFile).toBe(task.exitFile!.replace("exit.code", "response.md"));
 		expect(task.diagFile).toBe(task.exitFile!.replace("exit.code", "diag.jsonl"));
 		expect(task.promptFile).toBe(promptFile);
+	});
+
+	it("uses environment-configurable model and thinking defaults for sumocode agents", async () => {
+		process.env.CMUX_SURFACE_ID = "surface:1";
+		process.env.SUMOCODE_BG_AGENT_MODEL = "anthropic/claude-sonnet-4-5";
+		process.env.SUMOCODE_BG_AGENT_THINKING = "medium";
+		const pi = buildPiStub();
+		const cmuxSplit = await import("../commands/cmux-split.js");
+		const openSplit = vi.spyOn(cmuxSplit, "openCommandInNewSplitWithRefs").mockResolvedValue({
+			ok: true,
+			workspaceRef: "workspace:1",
+			surfaceRef: "surface:2",
+		});
+
+		const manager = new BackgroundTaskManager(pi as never);
+		const task = manager.spawnTask({
+			command: "review",
+			cwd: "/repo",
+			visible: true,
+			runner: "sumocode",
+			notifyOnExit: false,
+		});
+
+		await vi.waitFor(() => {
+			expect(task.cmux).toBeDefined();
+		});
+
+		const respawnArg = openSplit.mock.calls[0]?.[2] as string;
+		expect(respawnArg).toContain("--model 'anthropic/claude-sonnet-4-5'");
+		expect(respawnArg).toContain("--thinking 'medium'");
+		expect(task.model).toBe("anthropic/claude-sonnet-4-5");
+		expect(task.thinking).toBe("medium");
 	});
 
 	it("forwards model and thinking flags into the cmux respawn command", async () => {
@@ -384,6 +434,54 @@ describe("BackgroundTaskManager", () => {
 		const meta = JSON.parse(readFileSync(task.metaFile!, "utf8"));
 		expect(meta.status).toBe("completed");
 		expect(meta.responseFile).toBe(task.responseFile);
+	});
+
+	it("wakes the orchestrator exactly once when an agent response is harvested", async () => {
+		vi.useFakeTimers();
+		try {
+			process.env.CMUX_SURFACE_ID = "surface:1";
+			const pi = buildPiStub();
+			const cmuxSplit = await import("../commands/cmux-split.js");
+			vi.spyOn(cmuxSplit, "openCommandInNewSplitWithRefs").mockResolvedValue({
+				ok: true,
+				workspaceRef: "workspace:1",
+				surfaceRef: "surface:2",
+			});
+
+			const manager = new BackgroundTaskManager(pi as never);
+			const task = manager.spawnTask({
+				command: "summarize the diff",
+				cwd: "/repo",
+				visible: true,
+				runner: "sumocode",
+				title: "agent review",
+			});
+
+			await vi.waitFor(() => expect(task.cmux).toBeDefined());
+			writeFileSync(task.responseFile!, "done\n");
+
+			await vi.advanceTimersByTimeAsync(750);
+
+			expect(task.status).toBe("completed");
+			expect(task.exitCode).toBe(0);
+			expect(pi.sendUserMessage).toHaveBeenCalledTimes(1);
+			expect(pi.sendUserMessage).toHaveBeenCalledWith(
+				expect.stringContaining(`background task ${task.id} completed: agent review (cmux surface:2)`),
+				{ deliverAs: "followUp" },
+			);
+			const notifyCall = pi.exec.mock.calls.find(
+				(call) => call[0] === "cmux" && Array.isArray(call[1]) && (call[1] as string[])[0] === "notify",
+			);
+			expect(notifyCall, "expected a cmux notify exec call").toBeDefined();
+
+			// The response watcher is cleared by finalization, so the watchdog cannot
+			// later emit a second completion/failure notification for the same task.
+			await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
+			expect(task.status).toBe("completed");
+			expect(pi.sendUserMessage).toHaveBeenCalledTimes(1);
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("getTaskHarvest returns response.md for agent runners when ready", async () => {

--- a/src/background-tasks/task-manager.ts
+++ b/src/background-tasks/task-manager.ts
@@ -21,6 +21,7 @@ import {
 import {
 	type BackgroundTask,
 	type BackgroundTaskSnapshot,
+	type BackgroundTaskThinking,
 	type SpawnBackgroundTaskOptions,
 	toBackgroundTaskSnapshot,
 } from "./task-types.js";
@@ -36,6 +37,18 @@ import {
 const POLL_INTERVAL_MS = 500;
 const RESPONSE_POLL_INTERVAL_MS = 750;
 const DEFAULT_VISIBLE_DIRECTION: CmuxSplitDirection = "right";
+export const DEFAULT_SUMOCODE_AGENT_MODEL = "openai-codex/gpt-5.5";
+export const DEFAULT_SUMOCODE_AGENT_THINKING: BackgroundTaskThinking = "low";
+const AGENT_MODEL_ENV = "SUMOCODE_BG_AGENT_MODEL";
+const AGENT_THINKING_ENV = "SUMOCODE_BG_AGENT_THINKING";
+const THINKING_LEVELS = new Set<BackgroundTaskThinking>([
+	"off",
+	"minimal",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+]);
 
 /** Max grace period before stopTask escalates SIGTERM to SIGKILL. */
 const STOP_SIGTERM_GRACE_MS = 5_000;
@@ -72,6 +85,25 @@ function summarizeStatus(task: Pick<BackgroundTask, "status" | "exitCode">): str
 	if (task.status === "stopped") return "stopped";
 	if (task.exitCode === 0) return "completed";
 	return "failed";
+}
+
+function normalizeThinking(value: string | undefined): BackgroundTaskThinking | undefined {
+	if (!value) return undefined;
+	const normalized = value.trim() as BackgroundTaskThinking;
+	return THINKING_LEVELS.has(normalized) ? normalized : undefined;
+}
+
+function resolveAgentModel(runner: BackgroundTask["runner"], model: string | undefined): string | undefined {
+	if (runner !== "sumocode") return model?.trim() || undefined;
+	return model?.trim() || process.env[AGENT_MODEL_ENV]?.trim() || DEFAULT_SUMOCODE_AGENT_MODEL;
+}
+
+function resolveAgentThinking(
+	runner: BackgroundTask["runner"],
+	thinking: BackgroundTaskThinking | undefined,
+): BackgroundTaskThinking | undefined {
+	if (runner !== "sumocode") return thinking;
+	return thinking ?? normalizeThinking(process.env[AGENT_THINKING_ENV]) ?? DEFAULT_SUMOCODE_AGENT_THINKING;
 }
 
 function appendLogLine(logFile: string, line: string): void {
@@ -233,8 +265,8 @@ export class BackgroundTaskManager {
 			diagFile: runner === "shell" ? undefined : paths.diagFile,
 			visible,
 			runner,
-			model: options.model?.trim() || undefined,
-			thinking: options.thinking,
+			model: resolveAgentModel(runner, options.model),
+			thinking: resolveAgentThinking(runner, options.thinking),
 			notifyOnExit: options.notifyOnExit !== false,
 		};
 
@@ -426,12 +458,7 @@ export class BackgroundTaskManager {
 				return;
 			}
 			if (task.responseFile && existsSync(task.responseFile)) {
-				if (task.responseTimer) clearInterval(task.responseTimer);
-				task.responseTimer = undefined;
-				task.status = "completed";
-				task.exitCode = 0;
-				task.updatedAt = Date.now();
-				writeTaskMeta(task);
+				this.finalizeTask(task, 0, "self-exit");
 				return;
 			}
 			if (task.watchdogDeadline && Date.now() > task.watchdogDeadline) {

--- a/src/background-tasks/visible-spawn.ts
+++ b/src/background-tasks/visible-spawn.ts
@@ -99,9 +99,12 @@ export function buildVisibleTaskScript(options: VisibleTaskCommandOptions): stri
  *      the `task` subcommand. The orchestrator reads response.md to harvest
  *      the delegated work's output.
  *   2. `cd '<cwd>'` so the child opens in the right project.
- *   3. `exec sumocode task [--model X] [--thinking Y] --prompt-file '<path>'`.
+ *   3. `exec sumocode task --model X --thinking Y --prompt-file '<path>'`.
  *      `exec` ensures the wrapper shell is replaced by the sumocode process;
- *      when the child exits the cmux pane closes.
+ *      when the child exits the cmux pane closes. If the tool caller omits
+ *      model/thinking, BackgroundTaskManager resolves defaults first:
+ *      `openai-codex/gpt-5.5` with `low` thinking, configurable via
+ *      `SUMOCODE_BG_AGENT_MODEL` and `SUMOCODE_BG_AGENT_THINKING`.
  *
  * The prompt is passed via `--prompt-file <abs path>` so the cmux respawn
  * command stays short and fixed-length regardless of prompt size. Without


### PR DESCRIPTION
## Summary
- route successful SumoCode agent response harvest through the existing finalize/notify path
- default delegated SumoCode agents to openai-codex/gpt-5.5 with low thinking, configurable via env vars
- update bg_task docs and coverage for harvest wakeup/default model behavior

## Verification
- pnpm exec tsc --noEmit && pnpm build
- pnpm test
- pnpm vitest run src/background-tasks/task-manager.test.ts src/background-tasks/visible-spawn.test.ts
- manual bg_task runner=sumocode test: automatic follow-up arrived and bg_task log returned MANUAL_268_DIRECT_TOOL_PASS
- SumoCode diff review scribe: GREEN

Closes #268