### PR TITLE
feat(bg_task): durable registry recovery

### DIFF
--- a/src/background-tasks/background-task-tool.ts
+++ b/src/background-tasks/background-task-tool.ts
@@ -47,8 +47,8 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 	// reloading SumoCode would lose every long-running `bg_task spawn` job
 	// they had in flight. Only kill on a real process-quit shutdown; on
 	// session replacement, leave the child processes running (they're already
-	// detached / cmux-owned) and let the new manager start with an empty
-	// in-memory map. Recovery from disk-stored meta.json is a future feature.
+	// detached / cmux-owned) and let the new manager recover from disk-stored
+	// meta.json on startup.
 	pi.on("session_shutdown", (event) => {
 		const reason = (event as { reason?: string } | null | undefined)?.reason;
 		if (reason === "quit" || reason === undefined) {

--- a/src/background-tasks/task-manager.test.ts
+++ b/src/background-tasks/task-manager.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { appendFileSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -10,8 +10,10 @@ import {
 } from "./task-manager.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const execFileSyncMock = vi.hoisted(() => vi.fn(() => "Mon Jun  1 10:00:00 2026\n"));
 
 vi.mock("node:child_process", () => ({
+	execFileSync: execFileSyncMock,
 	spawn: spawnMock,
 }));
 
@@ -92,13 +94,18 @@ function mockLongLivedChild(opts: { unkillable?: boolean; pid?: number } = {}) {
 describe("BackgroundTaskManager", () => {
 	let baseDir: string;
 	let originalCmuxSurface: string | undefined;
+	let originalTmpdir: string | undefined;
 	let originalAgentModel: string | undefined;
 	let originalAgentThinking: string | undefined;
 
 	beforeEach(() => {
 		spawnMock.mockReset();
+		execFileSyncMock.mockReset();
+		execFileSyncMock.mockReturnValue("Mon Jun  1 10:00:00 2026\n");
 		baseDir = mkdtempSync(join(tmpdir(), "sumocode-bg-test-"));
 		originalCmuxSurface = process.env.CMUX_SURFACE_ID;
+		originalTmpdir = process.env.TMPDIR;
+		process.env.TMPDIR = baseDir;
 		originalAgentModel = process.env.SUMOCODE_BG_AGENT_MODEL;
 		originalAgentThinking = process.env.SUMOCODE_BG_AGENT_THINKING;
 		delete process.env.CMUX_WORKSPACE_ID;
@@ -106,7 +113,7 @@ describe("BackgroundTaskManager", () => {
 		delete process.env.SUMOCODE_BG_AGENT_THINKING;
 	});
 
-	function restoreEnv(name: "CMUX_SURFACE_ID" | "SUMOCODE_BG_AGENT_MODEL" | "SUMOCODE_BG_AGENT_THINKING", value: string | undefined): void {
+	function restoreEnv(name: "CMUX_SURFACE_ID" | "TMPDIR" | "SUMOCODE_BG_AGENT_MODEL" | "SUMOCODE_BG_AGENT_THINKING", value: string | undefined): void {
 		if (value === undefined) {
 			delete process.env[name];
 		} else {
@@ -118,6 +125,7 @@ describe("BackgroundTaskManager", () => {
 		vi.restoreAllMocks();
 		rmSync(baseDir, { recursive: true, force: true });
 		restoreEnv("CMUX_SURFACE_ID", originalCmuxSurface);
+		restoreEnv("TMPDIR", originalTmpdir);
 		restoreEnv("SUMOCODE_BG_AGENT_MODEL", originalAgentModel);
 		restoreEnv("SUMOCODE_BG_AGENT_THINKING", originalAgentThinking);
 	});
@@ -137,7 +145,7 @@ describe("BackgroundTaskManager", () => {
 		});
 
 		expect(spawnMock).toHaveBeenCalledOnce();
-		// On POSIX the shell wraps the command with `( cmd ) >>logFile 2>&1`
+		// On POSIX the shell wraps the command with log redirection + exit.code persistence
 		// so the orphaned process can keep writing to the log even if the
 		// orchestrator exits. Verify that shape rather than the file contents
 		// (the mocked spawn does not actually run a shell).
@@ -146,6 +154,7 @@ describe("BackgroundTaskManager", () => {
 		if (process.platform !== "win32") {
 			expect(commandStr).toContain("echo hello");
 			expect(commandStr).toContain(`>>'${task.logFile}'`);
+			expect(commandStr).toContain(`> '${task.exitFile}'`);
 			expect(commandStr).toContain("2>&1");
 			expect(spawnArgs[2]?.stdio).toBe("ignore");
 		}
@@ -175,7 +184,10 @@ describe("BackgroundTaskManager", () => {
 		expect(task.metaFile).toBeDefined();
 		expect(existsSync(task.metaFile!)).toBe(true);
 		const initial = JSON.parse(readFileSync(task.metaFile!, "utf8"));
+		expect(initial.schemaVersion).toBe(2);
 		expect(initial.id).toBe(task.id);
+		expect(initial.pid).toBe(4242);
+		expect(initial.processStartTime).toBe("Mon Jun  1 10:00:00 2026");
 		expect(initial.command).toBe("echo meta");
 		expect(initial.runner).toBe("shell");
 		expect(initial.status).toBe("running");
@@ -744,6 +756,416 @@ describe("BackgroundTaskManager", () => {
 		}
 	});
 
+	it("preserves notifyOnExit flag across recovery", () => {
+		const root = join(baseDir, "sumocode-bg", "bg-notify-false-1000");
+		mkdirSync(root, { recursive: true });
+		const logFile = join(root, "output.log");
+		const metaFile = join(root, "meta.json");
+		writeFileSync(logFile, "running\n");
+		writeFileSync(metaFile, `${JSON.stringify({
+			schemaVersion: 2,
+			id: "bg-notify-false",
+			command: "echo quiet",
+			cwd: "/tmp",
+			status: "running",
+			startedAt: 1000,
+			updatedAt: 1000,
+			logFile,
+			metaFile,
+			visible: false,
+			runner: "shell",
+			notifyOnExit: false,
+		}, null, 2)}\n`);
+
+		const manager = new BackgroundTaskManager(buildPiStub() as never);
+
+		expect(manager.findTask("bg-notify-false")?.notifyOnExit).toBe(false);
+	});
+
+	it("notifies when a recovered running task completes after reload", async () => {
+		const root = join(baseDir, "sumocode-bg", "bg-notify-true-1000");
+		mkdirSync(root, { recursive: true });
+		const logFile = join(root, "output.log");
+		const exitFile = join(root, "exit.code");
+		const metaFile = join(root, "meta.json");
+		writeFileSync(logFile, "running\n");
+		writeFileSync(metaFile, `${JSON.stringify({
+			schemaVersion: 2,
+			id: "bg-notify-true",
+			command: "echo loud",
+			cwd: "/tmp",
+			status: "running",
+			startedAt: 1000,
+			updatedAt: 1000,
+			logFile,
+			exitFile,
+			metaFile,
+			visible: false,
+			runner: "shell",
+			notifyOnExit: true,
+		}, null, 2)}\n`);
+		const pi = buildPiStub();
+		const manager = new BackgroundTaskManager(pi as never);
+		const task = manager.findTask("bg-notify-true");
+
+		writeFileSync(exitFile, "0");
+		await vi.waitFor(() => expect(task?.status).toBe("completed"));
+
+		expect(pi.sendUserMessage).toHaveBeenCalled();
+	});
+
+	it("recovers shell tasks and reconciles exit.code after reload", () => {
+		const root = join(baseDir, "sumocode-bg", "bg-recovered-1-1000");
+		mkdirSync(root, { recursive: true });
+		const logFile = join(root, "output.log");
+		const exitFile = join(root, "exit.code");
+		const metaFile = join(root, "meta.json");
+		writeFileSync(logFile, "done\n");
+		writeFileSync(exitFile, "0");
+		writeFileSync(metaFile, `${JSON.stringify({
+			schemaVersion: 2,
+			id: "bg-recovered-1",
+			command: "echo recovered",
+			cwd: "/tmp",
+			status: "running",
+			startedAt: 1000,
+			updatedAt: 1000,
+			logFile,
+			exitFile,
+			metaFile,
+			visible: false,
+			runner: "shell",
+		}, null, 2)}\n`);
+
+		const pi = buildPiStub();
+		const manager = new BackgroundTaskManager(pi as never);
+		const task = manager.findTask("bg-recovered-1");
+
+		expect(task?.status).toBe("completed");
+		expect(task?.exitCode).toBe(0);
+		expect(manager.getTaskHarvest(task!, 1000).content).toContain("done");
+		expect(pi.sendUserMessage).toHaveBeenCalledWith(
+			expect.stringContaining("background task bg-recovered-1 completed"),
+			{ deliverAs: "followUp" },
+		);
+	});
+
+	it("keeps new invisible shell tasks running when process identity cannot be captured", () => {
+		execFileSyncMock.mockImplementation(() => {
+			throw new Error("ps unavailable");
+		});
+		const child = mockLongLivedChild({ pid: 6161 });
+		spawnMock.mockReturnValue(child);
+		const manager = new BackgroundTaskManager(buildPiStub() as never);
+
+		const task = manager.spawnTask({ command: "sleep 100", cwd: "/tmp", notifyOnExit: false });
+
+		expect(task.status).toBe("running");
+		expect(child.kill).not.toHaveBeenCalled();
+		expect(readFileSync(task.logFile, "utf8")).toContain("failed to capture process identity");
+	});
+
+	it("stops recovered invisible shell tasks by persisted pid", async () => {
+		const root = join(baseDir, "sumocode-bg", "bg-recovered-running-1000");
+		mkdirSync(root, { recursive: true });
+		const logFile = join(root, "output.log");
+		const exitFile = join(root, "exit.code");
+		const metaFile = join(root, "meta.json");
+		writeFileSync(logFile, "running\n");
+		writeFileSync(metaFile, `${JSON.stringify({
+			schemaVersion: 2,
+			id: "bg-recovered-running",
+			pid: 7777,
+			processStartTime: "Mon Jun  1 10:00:00 2026",
+			command: "sleep 100",
+			cwd: "/tmp",
+			status: "running",
+			startedAt: 1000,
+			updatedAt: 1000,
+			logFile,
+			exitFile,
+			metaFile,
+			visible: false,
+			runner: "shell",
+		}, null, 2)}\n`);
+		let alive = true;
+		const processKill = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: string | number) => {
+			if (signal === 0) {
+				if (alive && (pid === 7777 || pid === -7777)) return true;
+				throw new Error("not alive");
+			}
+			if (pid === -7777 && signal === "SIGTERM") {
+				alive = false;
+				return true;
+			}
+			return true;
+		}) as typeof process.kill);
+		try {
+			const manager = new BackgroundTaskManager(buildPiStub() as never);
+			const task = manager.findTask("bg-recovered-running");
+
+			expect(task?.status).toBe("running");
+			const result = await manager.stopTask(task!);
+
+			expect(result.ok).toBe(true);
+			expect(task?.status).toBe("stopped");
+			expect(processKill).toHaveBeenCalledWith(-7777, "SIGTERM");
+		} finally {
+			processKill.mockRestore();
+		}
+	});
+
+	it("recaptures missing recovered process identity before stopping", async () => {
+		const root = join(baseDir, "sumocode-bg", "bg-unverified-pid-1000");
+		mkdirSync(root, { recursive: true });
+		const logFile = join(root, "output.log");
+		const exitFile = join(root, "exit.code");
+		const metaFile = join(root, "meta.json");
+		writeFileSync(logFile, "still here\n");
+		writeFileSync(metaFile, `${JSON.stringify({
+			schemaVersion: 2,
+			id: "bg-unverified-pid",
+			pid: 6666,
+			command: "sleep 100",
+			cwd: "/tmp",
+			status: "running",
+			startedAt: 1000,
+			updatedAt: 1000,
+			logFile,
+			exitFile,
+			metaFile,
+			visible: false,
+			runner: "shell",
+		}, null, 2)}\n`);
+		let alive = true;
+		const processKill = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: string | number) => {
+			if (signal === 0) {
+				if (alive && (pid === 6666 || pid === -6666)) return true;
+				throw new Error("not alive");
+			}
+			if (pid === -6666 && signal === "SIGTERM") {
+				alive = false;
+				return true;
+			}
+			return true;
+		}) as typeof process.kill);
+		try {
+			const manager = new BackgroundTaskManager(buildPiStub() as never);
+			const task = manager.findTask("bg-unverified-pid");
+
+			expect(task?.status).toBe("running");
+			expect(manager.getTaskHarvest(task!, 1000).content).toContain("still here");
+			expect(await manager.stopTask(task!)).toMatchObject({ ok: true });
+			expect(task?.status).toBe("stopped");
+			expect(processKill).toHaveBeenCalledWith(-6666, "SIGTERM");
+		} finally {
+			processKill.mockRestore();
+		}
+	});
+
+	it("leaves recovered shell task running when stop identity probe fails", async () => {
+		const root = join(baseDir, "sumocode-bg", "bg-probe-fails-1000");
+		mkdirSync(root, { recursive: true });
+		const logFile = join(root, "output.log");
+		const exitFile = join(root, "exit.code");
+		const metaFile = join(root, "meta.json");
+		writeFileSync(logFile, "running\n");
+		writeFileSync(metaFile, `${JSON.stringify({
+			schemaVersion: 2,
+			id: "bg-probe-fails",
+			pid: 5555,
+			processStartTime: "Mon Jun  1 10:00:00 2026",
+			command: "sleep 100",
+			cwd: "/tmp",
+			status: "running",
+			startedAt: 1000,
+			updatedAt: 1000,
+			logFile,
+			exitFile,
+			metaFile,
+			visible: false,
+			runner: "shell",
+		}, null, 2)}\n`);
+		execFileSyncMock.mockImplementation(() => {
+			throw new Error("ps unavailable");
+		});
+		const processKill = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: string | number) => {
+			if (signal === 0 && (pid === 5555 || pid === -5555)) return true;
+			return true;
+		}) as typeof process.kill);
+		try {
+			const manager = new BackgroundTaskManager(buildPiStub() as never);
+			const task = manager.findTask("bg-probe-fails");
+
+			expect(task?.status).toBe("running");
+			expect(await manager.stopTask(task!)).toMatchObject({ ok: false });
+			expect(task?.status).toBe("running");
+			expect(processKill).not.toHaveBeenCalledWith(-5555, "SIGTERM");
+
+			writeFileSync(exitFile, "0");
+			await vi.waitFor(() => expect(task?.status).toBe("completed"));
+		} finally {
+			processKill.mockRestore();
+		}
+	});
+
+	it("refuses to stop a recovered shell task when pid identity changed", async () => {
+		const root = join(baseDir, "sumocode-bg", "bg-reused-pid-1000");
+		mkdirSync(root, { recursive: true });
+		const logFile = join(root, "output.log");
+		const exitFile = join(root, "exit.code");
+		const metaFile = join(root, "meta.json");
+		writeFileSync(logFile, "running\n");
+		writeFileSync(metaFile, `${JSON.stringify({
+			schemaVersion: 2,
+			id: "bg-reused-pid",
+			pid: 8888,
+			processStartTime: "Mon Jun  1 10:00:00 2026",
+			command: "sleep 100",
+			cwd: "/tmp",
+			status: "running",
+			startedAt: 1000,
+			updatedAt: 1000,
+			logFile,
+			exitFile,
+			metaFile,
+			visible: false,
+			runner: "shell",
+		}, null, 2)}\n`);
+		execFileSyncMock.mockReturnValue("Mon Jun  1 11:00:00 2026\n");
+		const processKill = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: string | number) => {
+			if (signal === 0 && (pid === 8888 || pid === -8888)) return true;
+			return true;
+		}) as typeof process.kill);
+		try {
+			const manager = new BackgroundTaskManager(buildPiStub() as never);
+			const task = manager.findTask("bg-reused-pid");
+
+			expect(task?.status).toBe("failed");
+			expect(await manager.stopTask(task!)).toMatchObject({ ok: false });
+			expect(processKill).not.toHaveBeenCalledWith(-8888, "SIGTERM");
+		} finally {
+			processKill.mockRestore();
+		}
+	});
+
+	it("shutdown signals recovered invisible shell tasks by verified pid", () => {
+		const root = join(baseDir, "sumocode-bg", "bg-shutdown-1000");
+		mkdirSync(root, { recursive: true });
+		const logFile = join(root, "output.log");
+		const metaFile = join(root, "meta.json");
+		writeFileSync(logFile, "running\n");
+		writeFileSync(metaFile, `${JSON.stringify({
+			schemaVersion: 2,
+			id: "bg-shutdown",
+			pid: 4444,
+			processStartTime: "Mon Jun  1 10:00:00 2026",
+			command: "sleep 100",
+			cwd: "/tmp",
+			status: "running",
+			startedAt: 1000,
+			updatedAt: 1000,
+			logFile,
+			metaFile,
+			visible: false,
+			runner: "shell",
+		}, null, 2)}\n`);
+		const processKill = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: string | number) => {
+			if (signal === 0 && pid === 4444) return true;
+			return true;
+		}) as typeof process.kill);
+		try {
+			const manager = new BackgroundTaskManager(buildPiStub() as never);
+
+			manager.shutdown();
+
+			expect(processKill).toHaveBeenCalledWith(-4444, "SIGTERM");
+		} finally {
+			processKill.mockRestore();
+		}
+	});
+
+	it("recovers completed agent tasks from response.md after reload", () => {
+		const root = join(baseDir, "sumocode-bg", "bg-agent-1-1000");
+		mkdirSync(root, { recursive: true });
+		const logFile = join(root, "output.log");
+		const responseFile = join(root, "response.md");
+		const metaFile = join(root, "meta.json");
+		writeFileSync(logFile, "agent started\n");
+		writeFileSync(responseFile, "final answer\n");
+		writeFileSync(metaFile, `${JSON.stringify({
+			schemaVersion: 2,
+			id: "bg-agent-1",
+			command: "do work",
+			cwd: "/tmp",
+			status: "running",
+			startedAt: 1000,
+			updatedAt: 1000,
+			logFile,
+			metaFile,
+			responseFile,
+			visible: true,
+			runner: "sumocode",
+			cmux: { workspaceRef: "workspace:1", surfaceRef: "surface:2" },
+		}, null, 2)}\n`);
+
+		const manager = new BackgroundTaskManager(buildPiStub() as never);
+		const task = manager.findTask("bg-agent-1");
+
+		expect(task?.status).toBe("completed");
+		expect(task?.exitCode).toBe(0);
+		expect(manager.getTaskHarvest(task!, 1000)).toMatchObject({ kind: "response", content: "final answer\n", ready: true });
+	});
+
+	it("ignores older meta schema versions during recovery", () => {
+		const root = join(baseDir, "sumocode-bg", "bg-v1-1-1000");
+		mkdirSync(root, { recursive: true });
+		writeFileSync(join(root, "meta.json"), JSON.stringify({
+			schemaVersion: 1,
+			id: "bg-v1-1",
+			pid: 9999,
+			command: "sleep 100",
+			cwd: "/tmp",
+			status: "running",
+			startedAt: 1000,
+			updatedAt: 1000,
+			logFile: join(root, "output.log"),
+			visible: false,
+			runner: "shell",
+		}));
+
+		const manager = new BackgroundTaskManager(buildPiStub() as never);
+
+		expect(manager.findTask("bg-v1-1")).toBeUndefined();
+	});
+
+	it("ignores unknown meta schema versions during recovery", () => {
+		const root = join(baseDir, "sumocode-bg", "bg-legacy-1-1000");
+		mkdirSync(root, { recursive: true });
+		writeFileSync(join(root, "meta.json"), JSON.stringify({ schemaVersion: 999, id: "bg-legacy-1" }));
+
+		const manager = new BackgroundTaskManager(buildPiStub() as never);
+
+		expect(manager.findTask("bg-legacy-1")).toBeUndefined();
+	});
+
+	it("generates stable non-counter IDs that do not collide after reload", () => {
+		spawnMock.mockReturnValue(mockLongLivedChild({ pid: 9001 }));
+		const processKill = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: string | number) => {
+			if (signal === 0 && pid === 9001) return true;
+			return true;
+		}) as typeof process.kill);
+		try {
+			const first = new BackgroundTaskManager(buildPiStub() as never).spawnTask({ command: "sleep 10", cwd: "/tmp" });
+			const second = new BackgroundTaskManager(buildPiStub() as never).spawnTask({ command: "echo next", cwd: "/tmp" });
+
+			expect(second.id).not.toBe(first.id);
+			expect(second.id).toMatch(/^bg-[a-z0-9]+-[a-z0-9]+$/);
+		} finally {
+			processKill.mockRestore();
+		}
+	});
+
 	it("readLogTail returns only the tail bytes of a large log", async () => {
 		// Direct sanity check on the perf fix: write a 200KB file and confirm
 		// readLogTail returns < 20KB. The pollVisibleTask used to readFileSync
@@ -766,11 +1188,13 @@ describe("BackgroundTaskManager", () => {
 	it("lists and clears finished tasks", async () => {
 		spawnMock.mockReturnValue(mockChild(0));
 		const manager = new BackgroundTaskManager(buildPiStub() as never);
-		manager.spawnTask({ command: "echo one", cwd: "/tmp" });
+		const task = manager.spawnTask({ command: "echo one", cwd: "/tmp" });
 		await vi.waitFor(() => expect(manager.listTasks()[0]?.status).toBe("completed"));
 
 		expect(manager.listTasks()).toHaveLength(1);
 		expect(manager.clearFinishedTasks()).toBe(1);
 		expect(manager.listTasks()).toHaveLength(0);
+		expect(existsSync(task.metaFile!)).toBe(false);
+		expect(new BackgroundTaskManager(buildPiStub() as never).listTasks()).toHaveLength(0);
 	});
 });

--- a/src/background-tasks/task-manager.ts
+++ b/src/background-tasks/task-manager.ts
@@ -1,9 +1,10 @@
-import { type ChildProcess, spawn } from "node:child_process";
+import { execFileSync, type ChildProcess, spawn } from "node:child_process";
 import {
 	chmodSync,
 	closeSync,
 	existsSync,
 	mkdirSync,
+	readdirSync,
 	openSync,
 	readFileSync,
 	readSync,
@@ -11,7 +12,7 @@ import {
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
-import { dirname } from "node:path";
+import { dirname, join } from "node:path";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import {
 	isInCmux,
@@ -19,6 +20,7 @@ import {
 	type SplitDirection as CmuxSplitDirection,
 } from "../commands/cmux-split.js";
 import {
+	BACKGROUND_TASK_META_SCHEMA_VERSION,
 	type BackgroundTask,
 	type BackgroundTaskSnapshot,
 	type BackgroundTaskThinking,
@@ -177,19 +179,186 @@ function writeTaskMeta(task: BackgroundTask): void {
 	}
 }
 
+function getTaskRootDir(): string {
+	return join(process.env.TMPDIR ?? "/tmp", "sumocode-bg");
+}
+
+function generateTaskId(): string {
+	return `bg-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function isProcessAlive(pid: number | undefined): boolean {
+	if (pid == null) return false;
+	try {
+		process.kill(pid, 0);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function getProcessStartTime(pid: number | undefined): string | undefined {
+	if (pid == null) return undefined;
+	try {
+		if (process.platform === "win32") {
+			return execFileSync(
+				"powershell.exe",
+				["-NoProfile", "-Command", `(Get-CimInstance Win32_Process -Filter \"ProcessId=${pid}\").CreationDate`],
+				{ encoding: "utf8" },
+			).trim() || undefined;
+		}
+		return execFileSync("ps", ["-p", String(pid), "-o", "lstart="], { encoding: "utf8" }).trim() || undefined;
+	} catch {
+		return undefined;
+	}
+}
+
+function getProcessIdentityStatus(
+	pid: number | undefined,
+	expectedStartTime: string | undefined,
+): "same" | "different" | "unknown" {
+	if (!isProcessAlive(pid)) return "different";
+	if (!expectedStartTime) return "unknown";
+	const actualStartTime = getProcessStartTime(pid);
+	if (!actualStartTime) return "unknown";
+	return actualStartTime === expectedStartTime ? "same" : "different";
+}
+
+function signalProcessOrGroup(pid: number, signal: NodeJS.Signals): void {
+	let groupKilled = false;
+	if (process.platform !== "win32") {
+		try {
+			process.kill(-pid, signal);
+			groupKilled = true;
+		} catch {
+			groupKilled = false;
+		}
+	}
+	if (!groupKilled) {
+		try {
+			process.kill(pid, signal);
+		} catch {
+			// process already gone
+		}
+	}
+}
+
+function parseRecoveredTask(raw: unknown, metaFile: string): InternalTask | undefined {
+	if (!raw || typeof raw !== "object") return undefined;
+	const snapshot = raw as Partial<BackgroundTaskSnapshot>;
+	if (snapshot.schemaVersion !== BACKGROUND_TASK_META_SCHEMA_VERSION) return undefined;
+	const status = snapshot.status;
+	if (status !== "running" && status !== "completed" && status !== "failed" && status !== "stopped") return undefined;
+	if (
+		typeof snapshot.id !== "string" ||
+		typeof snapshot.command !== "string" ||
+		typeof snapshot.cwd !== "string" ||
+		typeof snapshot.startedAt !== "number" ||
+		typeof snapshot.updatedAt !== "number" ||
+		typeof snapshot.logFile !== "string" ||
+		typeof snapshot.visible !== "boolean" ||
+		(snapshot.runner !== "shell" && snapshot.runner !== "sumocode")
+	) {
+		return undefined;
+	}
+	return {
+		id: snapshot.id,
+		pid: snapshot.pid,
+		command: snapshot.command,
+		cwd: snapshot.cwd,
+		title: snapshot.title,
+		status,
+		startedAt: snapshot.startedAt,
+		updatedAt: snapshot.updatedAt,
+		exitCode: snapshot.exitCode,
+		logFile: snapshot.logFile,
+		exitFile: snapshot.exitFile,
+		metaFile,
+		promptFile: snapshot.promptFile,
+		responseFile: snapshot.responseFile,
+		diagFile: snapshot.diagFile,
+		processStartTime: snapshot.processStartTime,
+		visible: snapshot.visible,
+		runner: snapshot.runner,
+		model: snapshot.model,
+		thinking: snapshot.thinking,
+		cmux: snapshot.cmux,
+		notifyOnExit: snapshot.notifyOnExit !== false,
+	};
+}
+
 export class BackgroundTaskManager {
 	private tasks = new Map<string, InternalTask>();
-	private counter = 0;
 	private readonly pi: ExtensionAPI;
 
 	constructor(pi: ExtensionAPI) {
 		this.pi = pi;
+		this.recoverTasks();
 	}
 
 	listTasks(): BackgroundTaskSnapshot[] {
 		return [...this.tasks.values()]
 			.sort((a, b) => b.startedAt - a.startedAt)
 			.map(toBackgroundTaskSnapshot);
+	}
+
+	private recoverTasks(): void {
+		const root = getTaskRootDir();
+		if (!existsSync(root)) return;
+		let entries: string[];
+		try {
+			entries = readdirSync(root);
+		} catch {
+			return;
+		}
+		for (const entry of entries) {
+			const metaFile = join(root, entry, "meta.json");
+			if (!existsSync(metaFile)) continue;
+			try {
+				const task = parseRecoveredTask(JSON.parse(readFileSync(metaFile, "utf8")), metaFile);
+				if (!task || this.tasks.has(task.id)) continue;
+				this.reconcileRecoveredTask(task);
+				this.tasks.set(task.id, task);
+			} catch {
+				// Ignore malformed/unknown legacy metadata; recovery is best-effort.
+			}
+		}
+	}
+
+	private reconcileRecoveredTask(task: InternalTask): void {
+		if (task.status !== "running") {
+			task.finalized = true;
+			return;
+		}
+
+		const exitCode = task.exitFile && existsSync(task.exitFile)
+			? readExitCodeFromFile(readFileSync(task.exitFile, "utf8"))
+			: null;
+		if (exitCode != null) {
+			this.finalizeTask(task, exitCode, "self-exit");
+			return;
+		}
+
+		if (task.runner === "sumocode" && task.responseFile && existsSync(task.responseFile)) {
+			this.finalizeTask(task, 0, "self-exit");
+			return;
+		}
+
+		if (task.runner === "shell" && !task.visible && task.pid != null && task.processStartTime) {
+			const identityStatus = getProcessIdentityStatus(task.pid, task.processStartTime);
+			if (identityStatus === "different") {
+				this.finalizeTask(task, null, "self-exit");
+				return;
+			}
+		}
+
+		if (task.runner === "shell") {
+			task.pollTimer = setInterval(() => this.pollVisibleTask(task), POLL_INTERVAL_MS);
+			if (typeof task.pollTimer.unref === "function") task.pollTimer.unref();
+		} else if (task.responseFile) {
+			task.watchdogDeadline = Date.now() + DEFAULT_AGENT_WATCHDOG_MS;
+			this.armResponseWatcher(task);
+		}
 	}
 
 	findTask(id?: string, pid?: number): InternalTask | undefined {
@@ -242,7 +411,8 @@ export class BackgroundTaskManager {
 			throw new Error("visible background tasks require a cmux surface (CMUX_SURFACE_ID or CMUX_WORKSPACE_ID)");
 		}
 
-		const id = `bg-${++this.counter}`;
+		let id = generateTaskId();
+		while (this.tasks.has(id)) id = generateTaskId();
 		const now = Date.now();
 		const cwd = options.cwd.trim() || process.cwd();
 		const paths = buildVisibleTaskPaths(id, now);
@@ -305,7 +475,7 @@ export class BackgroundTaskManager {
 		// shell wrapper redirect output into the log file directly. The child
 		// is then truly orphan-able and persists across orchestrator restarts.
 		const wrappedCommand = detached
-			? `( ${command} ) >>${shellEscapeForBash(logFile)} 2>&1`
+			? `{ ( ${command} ); code=$?; printf '%s' "$code" > ${shellEscapeForBash(task.exitFile ?? `${logFile}.exit`)}; exit "$code"; } >>${shellEscapeForBash(logFile)} 2>&1`
 			: command;
 		const childStdio: "ignore" | ["ignore", "pipe", "pipe"] = detached
 			? "ignore"
@@ -322,6 +492,7 @@ export class BackgroundTaskManager {
 		});
 
 		task.pid = child.pid ?? undefined;
+		task.processStartTime = getProcessStartTime(task.pid);
 		task.child = child;
 
 		if (!detached) {
@@ -342,6 +513,12 @@ export class BackgroundTaskManager {
 			appendLogLine(logFile, `\n[spawn error] ${error.message}\n`);
 			this.finalizeTask(task, 1, "self-exit");
 		});
+
+		if (task.pid != null && !task.processStartTime) {
+			appendLogLine(logFile, "\n[bg-task] warning: failed to capture process identity; recovered stop will require identity recapture\n");
+		}
+
+		writeTaskMeta(task);
 
 		if (detached && child.pid) {
 			child.unref();
@@ -596,6 +773,7 @@ export class BackgroundTaskManager {
 		if (task.child?.pid) {
 			const killed = await this.terminateChildAndWait(task.child);
 			if (!killed) {
+				task.stopRequested = false;
 				return {
 					ok: false,
 					message: `Failed to stop task ${task.id}: child process (pid ${task.child.pid}) did not exit after SIGTERM + SIGKILL within ${Math.round(STOP_SIGTERM_GRACE_MS / 1000)}s.`,
@@ -607,6 +785,39 @@ export class BackgroundTaskManager {
 				this.finalizeTask(task, null, "stopped");
 			}
 			return { ok: true, message: `Stopped background task ${task.id}.` };
+		}
+
+		if (!task.visible && task.pid != null) {
+			if (!task.processStartTime) {
+				task.processStartTime = getProcessStartTime(task.pid);
+				if (task.processStartTime) writeTaskMeta(task);
+			}
+			const identityStatus = getProcessIdentityStatus(task.pid, task.processStartTime);
+			if (identityStatus === "unknown") {
+				task.stopRequested = false;
+				return {
+					ok: false,
+					message: `Refusing to stop task ${task.id}: recovered pid ${task.pid} process identity could not be verified.`,
+				};
+			}
+			if (identityStatus === "different") {
+				task.stopRequested = false;
+				this.finalizeTask(task, null, "self-exit");
+				return {
+					ok: false,
+					message: `Refusing to stop task ${task.id}: recovered pid ${task.pid} no longer matches the original background process.`,
+				};
+			}
+			const killed = await this.terminatePidAndWait(task.pid);
+			if (!killed) {
+				task.stopRequested = false;
+				return {
+					ok: false,
+					message: `Failed to stop task ${task.id}: recovered process (pid ${task.pid}) did not exit after SIGTERM + SIGKILL within ${Math.round(STOP_SIGTERM_GRACE_MS / 1000)}s.`,
+				};
+			}
+			this.finalizeTask(task, null, "stopped");
+			return { ok: true, message: `Stopped background task ${task.id} (pid ${task.pid}).` };
 		}
 
 		if (task.visible && task.cmux) {
@@ -623,6 +834,7 @@ export class BackgroundTaskManager {
 					killed: false,
 				}));
 			if (result.code !== 0) {
+				task.stopRequested = false;
 				return {
 					ok: false,
 					message: `Failed to close cmux surface ${task.cmux.surfaceRef}: ${result.stderr || result.stdout || `cmux close-surface exited ${result.code}`}`,
@@ -642,6 +854,34 @@ export class BackgroundTaskManager {
 	 * then wait a final short window for the kernel to clean up. Returns true
 	 * if the process exited, false otherwise.
 	 */
+	private async terminatePidAndWait(pid: number): Promise<boolean> {
+		const awaitExit = (timeoutMs: number): Promise<boolean> =>
+			new Promise<boolean>((resolve) => {
+				if (!isProcessAlive(pid)) {
+					resolve(true);
+					return;
+				}
+				const startedAt = Date.now();
+				const timer = setInterval(() => {
+					if (!isProcessAlive(pid)) {
+						clearInterval(timer);
+						resolve(true);
+						return;
+					}
+					if (Date.now() - startedAt >= timeoutMs) {
+						clearInterval(timer);
+						resolve(false);
+					}
+				}, 50);
+				if (typeof timer.unref === "function") timer.unref();
+			});
+
+		signalProcessOrGroup(pid, "SIGTERM");
+		if (await awaitExit(STOP_SIGTERM_GRACE_MS)) return true;
+		signalProcessOrGroup(pid, "SIGKILL");
+		return await awaitExit(2_000);
+	}
+
 	private async terminateChildAndWait(child: ChildProcess): Promise<boolean> {
 		const sendSignal = (signal: NodeJS.Signals): void => {
 			// Prefer process-group SIGTERM (negative pid) on POSIX so any
@@ -695,6 +935,7 @@ export class BackgroundTaskManager {
 			if (task.status === "running") continue;
 			if (task.pollTimer) clearInterval(task.pollTimer);
 			if (task.responseTimer) clearInterval(task.responseTimer);
+			if (task.metaFile) removePathIfExists(task.metaFile);
 			this.tasks.delete(id);
 			removed += 1;
 		}
@@ -749,6 +990,14 @@ export class BackgroundTaskManager {
 					}
 				} catch {
 					// ignore shutdown errors
+				}
+			} else if (!task.visible && task.pid != null) {
+				if (!task.processStartTime) {
+					task.processStartTime = getProcessStartTime(task.pid);
+					if (task.processStartTime) writeTaskMeta(task);
+				}
+				if (getProcessIdentityStatus(task.pid, task.processStartTime) === "same") {
+					signalProcessOrGroup(task.pid, "SIGTERM");
 				}
 			}
 			if (task.pollTimer) clearInterval(task.pollTimer);

--- a/src/background-tasks/task-types.ts
+++ b/src/background-tasks/task-types.ts
@@ -36,6 +36,7 @@ export interface BackgroundTask {
 	promptFile?: string;
 	responseFile?: string;
 	diagFile?: string;
+	processStartTime?: string;
 	visible: boolean;
 	runner: BackgroundTaskRunner;
 	model?: string;
@@ -56,7 +57,10 @@ export interface SpawnBackgroundTaskOptions {
 	notifyOnExit?: boolean;
 }
 
+export const BACKGROUND_TASK_META_SCHEMA_VERSION = 2;
+
 export interface BackgroundTaskSnapshot {
+	schemaVersion: number;
 	id: string;
 	pid?: number;
 	command: string;
@@ -67,19 +71,23 @@ export interface BackgroundTaskSnapshot {
 	updatedAt: number;
 	exitCode?: number | null;
 	logFile: string;
+	exitFile?: string;
 	metaFile?: string;
 	promptFile?: string;
 	responseFile?: string;
 	diagFile?: string;
+	processStartTime?: string;
 	visible: boolean;
 	runner: BackgroundTaskRunner;
 	model?: string;
 	thinking?: BackgroundTaskThinking;
 	cmux?: BackgroundTaskCmuxRefs;
+	notifyOnExit?: boolean;
 }
 
 export function toBackgroundTaskSnapshot(task: BackgroundTask): BackgroundTaskSnapshot {
 	return {
+		schemaVersion: BACKGROUND_TASK_META_SCHEMA_VERSION,
 		id: task.id,
 		pid: task.pid,
 		command: task.command,
@@ -90,14 +98,17 @@ export function toBackgroundTaskSnapshot(task: BackgroundTask): BackgroundTaskSn
 		updatedAt: task.updatedAt,
 		exitCode: task.exitCode,
 		logFile: task.logFile,
+		exitFile: task.exitFile,
 		metaFile: task.metaFile,
 		promptFile: task.promptFile,
 		responseFile: task.responseFile,
 		diagFile: task.diagFile,
+		processStartTime: task.processStartTime,
 		visible: task.visible,
 		runner: task.runner,
 		model: task.model,
 		thinking: task.thinking,
 		cmux: task.cmux,
+		notifyOnExit: task.notifyOnExit,
 	};
 }


### PR DESCRIPTION
Closes #269

## Summary
- Recover `bg_task` entries from persisted `meta.json` on manager startup.
- Reconcile shell and agent tasks from `exit.code`, `response.md`, and process liveness.
- Switch `bg_task` IDs from per-process counters to timestamp-random IDs and add `schemaVersion` to metadata.
- Persist `exit.code` for detached invisible shell tasks so reload recovery can classify completed/failed tasks.

## Verification
- `pnpm vitest run src/background-tasks/task-manager.test.ts`
- `pnpm test -- --runInBand`
- `pnpm exec tsc --noEmit && pnpm build`
