### PR TITLE
feat(release): ship SumoCode 0.4 milestone

### DIFF
--- a/.github/workflows/visual-bible.yml
+++ b/.github/workflows/visual-bible.yml
@@ -54,8 +54,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright Chromium
-        run: pnpm exec playwright install --with-deps chromium
+      - name: Select runner Chrome
+        shell: bash
+        run: |
+          set -euo pipefail
+          for candidate in google-chrome google-chrome-stable chromium chromium-browser; do
+            if command -v "$candidate" >/dev/null 2>&1; then
+              chrome_path="$(command -v "$candidate")"
+              "$chrome_path" --version
+              echo "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$chrome_path" >> "$GITHUB_ENV"
+              exit 0
+            fi
+          done
+          echo "No runner Chrome executable found" >&2
+          exit 1
 
       - name: Render Visual Bible PNGs
         run: pnpm render:bible

--- a/.github/workflows/visual-bible.yml
+++ b/.github/workflows/visual-bible.yml
@@ -34,7 +34,7 @@ jobs:
   render-and-export:
     name: render and export static bible
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     steps:
       - name: Checkout

--- a/.github/workflows/visual-v2.yml
+++ b/.github/workflows/visual-v2.yml
@@ -36,7 +36,7 @@ jobs:
   review-pack:
     name: build V2 parity review pack
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 35
 
     steps:
       - name: Checkout

--- a/.github/workflows/visual-v2.yml
+++ b/.github/workflows/visual-v2.yml
@@ -56,8 +56,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright Chromium
-        run: pnpm exec playwright install --with-deps chromium
+      - name: Select runner Chrome
+        shell: bash
+        run: |
+          set -euo pipefail
+          for candidate in google-chrome google-chrome-stable chromium chromium-browser; do
+            if command -v "$candidate" >/dev/null 2>&1; then
+              chrome_path="$(command -v "$candidate")"
+              "$chrome_path" --version
+              echo "PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=$chrome_path" >> "$GITHUB_ENV"
+              exit 0
+            fi
+          done
+          echo "No runner Chrome executable found" >&2
+          exit 1
 
       - name: Render Visual Bible targets
         run: pnpm render:bible

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,43 @@ Per the PRD's versioning roadmap (`docs/prd.md` § Versioning), `v0.2.x` and
 `v0.3.x` are documented retroactively for the chrome and theme work that
 landed between the original scaffold and this release.
 
+## [0.4.0] — 2026-06-10
+
+The worktree fan-out release. SumoCode can now run visible background review
+jobs, fan out agents into named git worktrees, keep durable task metadata across
+reloads, and gate the ship leg through explicit human confirmations.
+
+### Added
+- **Orientation-aware `/sumo:diff`** — portrait terminals open hunk in a down
+  split; landscape stays right; `--down` / `--right` override.
+- **Tracked `/sumo:review`** — review now launches a visible `bg_task`
+  `runner=sumocode` pane instead of queueing a main-agent task-tool loop.
+- **bg_task hardening** — real process-exit completion for agent panes,
+  orchestrator-owned pane lifecycle, agent concurrency backpressure
+  (`status=at_capacity`), clear-time task-dir cleanup, startup stale-dir prune,
+  and bounded log files.
+- **Git worktree module** (`src/git/worktree.ts`) — execFile-based create/list/
+  remove helpers, branch slugging, clean/head-advanced checks, and path-with-
+  spaces coverage.
+- **`bg_task worktree=true`** — named-branch worktree creation, persisted
+  worktree refs in `meta.json`, no auto-remove, explicit prune via clear.
+- **`/sumo:worktree`** — opens an interactive SumoCode pane inside a new
+  worktree with setup action, plus explicit prune listing/removal.
+- **`/sumo:ship`** — stages and commits locally, then requires confirmation
+  before push and again before `gh pr create`.
+- **Image plumbing** — retained transcript image blocks render through Pi TUI's
+  Image component with fallback, and editor image paste uses `[Image N]` tokens
+  while composing.
+- **Fan-out decision docs** — synthesis-vs-production boundary and pi-cmux
+  compatibility stance documented under `docs/research/`.
+
+### Changed
+- `bg_task` agent harvest waits for the child process exit marker rather than
+  first `response.md`, so multi-turn/kept-open child panes are not marked done
+  too early.
+- Completed agent panes stay open for inspection until explicitly stopped or
+  closed.
+
 ## [0.3.0] — 2026-05-07
 
 The "feature-complete personal shell" release. Three themes ship, the agent's

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 A Pi extension that ships its own retained terminal renderer (SumoTUI), three theme bundles, and a persistent memory surface. Daily-driven by the maintainer for two months.
 
 [![MIT License](https://img.shields.io/badge/license-MIT-2D211A?style=flat-square)](./LICENSE)
-[![Version](https://img.shields.io/badge/v0.3.0-B85A22?style=flat-square)](./CHANGELOG.md)
-[![Pi 0.75](https://img.shields.io/badge/pi-0.75.3-4A6B3A?style=flat-square)](https://github.com/earendil-works/pi)
-[![Tests](https://img.shields.io/badge/tests-868%20passing-4A6B3A?style=flat-square)](./test)
+[![Version](https://img.shields.io/badge/v0.4.0-B85A22?style=flat-square)](./CHANGELOG.md)
+[![Pi 0.79](https://img.shields.io/badge/pi-0.79-4A6B3A?style=flat-square)](https://github.com/earendil-works/pi)
+[![Tests](https://img.shields.io/badge/tests-1024%20passing-4A6B3A?style=flat-square)](./test)
 
 <br>
 

--- a/bin/sumocode.sh
+++ b/bin/sumocode.sh
@@ -15,6 +15,14 @@ SCRIPT_DIR="$(cd "$(dirname "${SOURCE}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
 export SUMO_TUI="${SUMO_TUI:-1}"
+# Node 22+ can persist V8 compile cache for CommonJS/ESM modules. SumoCode and
+# Pi execute TypeScript through jiti at runtime, so warm launches benefit from
+# Node's built-in bytecode cache without adding a project build step.
+if [[ -z "${NODE_COMPILE_CACHE:-}" ]]; then
+	NODE_COMPILE_CACHE="${ROOT_DIR}/node_modules/.cache/node-compile-cache"
+	mkdir -p "${NODE_COMPILE_CACHE}" 2>/dev/null || true
+	export NODE_COMPILE_CACHE
+fi
 # Set so the SumoCode `/sumo:reload` slash command knows it's running under
 # the loop-respawn launcher and can exit with the reload signal.
 export SUMOCODE_LAUNCHER="${SOURCE}"
@@ -145,13 +153,19 @@ EXAMPLES
 
 DIAGNOSTICS EVENTS
   Debug mode may record events such as:
-      runtime_start       process, cwd, branch, commit, terminal size
-      render_frame        retained render timings
-      slow_frame          render frame over the slow-frame threshold
-      render_patches      terminal patch count and cursor placement
-      mouse_batch         parsed SGR mouse bytes per stdin batch
-      mouse_dispatch      chat hit-testing and scroll offset transitions
-      pi_event            Pi lifecycle events observed by SumoCode
+      process_preload_start  Node preload + argv baseline for startup traces
+      process_module_load_*  slow module imports + aggregate module-load summary
+      runtime_start          process, cwd, branch, commit, terminal size
+      boot_screen_frame      first retained splash/boot frame written to terminal
+      app_ready              first owned-shell render with the real session UI
+      stable_chrome_ready    same reveal point, split out for startup budgeting
+      input_ready            editor/input mounted and interactive
+      render_frame           retained render timings
+      slow_frame             render frame over the slow-frame threshold
+      render_patches         terminal patch count and cursor placement
+      mouse_batch            parsed SGR mouse bytes per stdin batch
+      mouse_dispatch         chat hit-testing and scroll offset transitions
+      pi_event               Pi lifecycle events observed by SumoCode
 
   Event payloads are truncated/sanitized so logs stay readable and diagnostics
   never interrupt the interactive session.
@@ -331,6 +345,12 @@ if [[ "${DEBUG_MODE}" == "1" ]]; then
 	if [[ "${CLEAR_DIAG}" == "1" && "${DRY_RUN}" != "1" ]]; then rm -f "${SUMO_TUI_DIAG_FILE}"; fi
 	export SUMO_TUI_DIAG_FILE
 	export SUMO_TUI_DEBUG="${SUMO_TUI_DEBUG:-1}"
+	STARTUP_PRELOAD="${ROOT_DIR}/scripts/startup-diagnostics-preload.cjs"
+	if [[ -f "${STARTUP_PRELOAD}" ]]; then
+		# Quote the path inside NODE_OPTIONS because the primary dev tree contains a
+		# space. Node's option parser honours these quotes.
+		export NODE_OPTIONS="${NODE_OPTIONS:-} --require \"${STARTUP_PRELOAD}\""
+	fi
 	if command -v git >/dev/null 2>&1 && git -C "${ROOT_DIR}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 		export SUMOCODE_DEBUG_BRANCH="$(git -C "${ROOT_DIR}" branch --show-current 2>/dev/null || true)"
 		export SUMOCODE_DEBUG_COMMIT="$(git -C "${ROOT_DIR}" log --oneline -1 2>/dev/null || true)"
@@ -370,10 +390,24 @@ is_truthy_env_flag() {
 
 pi_main_file() {
 	local bin="$1"
-	local resolved dir cli_target cli_path main_file fallback
+	local resolved dir cli_target cli_path main_file fallback local_main
+
+	# Fast path for the project-local launcher. This is the common `sumocode`
+	# dev/install path and avoids parsing pnpm's shell shim on every startup.
+	local_main="${ROOT_DIR}/node_modules/@earendil-works/pi-coding-agent/dist/main.js"
+	if [[ "${bin}" == "${ROOT_DIR}/node_modules/.bin/pi" && -f "${local_main}" ]]; then
+		realpath "${local_main}"
+		return 0
+	fi
+
 	resolved="$(realpath "${bin}" 2>/dev/null || true)"
 	[[ -n "${resolved}" ]] || return 1
 	dir="$(dirname "${resolved}")"
+
+	if [[ "${resolved}" == "$(realpath "${ROOT_DIR}/node_modules/.bin/pi" 2>/dev/null || true)" && -f "${local_main}" ]]; then
+		realpath "${local_main}"
+		return 0
+	fi
 
 	# Direct installs may expose dist/main.js next to the resolved binary.
 	for fallback in "${dir}/main.js" "${dir}/../dist/main.js"; do
@@ -407,7 +441,7 @@ path_to_file_url() {
 pi_has_sumo_tui_patch() {
 	local main_file
 	main_file="$(pi_main_file "$1" 2>/dev/null || true)"
-	[[ -n "${main_file}" ]] && grep -q "loadSumoInteractiveMode" "${main_file}"
+	[[ -n "${main_file}" ]] && grep -Fq "loadSumoInteractiveMode" "${main_file}"
 }
 
 run_diag_summary() {

--- a/docs/perf/startup.json
+++ b/docs/perf/startup.json
@@ -1,6 +1,6 @@
 {
-  "generatedAt": "2026-05-07T14:48:13.265Z",
-  "commit": "f9afabb fix(approval): cap command + description rows so modal cannot overflow vertically (#241)",
+  "generatedAt": "2026-06-11T10:08:38.207Z",
+  "commit": "e86879a feat(startup): add boot readiness diagnostics",
   "runs": 5,
   "measurements": [
     {
@@ -8,114 +8,306 @@
       "samples": [
         {
           "ok": true,
-          "durationMs": 20.72654092311859,
+          "durationMs": 47.27591699361801,
           "code": 0,
           "signal": null,
           "stderr": ""
         },
         {
           "ok": true,
-          "durationMs": 17.967416048049927,
+          "durationMs": 46.71291700005531,
           "code": 0,
           "signal": null,
           "stderr": ""
         },
         {
           "ok": true,
-          "durationMs": 16.95358395576477,
+          "durationMs": 47.42783299088478,
           "code": 0,
           "signal": null,
           "stderr": ""
         },
         {
           "ok": true,
-          "durationMs": 17.123542070388794,
+          "durationMs": 45.61091700196266,
           "code": 0,
           "signal": null,
           "stderr": ""
         },
         {
           "ok": true,
-          "durationMs": 16.729292035102844,
+          "durationMs": 45.9382089972496,
           "code": 0,
           "signal": null,
           "stderr": ""
         }
       ],
-      "avgMiddleMs": 17.3,
-      "minMs": 16.7,
-      "maxMs": 20.7
+      "avgMiddleMs": 46.6,
+      "minMs": 45.6,
+      "maxMs": 47.4
     },
     {
       "label": "print-mode",
       "samples": [
         {
           "ok": true,
-          "durationMs": 6806.204792022705,
+          "durationMs": 5812.486458003521,
           "code": 0,
           "signal": null,
-          "stderr": ""
+          "stderr": "Warning: No models match pattern \"cursor/composer-2.5\"\nWarning: No models match pattern \"openai-codex/gpt-5.3-codex\"\n"
         },
         {
           "ok": true,
-          "durationMs": 5941.384124994278,
+          "durationMs": 7034.819958001375,
           "code": 0,
           "signal": null,
-          "stderr": ""
+          "stderr": "Warning: No models match pattern \"cursor/composer-2.5\"\nWarning: No models match pattern \"openai-codex/gpt-5.3-codex\"\n"
         },
         {
           "ok": true,
-          "durationMs": 7303.392708063126,
+          "durationMs": 7109.731000006199,
           "code": 0,
           "signal": null,
-          "stderr": ""
+          "stderr": "Warning: No models match pattern \"cursor/composer-2.5\"\nWarning: No models match pattern \"openai-codex/gpt-5.3-codex\"\n"
         },
         {
           "ok": true,
-          "durationMs": 7803.824165940285,
+          "durationMs": 7100.228208988905,
           "code": 0,
           "signal": null,
-          "stderr": ""
+          "stderr": "Warning: No models match pattern \"cursor/composer-2.5\"\nWarning: No models match pattern \"openai-codex/gpt-5.3-codex\"\n"
         },
         {
           "ok": true,
-          "durationMs": 5942.814875006676,
+          "durationMs": 7577.911083012819,
           "code": 0,
           "signal": null,
-          "stderr": ""
+          "stderr": "Warning: No models match pattern \"cursor/composer-2.5\"\nWarning: No models match pattern \"openai-codex/gpt-5.3-codex\"\n"
         }
       ],
-      "avgMiddleMs": 6684.1,
-      "minMs": 5941.4,
-      "maxMs": 7803.8
+      "avgMiddleMs": 7081.6,
+      "minMs": 5812.5,
+      "maxMs": 7577.9
     },
     {
       "label": "first-frame",
       "samples": [
         {
           "ok": true,
-          "durationMs": 1547.0335420370102
+          "durationMs": 1827.0501669943333
         },
         {
           "ok": true,
-          "durationMs": 1489.8589580059052
+          "durationMs": 1816.8587090075016
         },
         {
           "ok": true,
-          "durationMs": 1474.977334022522
+          "durationMs": 1813.880999982357
         },
         {
           "ok": true,
-          "durationMs": 1497.0913330316544
+          "durationMs": 1830.456582993269
         },
         {
           "ok": true,
-          "durationMs": 1534.0268750190735
+          "durationMs": 1847.645125001669
         }
       ],
-      "avgMiddleMs": 1507,
-      "minMs": 1475,
-      "maxMs": 1547
+      "avgMiddleMs": 1824.8,
+      "minMs": 1813.9,
+      "maxMs": 1847.6
+    },
+    {
+      "label": "boot-screen-frame",
+      "samples": [
+        {
+          "ok": true,
+          "durationMs": 1862,
+          "bootScreenFrameMs": 1862,
+          "appReadyMs": 1894,
+          "stableChromeMs": 1894,
+          "inputReadyMs": 1894
+        },
+        {
+          "ok": true,
+          "durationMs": 1851,
+          "bootScreenFrameMs": 1851,
+          "appReadyMs": 1884,
+          "stableChromeMs": 1884,
+          "inputReadyMs": 1884
+        },
+        {
+          "ok": true,
+          "durationMs": 1856,
+          "bootScreenFrameMs": 1856,
+          "appReadyMs": 1890,
+          "stableChromeMs": 1890,
+          "inputReadyMs": 1890
+        },
+        {
+          "ok": true,
+          "durationMs": 1848,
+          "bootScreenFrameMs": 1848,
+          "appReadyMs": 1881,
+          "stableChromeMs": 1881,
+          "inputReadyMs": 1881
+        },
+        {
+          "ok": true,
+          "durationMs": 1866,
+          "bootScreenFrameMs": 1866,
+          "appReadyMs": 1900,
+          "stableChromeMs": 1900,
+          "inputReadyMs": 1900
+        }
+      ],
+      "avgMiddleMs": 1856.3,
+      "minMs": 1848,
+      "maxMs": 1866
+    },
+    {
+      "label": "app-ready",
+      "samples": [
+        {
+          "ok": true,
+          "durationMs": 1894,
+          "bootScreenFrameMs": 1862,
+          "appReadyMs": 1894,
+          "stableChromeMs": 1894,
+          "inputReadyMs": 1894
+        },
+        {
+          "ok": true,
+          "durationMs": 1884,
+          "bootScreenFrameMs": 1851,
+          "appReadyMs": 1884,
+          "stableChromeMs": 1884,
+          "inputReadyMs": 1884
+        },
+        {
+          "ok": true,
+          "durationMs": 1890,
+          "bootScreenFrameMs": 1856,
+          "appReadyMs": 1890,
+          "stableChromeMs": 1890,
+          "inputReadyMs": 1890
+        },
+        {
+          "ok": true,
+          "durationMs": 1881,
+          "bootScreenFrameMs": 1848,
+          "appReadyMs": 1881,
+          "stableChromeMs": 1881,
+          "inputReadyMs": 1881
+        },
+        {
+          "ok": true,
+          "durationMs": 1900,
+          "bootScreenFrameMs": 1866,
+          "appReadyMs": 1900,
+          "stableChromeMs": 1900,
+          "inputReadyMs": 1900
+        }
+      ],
+      "avgMiddleMs": 1889.3,
+      "minMs": 1881,
+      "maxMs": 1900
+    },
+    {
+      "label": "stable-chrome",
+      "samples": [
+        {
+          "ok": true,
+          "durationMs": 1894,
+          "bootScreenFrameMs": 1862,
+          "appReadyMs": 1894,
+          "stableChromeMs": 1894,
+          "inputReadyMs": 1894
+        },
+        {
+          "ok": true,
+          "durationMs": 1884,
+          "bootScreenFrameMs": 1851,
+          "appReadyMs": 1884,
+          "stableChromeMs": 1884,
+          "inputReadyMs": 1884
+        },
+        {
+          "ok": true,
+          "durationMs": 1890,
+          "bootScreenFrameMs": 1856,
+          "appReadyMs": 1890,
+          "stableChromeMs": 1890,
+          "inputReadyMs": 1890
+        },
+        {
+          "ok": true,
+          "durationMs": 1881,
+          "bootScreenFrameMs": 1848,
+          "appReadyMs": 1881,
+          "stableChromeMs": 1881,
+          "inputReadyMs": 1881
+        },
+        {
+          "ok": true,
+          "durationMs": 1900,
+          "bootScreenFrameMs": 1866,
+          "appReadyMs": 1900,
+          "stableChromeMs": 1900,
+          "inputReadyMs": 1900
+        }
+      ],
+      "avgMiddleMs": 1889.3,
+      "minMs": 1881,
+      "maxMs": 1900
+    },
+    {
+      "label": "input-ready",
+      "samples": [
+        {
+          "ok": true,
+          "durationMs": 1894,
+          "bootScreenFrameMs": 1862,
+          "appReadyMs": 1894,
+          "stableChromeMs": 1894,
+          "inputReadyMs": 1894
+        },
+        {
+          "ok": true,
+          "durationMs": 1884,
+          "bootScreenFrameMs": 1851,
+          "appReadyMs": 1884,
+          "stableChromeMs": 1884,
+          "inputReadyMs": 1884
+        },
+        {
+          "ok": true,
+          "durationMs": 1890,
+          "bootScreenFrameMs": 1856,
+          "appReadyMs": 1890,
+          "stableChromeMs": 1890,
+          "inputReadyMs": 1890
+        },
+        {
+          "ok": true,
+          "durationMs": 1881,
+          "bootScreenFrameMs": 1848,
+          "appReadyMs": 1881,
+          "stableChromeMs": 1881,
+          "inputReadyMs": 1881
+        },
+        {
+          "ok": true,
+          "durationMs": 1900,
+          "bootScreenFrameMs": 1866,
+          "appReadyMs": 1900,
+          "stableChromeMs": 1900,
+          "inputReadyMs": 1900
+        }
+      ],
+      "avgMiddleMs": 1889.3,
+      "minMs": 1881,
+      "maxMs": 1900
     }
   ]
 }

--- a/docs/perf/startup.md
+++ b/docs/perf/startup.md
@@ -2,12 +2,16 @@
 
 Report-only startup measurements for the current checkout. These numbers are intentionally not CI gates; use them to compare phase-by-phase deltas.
 
-- commit: `f9afabb fix(approval): cap command + description rows so modal cannot overflow vertically (#241)`
+- commit: `e86879a feat(startup): add boot readiness diagnostics`
 - runs: 5
-- generated: 2026-05-07T14:48:13.265Z
+- generated: 2026-06-11T10:08:38.207Z
 
 | Measurement | Avg middle runs | Min | Max | Runs |
 | --- | ---: | ---: | ---: | ---: |
-| launcher-dry-run | 17.3ms | 16.7ms | 20.7ms | 5 |
-| print-mode | 6684.1ms | 5941.4ms | 7803.8ms | 5 |
-| first-frame | 1507ms | 1475ms | 1547ms | 5 |
+| launcher-dry-run | 46.6ms | 45.6ms | 47.4ms | 5 |
+| print-mode | 7081.6ms | 5812.5ms | 7577.9ms | 5 |
+| first-frame | 1824.8ms | 1813.9ms | 1847.6ms | 5 |
+| boot-screen-frame | 1856.3ms | 1848ms | 1866ms | 5 |
+| app-ready | 1889.3ms | 1881ms | 1900ms | 5 |
+| stable-chrome | 1889.3ms | 1881ms | 1900ms | 5 |
+| input-ready | 1889.3ms | 1881ms | 1900ms | 5 |

--- a/docs/research/fanout-coexistence.md
+++ b/docs/research/fanout-coexistence.md
@@ -1,0 +1,45 @@
+# Fan-out coexistence: synthesis workflows vs production worktrees
+
+Date: 2026-06-10  
+Milestone: v0.4  
+Issue: #279
+
+## Decision
+
+SumoCode uses two fan-out lanes with a hard routing boundary:
+
+- **Synthesis fan-out**: in-memory subagents for research, audits, comparisons, and review synthesis where the output is one answer. The preferred path is the already-installed `pi-subagents` capability; `pi-dynamic-workflows` remains prior art until it is older, stable, and clearly better than `pi-subagents` for this repo.
+- **Production fan-out**: visible `bg_task` / cmux panes, optionally with `worktree=true`, for agents that may change files on isolated named branches and produce artifacts that the orchestrator reconciles and ships.
+
+Do **not** express production worktree fan-out as a dynamic workflow script. Worktree fan-out needs visible panes, durable task metadata, cmux lifecycle, branch/worktree tracking, and explicit prune/ship controls. Those are host/runtime concerns, not a model-authored in-memory DAG concern.
+
+## Tool-routing guidance
+
+Use synthesis fan-out (`pi-subagents` / future workflow-like tool) when:
+
+- the task is read-only or advisory;
+- the result should be synthesized into one parent answer;
+- no branch, pane, or durable process lifecycle is required;
+- examples: architecture audit, code review opinions, research, option comparison.
+
+Use production fan-out (`bg_task runner=sumocode visible=true worktree=true`) when:
+
+- a child may edit files or commit work;
+- isolation from the parent checkout matters;
+- the user needs an inspectable cmux pane;
+- the output includes a branch/worktree to reconcile, review, prune, or ship.
+
+## Relationship to pi-dynamic-workflows
+
+`pi-dynamic-workflows` is useful prior art for:
+
+- compact phase/progress copy;
+- deterministic script sandboxing;
+- explicit structured-output termination;
+- model-authored `parallel`/`pipeline` ergonomics.
+
+It is not adopted as a SumoCode dependency in v0.4. If it matures, open a follow-up design issue to compare it against `pi-subagents` as the single synthesis fan-out path.
+
+## Impact on v0.4 production track
+
+No production-track issue changes because of this decision. Issues #273–#276 continue to use SumoCode-local git/cmux/bg_task primitives. The concurrency-cap UX in #271 may reuse the concise progress/backpressure language from workflow tools, but not their execution substrate.

--- a/docs/research/pi-cmux-agent-command-boundary.md
+++ b/docs/research/pi-cmux-agent-command-boundary.md
@@ -1,0 +1,40 @@
+# pi-cmux configurable agent command boundary
+
+Date: 2026-06-10  
+Milestone: v0.4  
+Issue: #280
+
+## Decision
+
+SumoCode keeps its small local cmux layer for v0.4 and treats `pi-cmux` as prior art until `pi-cmux` can launch an arbitrary Pi-compatible agent command without hardcoding `exec pi`.
+
+SumoCode must never load a command path that opens classic Pi when the user intended SumoCode. `bin/sumocode.sh` owns the retained renderer environment (`SUMO_TUI=1`, `SUMO_TUI_MODULE`, launcher guards, diagnostics, task mode), so cmux helpers must launch `sumocode`, not `pi`, when invoked from SumoCode.
+
+## Desired upstream seam
+
+Upstream `pi-cmux` should make the launched agent configurable while preserving default Pi behavior:
+
+```ts
+const agentCommand = process.env.PI_CMUX_AGENT_COMMAND ?? "pi";
+const agentLabel = process.env.PI_CMUX_AGENT_LABEL ?? "Pi";
+const notifyTitle = process.env.PI_CMUX_NOTIFY_TITLE ?? agentLabel;
+```
+
+The command should be argv/template safe for paths with spaces. A single shell string is acceptable only if `pi-cmux` keeps robust shell escaping; otherwise prefer command + args fields such as:
+
+```bash
+PI_CMUX_AGENT_COMMAND="/Volumes/SumoDeus NVMe/code/sumocode/bin/sumocode.sh"
+PI_CMUX_AGENT_ARGS="--no-session"
+PI_CMUX_AGENT_LABEL="SumoCode"
+```
+
+## SumoCode v0.4 stance
+
+- Do not depend on/load `pi-cmux` commands in SumoCode v0.4.
+- Continue using `src/commands/cmux-split.ts`, the small attributed helper copied from `pi-cmux` with SumoCode-safe command construction.
+- Keep worktree and review commands local until upstream has the agent-command seam and SumoCode has tested it in retained mode.
+- If upstream-first work is taken on, open an upstream issue/PR against `pi-cmux` adding configurable agent command/label/notify title with default behavior unchanged.
+
+## Roadmap impact
+
+Issues #273 and #275 intentionally use SumoCode-local git/cmux helpers. `pi-cmux` remains a reference for split discovery, pane labels, notifications, and worktree continuation UX, not a runtime dependency.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dhruvkelawala/sumocode",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "SumoCode — a Pi extension that makes the terminal AI coding experience feel personal. OpenCode visual language + persistent memory + preattentive status signals.",
   "keywords": [
     "pi-package",

--- a/scripts/perf-startup.mjs
+++ b/scripts/perf-startup.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { spawn } from "node:child_process";
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -10,8 +10,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
 const OUT_PATH = join(ROOT, "docs", "perf", "startup.json");
 const SUMMARY_PATH = join(ROOT, "docs", "perf", "startup.md");
+const STARTUP_PRELOAD = join(ROOT, "scripts", "startup-diagnostics-preload.cjs");
 const RUNS = Math.max(1, Number.parseInt(process.env.SUMOCODE_STARTUP_PERF_RUNS ?? "5", 10));
 const TIMEOUT_MS = Math.max(1000, Number.parseInt(process.env.SUMOCODE_STARTUP_PERF_TIMEOUT_MS ?? "15000", 10));
+const STARTUP_EVENT_POLL_MS = 25;
 
 function nowMs() {
 	return Number(process.hrtime.bigint()) / 1_000_000;
@@ -26,6 +28,56 @@ function middleAverage(values) {
 
 function round(value) {
 	return Math.round(value * 10) / 10;
+}
+
+function buildNodeOptions() {
+	const existing = process.env.NODE_OPTIONS?.trim() ?? "";
+	if (!STARTUP_PRELOAD) return existing;
+	if (existing.includes(STARTUP_PRELOAD)) return existing;
+	const preloadFlag = `--require "${STARTUP_PRELOAD}"`;
+	return `${existing} ${preloadFlag}`.trim();
+}
+
+async function readDiagnosticEvents(path) {
+	try {
+		const raw = await readFile(path, "utf8");
+		return raw
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => {
+				try {
+					return JSON.parse(line);
+				} catch {
+					return undefined;
+				}
+			})
+			.filter((event) => event && typeof event === "object");
+	} catch {
+		return [];
+	}
+}
+
+function eventElapsedMs(events, eventName, startWallMs) {
+	const event = events.find((entry) => entry?.event === eventName);
+	return typeof event?.ts === "number" ? Math.max(0, event.ts - startWallMs) : undefined;
+}
+
+function summariseMeasurement(label, samples) {
+	const durations = samples.map((sample) => sample.durationMs);
+	return {
+		label,
+		samples,
+		avgMiddleMs: round(middleAverage(durations)),
+		minMs: round(Math.min(...durations)),
+		maxMs: round(Math.max(...durations)),
+	};
+}
+
+function metricSamples(rawSamples, key) {
+	return rawSamples.map((sample) => ({
+		...sample,
+		durationMs: sample[key] ?? sample.durationMs,
+	}));
 }
 
 async function measureProcess(label, command, args) {
@@ -54,8 +106,7 @@ async function measureProcess(label, command, args) {
 		});
 		samples.push(result);
 	}
-	const durations = samples.map((sample) => sample.durationMs);
-	return { label, samples, avgMiddleMs: round(middleAverage(durations)), minMs: round(Math.min(...durations)), maxMs: round(Math.max(...durations)) };
+	return summariseMeasurement(label, samples);
 }
 
 async function measureFirstFrame() {
@@ -70,31 +121,126 @@ async function measureFirstFrame() {
 			env: { ...process.env, TERM: "xterm-256color", SUMO_TUI: "1" },
 		});
 		let output = "";
+		let settled = false;
 		const sample = await new Promise((resolveSample) => {
+			const settle = (result) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				resolveSample(result);
+			};
 			const timer = setTimeout(() => {
 				child.kill("SIGTERM");
-				resolveSample({ ok: false, durationMs: nowMs() - start, error: "first frame timed out", output: output.slice(-1200) });
+				settle({ ok: false, durationMs: nowMs() - start, error: "first frame timed out", output: output.slice(-1200) });
 			}, TIMEOUT_MS);
 			child.onData((data) => {
 				output += data;
 				if (output.length > 20_000) output = output.slice(-10_000);
 				if (data.includes("\x1b[?1049h") || data.includes("\x1b[?2026h") || output.includes("DIVINE INVOCATION")) {
-					clearTimeout(timer);
 					const durationMs = nowMs() - start;
 					child.kill("SIGINT");
-					resolveSample({ ok: true, durationMs });
+					setTimeout(() => child.kill("SIGTERM"), 250).unref?.();
+					settle({ ok: true, durationMs });
 				}
 			});
 			child.onExit(({ exitCode, signal }) => {
-				clearTimeout(timer);
-				resolveSample({ ok: false, durationMs: nowMs() - start, exitCode, signal, output: output.slice(-1200) });
+				settle({ ok: false, durationMs: nowMs() - start, exitCode, signal, output: output.slice(-1200) });
 			});
 		});
 		samples.push(sample);
 		await new Promise((resolveSleep) => setTimeout(resolveSleep, 100));
 	}
-	const durations = samples.map((sample) => sample.durationMs);
-	return { label: "first-frame", samples, avgMiddleMs: round(middleAverage(durations)), minMs: round(Math.min(...durations)), maxMs: round(Math.max(...durations)) };
+	return summariseMeasurement("first-frame", samples);
+}
+
+async function measureStartupTimeline() {
+	const rawSamples = [];
+	for (let index = 0; index < RUNS; index += 1) {
+		const diagDir = await mkdtemp(join(tmpdir(), "sumocode-startup-diag-"));
+		const diagFile = join(diagDir, "startup.jsonl");
+		const start = nowMs();
+		const startWallMs = Date.now();
+		const child = spawnPty(join(ROOT, "bin", "sumocode.sh"), ["--offline", "--no-extensions", "--no-session"], {
+			name: "xterm-256color",
+			cols: 100,
+			rows: 30,
+			cwd: ROOT,
+			env: {
+				...process.env,
+				TERM: "xterm-256color",
+				SUMO_TUI: "1",
+				SUMO_TUI_DIAG_FILE: diagFile,
+				SUMO_TUI_DEBUG: process.env.SUMO_TUI_DEBUG ?? "1",
+				NODE_OPTIONS: buildNodeOptions(),
+			},
+		});
+		let output = "";
+		let settled = false;
+		const sample = await new Promise((resolveSample) => {
+			let pollHandle;
+			const settle = async (result) => {
+				if (settled) return;
+				settled = true;
+				clearTimeout(timer);
+				if (pollHandle !== undefined) clearInterval(pollHandle);
+				try {
+					child.kill("SIGINT");
+				} catch {}
+				setTimeout(() => {
+					try {
+						child.kill("SIGTERM");
+					} catch {}
+				}, 250).unref?.();
+				resolveSample(result);
+			};
+			const collect = async () => {
+				const events = await readDiagnosticEvents(diagFile);
+				return {
+					events,
+					bootScreenFrameMs: eventElapsedMs(events, "boot_screen_frame", startWallMs),
+					appReadyMs: eventElapsedMs(events, "app_ready", startWallMs),
+					stableChromeMs: eventElapsedMs(events, "stable_chrome_ready", startWallMs),
+					inputReadyMs: eventElapsedMs(events, "input_ready", startWallMs),
+				};
+			};
+			pollHandle = setInterval(async () => {
+				const snapshot = await collect();
+				if (
+					snapshot.bootScreenFrameMs !== undefined
+					&& snapshot.appReadyMs !== undefined
+					&& snapshot.stableChromeMs !== undefined
+					&& snapshot.inputReadyMs !== undefined
+				) {
+					const { events: _events, ...timings } = snapshot;
+					await settle({ ok: true, durationMs: nowMs() - start, ...timings });
+				}
+			}, STARTUP_EVENT_POLL_MS);
+			const timer = setTimeout(async () => {
+				const snapshot = await collect();
+				const { events, ...timings } = snapshot;
+				await settle({ ok: false, durationMs: nowMs() - start, error: "startup timeline timed out", output: output.slice(-1200), diagEvents: events.slice(-25), ...timings });
+			}, TIMEOUT_MS);
+			child.onData((data) => {
+				output += data;
+				if (output.length > 20_000) output = output.slice(-10_000);
+			});
+			child.onExit(async ({ exitCode, signal }) => {
+				if (settled) return;
+				const snapshot = await collect();
+				const { events, ...timings } = snapshot;
+				await settle({ ok: false, durationMs: nowMs() - start, exitCode, signal, output: output.slice(-1200), diagEvents: events.slice(-25), ...timings });
+			});
+		});
+		rawSamples.push(sample);
+		await rm(diagDir, { recursive: true, force: true });
+		await new Promise((resolveSleep) => setTimeout(resolveSleep, 100));
+	}
+	return [
+		summariseMeasurement("boot-screen-frame", metricSamples(rawSamples, "bootScreenFrameMs")),
+		summariseMeasurement("app-ready", metricSamples(rawSamples, "appReadyMs")),
+		summariseMeasurement("stable-chrome", metricSamples(rawSamples, "stableChromeMs")),
+		summariseMeasurement("input-ready", metricSamples(rawSamples, "inputReadyMs")),
+	];
 }
 
 function markdown(report) {
@@ -113,6 +259,7 @@ async function main() {
 		await measureProcess("launcher-dry-run", join(ROOT, "bin", "sumocode.sh"), ["--dry-run"]),
 		await measureProcess("print-mode", join(ROOT, "bin", "sumocode.sh"), ["--offline", "--no-extensions", "--no-session", "--print", "hello"]),
 		await measureFirstFrame(),
+		...(await measureStartupTimeline()),
 	];
 	const report = { generatedAt: new Date().toISOString(), commit, runs: RUNS, measurements };
 	await mkdir(dirname(OUT_PATH), { recursive: true });

--- a/scripts/render-bible.mjs
+++ b/scripts/render-bible.mjs
@@ -72,7 +72,11 @@ if (htmls.length === 0) {
 console.log(`[render-bible] ${htmls.length} mockup(s) → ${renderDir}`);
 console.log("");
 
-const browser = await chromium.launch({ headless: true });
+const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+const browser = await chromium.launch({
+	headless: true,
+	...(chromiumExecutablePath ? { executablePath: chromiumExecutablePath } : {}),
+});
 const context = await browser.newContext({
 	viewport: { width: 1800, height: 1200 },
 	deviceScaleFactor: 2, // retina-quality goldens

--- a/scripts/startup-diagnostics-preload.cjs
+++ b/scripts/startup-diagnostics-preload.cjs
@@ -1,0 +1,69 @@
+const { appendFileSync } = require('node:fs');
+const Module = require('node:module');
+const { performance } = require('node:perf_hooks');
+
+const diagFile = process.env.SUMO_TUI_DIAG_FILE;
+const entrypoint = process.argv[1] || "";
+const shouldInstrument = entrypoint.includes("pi-coding-agent") || entrypoint.endsWith("/pi") || entrypoint.endsWith("/pi.js");
+if (diagFile && shouldInstrument && !global.__sumocodeStartupDiagnosticsInstalled) {
+	global.__sumocodeStartupDiagnosticsInstalled = true;
+	const startedAt = performance.now();
+	let lastMark = startedAt;
+	const originalLoad = Module._load;
+	const stats = { count: 0, totalMs: 0, maxMs: 0, slowest: undefined };
+
+	function round(value) {
+		return Math.round(value * 100) / 100;
+	}
+
+	function log(event, fields = {}) {
+		try {
+			const now = performance.now();
+			appendFileSync(diagFile, `${JSON.stringify({
+				ts: Date.now(),
+				event,
+				sinceProcessPreloadMs: round(now - startedAt),
+				deltaMs: round(now - lastMark),
+				...fields,
+			})}\n`, 'utf8');
+			lastMark = now;
+		} catch {}
+	}
+
+	log('process_preload_start', { pid: process.pid, cwd: process.cwd(), argv: process.argv.slice(0, 6) });
+
+	Module._load = function sumocodeInstrumentedModuleLoad(request, parent, isMain) {
+		const start = performance.now();
+		try {
+			return originalLoad.apply(this, arguments);
+		} finally {
+			const durationMs = performance.now() - start;
+			stats.count += 1;
+			stats.totalMs += durationMs;
+			if (durationMs > stats.maxMs) {
+				stats.maxMs = durationMs;
+				stats.slowest = request;
+			}
+			if (durationMs >= 20) {
+				log('process_module_load_slow', {
+					spec: String(request),
+					durationMs: round(durationMs),
+					parent: parent?.filename,
+					isMain: Boolean(isMain),
+				});
+			}
+		}
+	};
+
+	function flushSummary() {
+		log('process_module_load_summary', {
+			count: stats.count,
+			totalMs: round(stats.totalMs),
+			maxMs: round(stats.maxMs),
+			slowestSpec: stats.slowest,
+		});
+	}
+
+	process.once('beforeExit', flushSummary);
+	process.once('exit', flushSummary);
+}

--- a/scripts/visual-v2/terminal-dom-renderer.mjs
+++ b/scripts/visual-v2/terminal-dom-renderer.mjs
@@ -10,7 +10,11 @@ export async function renderTerminalSnapshot(snapshot, outputPng, options = {}) 
 	const html = terminalSnapshotHtml(snapshot, options);
 	writeFile(htmlPath, html);
 
-	const browser = await chromium.launch({ headless: true });
+	const chromiumExecutablePath = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH;
+	const browser = await chromium.launch({
+		headless: true,
+		...(chromiumExecutablePath ? { executablePath: chromiumExecutablePath } : {}),
+	});
 	try {
 		const page = await browser.newPage({
 			viewport: { width: 2200, height: 2200 },

--- a/src/background-tasks/background-task-tool.test.ts
+++ b/src/background-tasks/background-task-tool.test.ts
@@ -16,4 +16,59 @@ describe("installBackgroundTasks", () => {
 		expect(registerCommand).toHaveBeenCalledWith("bg-run", expect.any(Object));
 		expect(on).toHaveBeenCalledWith("session_shutdown", expect.any(Function));
 	});
+
+	it("returns successful at_capacity result instead of throwing when agent cap is full", async () => {
+		const originalSurface = process.env.CMUX_SURFACE_ID;
+		const originalCapacity = process.env.SUMOCODE_BG_AGENT_CAPACITY;
+		process.env.CMUX_SURFACE_ID = "surface:1";
+		process.env.SUMOCODE_BG_AGENT_CAPACITY = "1";
+		try {
+			const cmuxSplit = await import("../commands/cmux-split.js");
+			vi.spyOn(cmuxSplit, "openCommandInNewSplitWithRefs").mockResolvedValue({
+				ok: true,
+				workspaceRef: "workspace:1",
+				surfaceRef: "surface:2",
+			});
+			let tool: { execute: (...args: never[]) => Promise<{ content: Array<{ text: string }>; details?: unknown }> } | undefined;
+			const registerTool = vi.fn((definition) => {
+				tool = definition;
+			});
+			const pi = {
+				registerTool,
+				registerCommand: vi.fn(),
+				on: vi.fn(),
+				sendUserMessage: vi.fn(),
+				exec: vi.fn(async () => ({ code: 0, stdout: "", stderr: "", killed: false })),
+			};
+			installBackgroundTasks(pi as never);
+
+			await tool?.execute(
+				"call-1" as never,
+				{ action: "spawn", command: "review one", runner: "sumocode", visible: true, title: "agent one" } as never,
+				undefined as never,
+				undefined as never,
+				{ cwd: "/repo" } as never,
+			);
+			const result = await tool?.execute(
+				"call-2" as never,
+				{ action: "spawn", command: "review two", runner: "sumocode", visible: true } as never,
+				undefined as never,
+				undefined as never,
+				{ cwd: "/repo" } as never,
+			);
+
+			expect(result?.content[0]?.text).toContain("status=at_capacity");
+			expect(result?.details).toMatchObject({
+				action: "spawn",
+				status: "at_capacity",
+				capacity: 1,
+				runningCount: 1,
+			});
+		} finally {
+			if (originalSurface === undefined) delete process.env.CMUX_SURFACE_ID;
+			else process.env.CMUX_SURFACE_ID = originalSurface;
+			if (originalCapacity === undefined) delete process.env.SUMOCODE_BG_AGENT_CAPACITY;
+			else process.env.SUMOCODE_BG_AGENT_CAPACITY = originalCapacity;
+		}
+	});
 });

--- a/src/background-tasks/background-task-tool.ts
+++ b/src/background-tasks/background-task-tool.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { Type } from "typebox";
 import {
+	BackgroundTaskCapacityError,
 	BackgroundTaskManager,
 	DEFAULT_SUMOCODE_AGENT_MODEL,
 	DEFAULT_SUMOCODE_AGENT_THINKING,
@@ -38,6 +39,22 @@ function makeToolResult(text: string, details?: unknown) {
 	};
 }
 
+function formatAtCapacity(error: BackgroundTaskCapacityError): ReturnType<typeof makeToolResult> {
+	const details = error.details;
+	const runningLines = details.running.length > 0
+		? details.running.map((task) => `- ${task.id}${task.title ? ` · ${task.title}` : ""} · ${task.status} · ${Math.round(task.ageMs / 1000)}s`).join("\n")
+		: "- (no running agent tasks found)";
+	return makeToolResult(
+		[
+			`status=at_capacity — this is expected, not a failure. ${details.runningCount}/${details.capacity} SumoCode agent slots are in use.`,
+			"Running agent tasks:",
+			runningLines,
+			`Next action: ${details.retryHint}.`,
+		].join("\n"),
+		{ action: "spawn", ...details },
+	);
+}
+
 export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager {
 	const manager = new BackgroundTaskManager(pi);
 
@@ -64,14 +81,14 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 			"",
 			"• SHELL (runner='shell', default) — spawn a managed shell command. Output is tee'd to a log file, exit code is captured, and completion wakes the orchestrator via a follow-up message and cmux notification. Use for builds, tests, deploys, watchers, anything you want to fire-and-forget.",
 			"",
-			`• AGENT (runner='sumocode', visible=true required) — spawn a child SumoCode agent in a new cmux split. The prompt is delivered as the kickoff message, the child opens straight into the agent loop (no splash). If model/thinking are omitted, SumoCode uses ${DEFAULT_SUMOCODE_AGENT_MODEL} with ${DEFAULT_SUMOCODE_AGENT_THINKING} thinking (override process-wide with SUMOCODE_BG_AGENT_MODEL / SUMOCODE_BG_AGENT_THINKING). Explicit model/thinking params override those defaults. The child writes its FINAL assistant message to response.md; the orchestrator reads it via bg_task log. Task transitions to status='completed' as soon as response.md appears. After 10s idle, the pane auto-closes via cmux close-surface.`,
+			`• AGENT (runner='sumocode', visible=true required) — spawn a child SumoCode agent in a new cmux split. The prompt is delivered as the kickoff message, the child opens straight into the agent loop (no splash). If model/thinking are omitted, SumoCode uses ${DEFAULT_SUMOCODE_AGENT_MODEL} with ${DEFAULT_SUMOCODE_AGENT_THINKING} thinking (override process-wide with SUMOCODE_BG_AGENT_MODEL / SUMOCODE_BG_AGENT_THINKING). Explicit model/thinking params override those defaults. The child writes its latest assistant message to response.md and writes an exit marker on real process exit; the orchestrator reads the final response via bg_task log after completion. The cmux pane remains open until explicitly stopped/closed.`,
 			"",
 			"Actions:",
 			"  spawn  — start a task. Returns task id + paths.",
 			"  list   — list tracked tasks with status, runner, cmux refs.",
-			"  log    — read the task's output. For shell, returns output.log tail. For agent, returns response.md (the harvested final assistant message) when present, or a 'still working' marker if the agent hasn't responded yet. Poll until ready.",
+			"  log    — read the task's output. For shell, returns output.log tail. For agent, returns response.md after real process exit, or a 'still working' marker while the child is still alive. Poll until ready.",
 			"  stop   — SIGTERM a shell task, or cmux close-surface for an agent pane.",
-			"  clear  — remove finished/stopped tasks from the in-memory list.",
+			"  clear  — remove finished/stopped tasks from the registry and delete their on-disk task dirs. Worktrees are preserved unless pruneWorktree=true.",
 		].join("\n"),
 		promptSnippet:
 			"Spawn managed shell tasks or hand off prompts to a visible SumoCode agent pane (with model/thinking override and harvestable response).",
@@ -81,7 +98,9 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 			`To delegate a prompt to a child SumoCode agent, use bg_task with runner='sumocode' and visible=true. If the user does not specify a model, omit model/thinking and let the child default to ${DEFAULT_SUMOCODE_AGENT_MODEL} with ${DEFAULT_SUMOCODE_AGENT_THINKING} thinking. The child opens in a cmux split, runs the prompt, and writes its response back. Read it with bg_task action='log' once status='completed'.`,
 			`Pass model and thinking to bg_task only when the user explicitly wants to override the agent defaults (${DEFAULT_SUMOCODE_AGENT_MODEL}, thinking=${DEFAULT_SUMOCODE_AGENT_THINKING}); process-wide defaults can be set with SUMOCODE_BG_AGENT_MODEL and SUMOCODE_BG_AGENT_THINKING.`,
 			"To read a delegated agent's response, call bg_task with action='log' and id='bg-N'. If the response isn't ready yet, the result will indicate 'still working' — poll again. List with bg_task action='list' to see which tasks have status='completed'.",
-			"Use bg_task action='stop' to cancel a task. For agent panes this closes the cmux surface, preserving any response that was already written.",
+			"If runner='sumocode' spawn returns status='at_capacity', treat it as expected backpressure: wait for a listed agent task to complete or stop one, then retry the spawn. Shell tasks are not blocked by this agent cap.",
+			"Use worktree=true with runner='sumocode' to spawn an agent in a named git worktree; worktrees are never auto-removed and require explicit pruneWorktree=true on clear (or a future worktree prune command).",
+			"Use bg_task action='stop' to cancel a task. For agent panes this closes the cmux surface; completed panes are otherwise left open for inspection.",
 		],
 		parameters: Type.Object({
 			action: StringEnum(["spawn", "list", "log", "stop", "clear"] as const, {
@@ -126,6 +145,14 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 						`Pi thinking level for runner='sumocode'. Defaults to ${DEFAULT_SUMOCODE_AGENT_THINKING} when omitted (or SUMOCODE_BG_AGENT_THINKING if set). Forwarded as --thinking to the child. Ignored for runner='shell'.`,
 				}),
 			),
+			worktree: Type.Optional(
+				Type.Boolean({
+					description: "Create a named git worktree before spawning runner='sumocode', then launch the child in that worktree. Never auto-removes the worktree.",
+				}),
+			),
+			branch: Type.Optional(Type.String({ description: "Optional branch name for worktree=true. Defaults to sumo/<slug>." })),
+			baseRef: Type.Optional(Type.String({ description: "Optional base ref for worktree=true. Defaults to HEAD." })),
+			pruneWorktree: Type.Optional(Type.Boolean({ description: "For action=clear, explicitly remove tracked worktrees for finished tasks. Defaults false." })),
 			direction: Type.Optional(
 				StringEnum(["right", "down"] as const, {
 					description: "Cmux split direction when visible=true. Default: right.",
@@ -150,22 +177,33 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 			}
 
 			if (params.action === "clear") {
-				const removed = manager.clearFinishedTasks();
-				return makeToolResult(`Removed ${removed} finished background task(s).`, { action: "clear", removed });
+				const removed = manager.clearFinishedTasks({ pruneWorktrees: params.pruneWorktree === true });
+				return makeToolResult(`Removed ${removed} finished background task(s).`, { action: "clear", removed, pruneWorktree: params.pruneWorktree === true });
 			}
 
 			if (params.action === "spawn") {
-				const task = manager.spawnTask({
-					command: params.command ?? "",
-					cwd: params.cwd ?? ctx.cwd,
-					title: params.title,
-					visible: params.visible,
-					direction: params.direction,
-					runner: params.runner,
-					model: params.model,
-					thinking: params.thinking as BackgroundTaskThinking | undefined,
-					notifyOnExit: params.notifyOnExit,
-				});
+				let task: BackgroundTask;
+				try {
+					task = manager.spawnTask({
+						command: params.command ?? "",
+						cwd: params.cwd ?? ctx.cwd,
+						title: params.title,
+						visible: params.visible,
+						direction: params.direction,
+						runner: params.runner,
+						model: params.model,
+						thinking: params.thinking as BackgroundTaskThinking | undefined,
+						worktree: params.worktree,
+						branch: params.branch,
+						baseRef: params.baseRef,
+						notifyOnExit: params.notifyOnExit,
+					});
+				} catch (error) {
+					if (error instanceof BackgroundTaskCapacityError) {
+						return formatAtCapacity(error);
+					}
+					throw error;
+				}
 
 				const snapshot = toBackgroundTaskSnapshot(task);
 				const cmuxLine = task.cmux
@@ -176,12 +214,15 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 					task.runner === "sumocode"
 						? `\nHarvest: bg_task action=log id=${task.id} (returns response.md when ready)`
 						: "";
+				const worktreeLine = task.worktree
+					? `\nWorktree: ${task.worktree.branch} at ${task.worktree.path}`
+					: "";
 				const modelLine = task.model || task.thinking
 					? `\nModel: ${task.model ?? "(inherit)"}${task.thinking ? ` thinking=${task.thinking}` : ""}`
 					: "";
 
 				return makeToolResult(
-					`Started ${task.id} in the background.\nCommand: ${task.command}\nCwd: ${task.cwd}\nRunner: ${task.runner}${modelLine}\nLog: ${task.logFile}${pidLine}${cmuxLine}${harvestHint}`,
+					`Started ${task.id} in the background.\nCommand: ${task.command}\nCwd: ${task.cwd}\nRunner: ${task.runner}${modelLine}${worktreeLine}\nLog: ${task.logFile}${pidLine}${cmuxLine}${harvestHint}`,
 					{ action: "spawn", task: snapshot },
 				);
 			}
@@ -210,7 +251,7 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 					if (task.status === "running") {
 						const paneHint = task.cmux ? ` (cmux pane ${task.cmux.surfaceRef})` : "";
 						return makeToolResult(
-							`Agent ${task.id} is still working${paneHint}. response.md not written yet — poll bg_task action=log again, or check bg_task action=list for status.`,
+							`Agent ${task.id} is still working${paneHint}. Waiting for real process exit before harvesting final response — poll bg_task action=log again, or check bg_task action=list for status.`,
 							{ action: "log", task: snapshot, kind: "response", ready: false },
 						);
 					}

--- a/src/background-tasks/background-task-tool.ts
+++ b/src/background-tasks/background-task-tool.ts
@@ -11,9 +11,9 @@ import { type BackgroundTask, type BackgroundTaskThinking, toBackgroundTaskSnaps
 
 /**
  * Read the last ~2KB of an agent task's output.log when surfacing a terminal
- * state without response.md. The log captures the watchdog-timeout message
- * (and any other bg-task instrumentation) so the caller can see WHY harvest
- * never completed instead of just "ended without response.md".
+ * state without response.md. The log captures bg-task instrumentation so the
+ * caller can see WHY harvest never completed instead of just "ended without
+ * response.md".
  */
 function readLogTailForAgent(task: BackgroundTask, maxChars = 2048): string {
 	if (!task.logFile || !existsSync(task.logFile)) return "";
@@ -164,7 +164,7 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 			notifyOnExit: Type.Optional(
 				Type.Boolean({
 					description:
-						"Wake the orchestrator with a follow-up message + cmux notification when the task reaches a terminal state. Defaults to true. For agent runners, this fires when response.md is harvested or the watchdog fails.",
+						"Wake the orchestrator with a follow-up message + cmux notification when the task reaches a terminal state. Defaults to true. For agent runners, this fires after the real process-exit marker is harvested.",
 				}),
 			),
 		}),
@@ -246,8 +246,8 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 					}
 					// No response.md content. Either the task is still running (poll
 					// again) or it reached a terminal state without writing response.md
-					// (watchdog, stop, crash). Surface the actual state so callers don't
-					// poll forever.
+					// (stop, crash/nonzero exit). Surface the actual state so callers
+					// don't poll forever.
 					if (task.status === "running") {
 						const paneHint = task.cmux ? ` (cmux pane ${task.cmux.surfaceRef})` : "";
 						return makeToolResult(
@@ -259,7 +259,7 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 					const logTail = readLogTailForAgent(task);
 					const logFooter = logTail ? `\n\n--- output.log tail ---\n${logTail}` : "";
 					return makeToolResult(
-						`Agent ${task.id} ended without writing response.md (status=${task.status}${exitDetail}). The agent may have crashed, been stopped, or hit the harvest watchdog before its first agent_end fired.${logFooter}`,
+						`Agent ${task.id} ended without writing response.md (status=${task.status}${exitDetail}). The agent may have crashed, been stopped, or exited before its first agent_end fired.${logFooter}`,
 						{
 							action: "log",
 							task: snapshot,

--- a/src/background-tasks/background-task-tool.ts
+++ b/src/background-tasks/background-task-tool.ts
@@ -79,7 +79,7 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 		description: [
 			"Spawn long-running work in a background process or a visible cmux pane. Two modes:",
 			"",
-			"• SHELL (runner='shell', default) — spawn a managed shell command. Output is tee'd to a log file, exit code is captured, and completion wakes the orchestrator via a follow-up message and cmux notification. Use for builds, tests, deploys, watchers, anything you want to fire-and-forget.",
+			"• SHELL (runner='shell', default) — spawn a managed shell command. Output is tee'd to a log file, exit code is captured, and completion fires a passive cmux notification; pass notifyOnExit:true to also wake the orchestrator with a follow-up so the agent acts on the result. Use for builds, tests, deploys, watchers, anything you want to fire-and-forget.",
 			"",
 			`• AGENT (runner='sumocode', visible=true required) — spawn a child SumoCode agent in a new cmux split. The prompt is delivered as the kickoff message, the child opens straight into the agent loop (no splash). If model/thinking are omitted, SumoCode uses ${DEFAULT_SUMOCODE_AGENT_MODEL} with ${DEFAULT_SUMOCODE_AGENT_THINKING} thinking (override process-wide with SUMOCODE_BG_AGENT_MODEL / SUMOCODE_BG_AGENT_THINKING). Explicit model/thinking params override those defaults. The child writes its latest assistant message to response.md and writes an exit marker on real process exit; the orchestrator reads the final response via bg_task log after completion. The cmux pane remains open until explicitly stopped/closed.`,
 			"",
@@ -94,7 +94,7 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 			"Spawn managed shell tasks or hand off prompts to a visible SumoCode agent pane (with model/thinking override and harvestable response).",
 		promptGuidelines: [
 			"Use bg_task when the user wants long-running work to continue while the conversation stays usable.",
-			"For shell commands (build, test, deploy, watchers), use bg_task with runner='shell' (the default) — output is logged and the orchestrator is notified on exit.",
+			"For shell commands (build, test, deploy, watchers), use bg_task with runner='shell' (the default) — output is logged and a passive cmux toast fires on exit; pass notifyOnExit:true to wake the agent on completion.",
 			`To delegate a prompt to a child SumoCode agent, use bg_task with runner='sumocode' and visible=true. If the user does not specify a model, omit model/thinking and let the child default to ${DEFAULT_SUMOCODE_AGENT_MODEL} with ${DEFAULT_SUMOCODE_AGENT_THINKING} thinking. The child opens in a cmux split, runs the prompt, and writes its response back. Read it with bg_task action='log' once status='completed'.`,
 			`Pass model and thinking to bg_task only when the user explicitly wants to override the agent defaults (${DEFAULT_SUMOCODE_AGENT_MODEL}, thinking=${DEFAULT_SUMOCODE_AGENT_THINKING}); process-wide defaults can be set with SUMOCODE_BG_AGENT_MODEL and SUMOCODE_BG_AGENT_THINKING.`,
 			"To read a delegated agent's response, call bg_task with action='log' and id='bg-N'. If the response isn't ready yet, the result will indicate 'still working' — poll again. List with bg_task action='list' to see which tasks have status='completed'.",
@@ -164,7 +164,7 @@ export function installBackgroundTasks(pi: ExtensionAPI): BackgroundTaskManager 
 			notifyOnExit: Type.Optional(
 				Type.Boolean({
 					description:
-						"Wake the orchestrator with a follow-up message + cmux notification when the task reaches a terminal state. Defaults to true. For agent runners, this fires after the real process-exit marker is harvested.",
+						"Wake the orchestrator with a follow-up turn when the task finishes, so the agent acts on the result (e.g. chaining background work). Defaults to FALSE — set true only when you intend to react to completion. A passive cmux notification fires regardless of this flag. For agent runners the follow-up fires after the real process-exit marker is harvested.",
 				}),
 			),
 		}),

--- a/src/background-tasks/task-manager.test.ts
+++ b/src/background-tasks/task-manager.test.ts
@@ -317,6 +317,7 @@ describe("BackgroundTaskManager", () => {
 		const respawnArg = openSplit.mock.calls[0]?.[2] as string;
 		expect(respawnArg).toContain("cd '/repo with spaces' && ");
 		expect(respawnArg).toContain("SUMOCODE_TASK_RESPONSE_FILE=");
+		expect(respawnArg).toContain("SUMOCODE_TASK_STARTED_FILE=");
 		expect(respawnArg).toContain("SUMOCODE_TASK_DIAG_FILE=");
 		expect(respawnArg).toContain(`exec sumocode task --model '${DEFAULT_SUMOCODE_AGENT_MODEL}' --thinking '${DEFAULT_SUMOCODE_AGENT_THINKING}' --prompt-file '`);
 		expect(respawnArg).toContain("/prompt.txt'");
@@ -344,6 +345,7 @@ describe("BackgroundTaskManager", () => {
 
 		// Task snapshot exposes the harvest paths so future tooling can find them.
 		expect(task.responseFile).toBe(task.exitFile!.replace("exit.code", "response.md"));
+		expect(task.markerFile).toBe(task.exitFile!.replace("exit.code", "started.marker"));
 		expect(task.diagFile).toBe(task.exitFile!.replace("exit.code", "diag.jsonl"));
 		expect(task.promptFile).toBe(promptFile);
 	});
@@ -820,7 +822,7 @@ describe("BackgroundTaskManager", () => {
 		expect(harvest.content).toBe("");
 	});
 
-	it("keeps agent task running when no exit marker appears after the old watchdog window", async () => {
+	it("keeps started agent task running when no exit marker appears after the old watchdog window", async () => {
 		vi.useFakeTimers();
 		try {
 			process.env.CMUX_SURFACE_ID = "surface:1";
@@ -843,15 +845,48 @@ describe("BackgroundTaskManager", () => {
 			// Let the spawn microtask settle so the response watcher is armed.
 			await vi.advanceTimersByTimeAsync(50);
 			expect(task.status).toBe("running");
+			writeFileSync(task.markerFile!, `${process.pid}\n`);
 
-			// Walk past the previous 10-minute response-era watchdog window. Agent
-			// completion is now real process exit, so missing marker means still
+			// Walk past the previous 10-minute response-era watchdog window. Once
+			// task-mode writes started.marker, missing exit marker means still
 			// running/unknown rather than failed.
 			await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
 
 			expect(task.status).toBe("running");
-			expect(readFileSync(task.logFile, "utf8")).not.toContain("watchdog timeout");
+			expect(readFileSync(task.logFile, "utf8")).not.toContain("startup timeout");
 			manager.shutdown();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("fails agent task when task-mode never writes started marker", async () => {
+		vi.useFakeTimers();
+		try {
+			process.env.CMUX_SURFACE_ID = "surface:1";
+			const pi = buildPiStub();
+			const cmuxSplit = await import("../commands/cmux-split.js");
+			vi.spyOn(cmuxSplit, "openCommandInNewSplitWithRefs").mockResolvedValue({
+				ok: true,
+				workspaceRef: "workspace:1",
+				surfaceRef: "surface:8",
+			});
+
+			const manager = new BackgroundTaskManager(pi as never);
+			const task = manager.spawnTask({
+				command: "crashy prompt",
+				cwd: "/repo",
+				visible: true,
+				runner: "sumocode",
+				notifyOnExit: false,
+			});
+			await vi.advanceTimersByTimeAsync(50);
+			expect(task.status).toBe("running");
+
+			await vi.advanceTimersByTimeAsync(3 * 60 * 1000);
+
+			expect(task.status).toBe("failed");
+			expect(readFileSync(task.logFile, "utf8")).toContain("startup timeout");
 		} finally {
 			vi.useRealTimers();
 		}
@@ -913,6 +948,48 @@ describe("BackgroundTaskManager", () => {
 		await vi.waitFor(() => expect(task?.status).toBe("completed"));
 
 		expect(pi.sendUserMessage).toHaveBeenCalled();
+	});
+
+	it("recovers agent tasks and fails startup if task-mode never writes started marker", async () => {
+		vi.useFakeTimers();
+		try {
+			const startedAt = Date.now();
+			const root = join(baseDir, "sumocode-bg", `bg-recovered-agent-${startedAt}`);
+			mkdirSync(root, { recursive: true });
+			const logFile = join(root, "output.log");
+			const exitFile = join(root, "exit.code");
+			const markerFile = join(root, "started.marker");
+			const responseFile = join(root, "response.md");
+			const metaFile = join(root, "meta.json");
+			writeFileSync(logFile, "running\n");
+			writeFileSync(metaFile, `${JSON.stringify({
+				schemaVersion: 2,
+				id: "bg-recovered-agent",
+				command: "recover agent",
+				cwd: "/tmp",
+				status: "running",
+				startedAt,
+				updatedAt: startedAt,
+				logFile,
+				exitFile,
+				markerFile,
+				responseFile,
+				metaFile,
+				visible: true,
+				runner: "sumocode",
+			}, null, 2)}\n`);
+
+			const manager = new BackgroundTaskManager(buildPiStub() as never);
+			const task = manager.findTask("bg-recovered-agent");
+			expect(task?.status).toBe("running");
+
+			await vi.advanceTimersByTimeAsync(3 * 60 * 1000);
+
+			expect(task?.status).toBe("failed");
+			expect(readFileSync(logFile, "utf8")).toContain("startup timeout");
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 
 	it("recovers shell tasks and reconciles exit.code after reload", () => {

--- a/src/background-tasks/task-manager.test.ts
+++ b/src/background-tasks/task-manager.test.ts
@@ -1,9 +1,10 @@
 import { EventEmitter } from "node:events";
 import { appendFileSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+	BackgroundTaskCapacityError,
 	BackgroundTaskManager,
 	DEFAULT_SUMOCODE_AGENT_MODEL,
 	DEFAULT_SUMOCODE_AGENT_THINKING,
@@ -13,6 +14,7 @@ const spawnMock = vi.hoisted(() => vi.fn());
 const execFileSyncMock = vi.hoisted(() => vi.fn(() => "Mon Jun  1 10:00:00 2026\n"));
 
 vi.mock("node:child_process", () => ({
+	execFile: vi.fn(),
 	execFileSync: execFileSyncMock,
 	spawn: spawnMock,
 }));
@@ -410,7 +412,91 @@ describe("BackgroundTaskManager", () => {
 		expect(task.thinking).toBe("low");
 	});
 
-	it("transitions agent task to status=completed when response.md appears", async () => {
+	it("rejects over-capacity agent spawns with structured backpressure while allowing shell tasks", async () => {
+		process.env.CMUX_SURFACE_ID = "surface:1";
+		spawnMock.mockReturnValue(mockLongLivedChild());
+		const pi = buildPiStub();
+		const cmuxSplit = await import("../commands/cmux-split.js");
+		vi.spyOn(cmuxSplit, "openCommandInNewSplitWithRefs").mockResolvedValue({
+			ok: true,
+			workspaceRef: "workspace:1",
+			surfaceRef: "surface:2",
+		});
+
+		const manager = new BackgroundTaskManager(pi as never, { agentCapacity: 1 });
+		const first = manager.spawnTask({
+			command: "review one",
+			cwd: "/repo",
+			visible: true,
+			runner: "sumocode",
+			title: "agent one",
+			notifyOnExit: false,
+		});
+		await vi.waitFor(() => expect(first.cmux).toBeDefined());
+
+		let capacityError: unknown;
+		try {
+			manager.spawnTask({
+				command: "review two",
+				cwd: "/repo",
+				visible: true,
+				runner: "sumocode",
+				notifyOnExit: false,
+			});
+		} catch (error) {
+			capacityError = error;
+		}
+
+		expect(capacityError).toBeInstanceOf(BackgroundTaskCapacityError);
+		expect((capacityError as BackgroundTaskCapacityError).details).toMatchObject({
+			status: "at_capacity",
+			capacity: 1,
+			runningCount: 1,
+		});
+		expect((capacityError as BackgroundTaskCapacityError).details.running[0]?.id).toBe(first.id);
+		expect(manager.listTasks().filter((task) => task.runner === "sumocode")).toHaveLength(1);
+
+		const shellTask = manager.spawnTask({ command: "sleep 100", cwd: "/repo", notifyOnExit: false });
+		expect(shellTask.runner).toBe("shell");
+	});
+
+	it("creates and persists a worktree before spawning a sumocode agent", async () => {
+		process.env.CMUX_SURFACE_ID = "surface:1";
+		const pi = buildPiStub();
+		const cmuxSplit = await import("../commands/cmux-split.js");
+		const openSplit = vi.spyOn(cmuxSplit, "openCommandInNewSplitWithRefs").mockResolvedValue({
+			ok: true,
+			workspaceRef: "workspace:1",
+			surfaceRef: "surface:2",
+		});
+		const worktree = await import("../git/worktree.js");
+		const create = vi.spyOn(worktree, "createWorktreeSync").mockReturnValue({
+			ok: true,
+			path: "/repo/.worktrees/sumo__review",
+			branch: "sumo/review",
+			baseRef: "HEAD",
+		});
+
+		const manager = new BackgroundTaskManager(pi as never);
+		const task = manager.spawnTask({
+			command: "review",
+			cwd: "/repo",
+			visible: true,
+			runner: "sumocode",
+			worktree: true,
+			title: "review",
+			notifyOnExit: false,
+		});
+		await vi.waitFor(() => expect(task.cmux).toBeDefined());
+
+		expect(create).toHaveBeenCalledWith({ repoRoot: "/repo", branch: undefined, baseRef: undefined, task: "review" });
+		expect(task.cwd).toBe("/repo/.worktrees/sumo__review");
+		expect(task.worktree).toEqual({ path: "/repo/.worktrees/sumo__review", branch: "sumo/review", baseRef: "HEAD", repoRoot: "/repo" });
+		expect(openSplit.mock.calls[0]?.[2]).toContain("cd '/repo/.worktrees/sumo__review'");
+		expect(JSON.parse(readFileSync(task.metaFile!, "utf8")).worktree).toEqual(task.worktree);
+	});
+
+	it("keeps agent task running when response.md appears before real process exit", async () => {
 		process.env.CMUX_SURFACE_ID = "surface:1";
 		const pi = buildPiStub();
 		const cmuxSplit = await import("../commands/cmux-split.js");
@@ -432,9 +518,13 @@ describe("BackgroundTaskManager", () => {
 		await vi.waitFor(() => expect(task.cmux).toBeDefined());
 		expect(task.status).toBe("running");
 
-		// Simulate the child writing response.md
+		// Simulate the child writing response.md on agent_end. The task must not
+		// complete until task-mode writes the real process-exit marker.
 		writeFileSync(task.responseFile!, "hello world\n");
+		await new Promise((resolve) => setTimeout(resolve, 800));
+		expect(task.status).toBe("running");
 
+		writeFileSync(task.exitFile!, "0\n");
 		await vi.waitFor(
 			() => {
 				expect(task.status).toBe("completed");
@@ -471,6 +561,7 @@ describe("BackgroundTaskManager", () => {
 
 			await vi.waitFor(() => expect(task.cmux).toBeDefined());
 			writeFileSync(task.responseFile!, "done\n");
+			writeFileSync(task.exitFile!, "0\n");
 
 			await vi.advanceTimersByTimeAsync(750);
 
@@ -522,6 +613,13 @@ describe("BackgroundTaskManager", () => {
 		expect(harvest.content).toBe("");
 
 		writeFileSync(task.responseFile!, "## Review\n\nLooks good\n");
+		harvest = manager.getTaskHarvest(task);
+		expect(harvest.kind).toBe("response");
+		expect(harvest.ready).toBe(false);
+		expect(harvest.content).toContain("## Review");
+
+		writeFileSync(task.exitFile!, "0\n");
+		await vi.waitFor(() => expect(task.status).toBe("completed"));
 		harvest = manager.getTaskHarvest(task);
 		expect(harvest.kind).toBe("response");
 		expect(harvest.ready).toBe(true);
@@ -1085,14 +1183,16 @@ describe("BackgroundTaskManager", () => {
 		}
 	});
 
-	it("recovers completed agent tasks from response.md after reload", () => {
+	it("recovers completed agent tasks from the real-exit marker after reload", () => {
 		const root = join(baseDir, "sumocode-bg", "bg-agent-1-1000");
 		mkdirSync(root, { recursive: true });
 		const logFile = join(root, "output.log");
 		const responseFile = join(root, "response.md");
+		const exitFile = join(root, "exit.code");
 		const metaFile = join(root, "meta.json");
 		writeFileSync(logFile, "agent started\n");
 		writeFileSync(responseFile, "final answer\n");
+		writeFileSync(exitFile, "0\n");
 		writeFileSync(metaFile, `${JSON.stringify({
 			schemaVersion: 2,
 			id: "bg-agent-1",
@@ -1103,6 +1203,7 @@ describe("BackgroundTaskManager", () => {
 			updatedAt: 1000,
 			logFile,
 			metaFile,
+			exitFile,
 			responseFile,
 			visible: true,
 			runner: "sumocode",
@@ -1195,6 +1296,70 @@ describe("BackgroundTaskManager", () => {
 		expect(manager.clearFinishedTasks()).toBe(1);
 		expect(manager.listTasks()).toHaveLength(0);
 		expect(existsSync(task.metaFile!)).toBe(false);
+		expect(existsSync(task.logFile)).toBe(false);
+		expect(existsSync(dirname(task.logFile))).toBe(false);
 		expect(new BackgroundTaskManager(buildPiStub() as never).listTasks()).toHaveLength(0);
+	});
+
+	it("prunes stale finished task dirs during recovery without touching running tasks", () => {
+		const staleRoot = join(baseDir, "sumocode-bg", "bg-stale-1000");
+		const runningRoot = join(baseDir, "sumocode-bg", "bg-running-1000");
+		mkdirSync(staleRoot, { recursive: true });
+		mkdirSync(runningRoot, { recursive: true });
+		const staleLog = join(staleRoot, "output.log");
+		const runningLog = join(runningRoot, "output.log");
+		writeFileSync(staleLog, "old\n");
+		writeFileSync(runningLog, "still running\n");
+		writeFileSync(join(staleRoot, "meta.json"), `${JSON.stringify({
+			schemaVersion: 2,
+			id: "bg-stale",
+			command: "old",
+			cwd: "/tmp",
+			status: "completed",
+			startedAt: 1000,
+			updatedAt: 1000,
+			logFile: staleLog,
+			metaFile: join(staleRoot, "meta.json"),
+			visible: false,
+			runner: "shell",
+		}, null, 2)}\n`);
+		writeFileSync(join(runningRoot, "meta.json"), `${JSON.stringify({
+			schemaVersion: 2,
+			id: "bg-running",
+			command: "sleep 100",
+			cwd: "/tmp",
+			status: "running",
+			startedAt: 1000,
+			updatedAt: 1000,
+			logFile: runningLog,
+			metaFile: join(runningRoot, "meta.json"),
+			visible: false,
+			runner: "shell",
+		}, null, 2)}\n`);
+
+		const manager = new BackgroundTaskManager(buildPiStub() as never, { finishedTaskMaxAgeMs: 1 });
+
+		expect(manager.findTask("bg-stale")).toBeUndefined();
+		expect(existsSync(staleRoot)).toBe(false);
+		expect(manager.findTask("bg-running")).toBeDefined();
+		expect(existsSync(runningRoot)).toBe(true);
+	});
+
+	it("caps output.log size for running tasks", async () => {
+		const child = mockLongLivedChild();
+		spawnMock.mockReturnValue(child);
+		vi.useFakeTimers();
+		try {
+			const manager = new BackgroundTaskManager(buildPiStub() as never, { logMaxBytes: 512 });
+			const task = manager.spawnTask({ command: "watch", cwd: "/tmp", notifyOnExit: false });
+			appendFileSync(task.logFile, "x".repeat(4096));
+
+			await vi.advanceTimersByTimeAsync(2_000);
+
+			expect(readFileSync(task.logFile, "utf8").length).toBeLessThanOrEqual(512);
+			expect(readFileSync(task.logFile, "utf8")).toContain("log truncated");
+		} finally {
+			vi.useRealTimers();
+		}
 	});
 });

--- a/src/background-tasks/task-manager.test.ts
+++ b/src/background-tasks/task-manager.test.ts
@@ -577,8 +577,8 @@ describe("BackgroundTaskManager", () => {
 			);
 			expect(notifyCall, "expected a cmux notify exec call").toBeDefined();
 
-			// The response watcher is cleared by finalization, so the watchdog cannot
-			// later emit a second completion/failure notification for the same task.
+			// The response watcher is cleared by finalization, so later polling cannot
+			// emit a second completion/failure notification for the same task.
 			await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
 			expect(task.status).toBe("completed");
 			expect(pi.sendUserMessage).toHaveBeenCalledTimes(1);
@@ -810,7 +810,7 @@ describe("BackgroundTaskManager", () => {
 		expect(harvest.ready).toBe(false);
 		expect(harvest.content).toBe("");
 
-		// Simulate a terminal failure (e.g. watchdog timeout) WITHOUT response.md.
+		// Simulate a terminal failure WITHOUT response.md.
 		// The harvest should now report ready=true so callers don't poll forever.
 		task.status = "failed";
 		task.exitCode = null;
@@ -820,7 +820,7 @@ describe("BackgroundTaskManager", () => {
 		expect(harvest.content).toBe("");
 	});
 
-	it("transitions agent task to failed when response.md never appears (watchdog timeout)", async () => {
+	it("keeps agent task running when no exit marker appears after the old watchdog window", async () => {
 		vi.useFakeTimers();
 		try {
 			process.env.CMUX_SURFACE_ID = "surface:1";
@@ -834,7 +834,7 @@ describe("BackgroundTaskManager", () => {
 
 			const manager = new BackgroundTaskManager(pi as never);
 			const task = manager.spawnTask({
-				command: "crashy prompt",
+				command: "long-running prompt",
 				cwd: "/repo",
 				visible: true,
 				runner: "sumocode",
@@ -844,11 +844,14 @@ describe("BackgroundTaskManager", () => {
 			await vi.advanceTimersByTimeAsync(50);
 			expect(task.status).toBe("running");
 
-			// Walk past the watchdog deadline (10 min default).
+			// Walk past the previous 10-minute response-era watchdog window. Agent
+			// completion is now real process exit, so missing marker means still
+			// running/unknown rather than failed.
 			await vi.advanceTimersByTimeAsync(11 * 60 * 1000);
 
-			expect(task.status).toBe("failed");
-			expect(readFileSync(task.logFile, "utf8")).toContain("watchdog timeout");
+			expect(task.status).toBe("running");
+			expect(readFileSync(task.logFile, "utf8")).not.toContain("watchdog timeout");
+			manager.shutdown();
 		} finally {
 			vi.useRealTimers();
 		}

--- a/src/background-tasks/task-manager.test.ts
+++ b/src/background-tasks/task-manager.test.ts
@@ -140,6 +140,7 @@ describe("BackgroundTaskManager", () => {
 		const task = manager.spawnTask({
 			command: "echo hello",
 			cwd: "/tmp/project",
+			notifyOnExit: true,
 		});
 
 		await vi.waitFor(() => {
@@ -224,6 +225,31 @@ describe("BackgroundTaskManager", () => {
 		expect(args.some((a) => a.includes(task.id))).toBe(true);
 		expect(args).toContain("--body");
 		expect(args).toContain("build artifacts");
+
+		// New default: a fire-and-forget shell task must NOT wake the agent. The
+		// passive cmux toast above is decoupled from the message-queue follow-up.
+		expect(pi.sendUserMessage).not.toHaveBeenCalled();
+	});
+
+	it("does not wake the orchestrator for a default fire-and-forget task", async () => {
+		spawnMock.mockReturnValue(mockChild(0));
+		const pi = buildPiStub();
+		const manager = new BackgroundTaskManager(pi as never);
+
+		const task = manager.spawnTask({
+			command: "echo quiet",
+			cwd: "/tmp/project",
+		});
+
+		await vi.waitFor(() => {
+			expect(task.status).toBe("completed");
+		});
+
+		// notifyOnExit defaults to false: completion must NOT inject a
+		// message-queue follow-up that wakes the agent. (The in-cmux
+		// passive-notify-still-fires angle is covered above; this is the plain
+		// no-wake default.)
+		expect(pi.sendUserMessage).not.toHaveBeenCalled();
 	});
 
 	it("does not fire cmux notify outside cmux", async () => {
@@ -472,9 +498,9 @@ describe("BackgroundTaskManager", () => {
 			surfaceRef: "surface:2",
 		});
 		const worktree = await import("../git/worktree.js");
-		const create = vi.spyOn(worktree, "createWorktreeSync").mockReturnValue({
+		const create = vi.spyOn(worktree, "createWorktree").mockResolvedValue({
 			ok: true,
-			path: "/repo/.worktrees/sumo__review",
+			path: "/repo.sumo-worktrees/sumo__review",
 			branch: "sumo/review",
 			baseRef: "HEAD",
 		});
@@ -491,11 +517,48 @@ describe("BackgroundTaskManager", () => {
 		});
 		await vi.waitFor(() => expect(task.cmux).toBeDefined());
 
-		expect(create).toHaveBeenCalledWith({ repoRoot: "/repo", branch: undefined, baseRef: undefined, task: "review" });
-		expect(task.cwd).toBe("/repo/.worktrees/sumo__review");
-		expect(task.worktree).toEqual({ path: "/repo/.worktrees/sumo__review", branch: "sumo/review", baseRef: "HEAD", repoRoot: "/repo" });
-		expect(openSplit.mock.calls[0]?.[2]).toContain("cd '/repo/.worktrees/sumo__review'");
+		expect(create).toHaveBeenCalledWith({ repoRoot: "/repo", branch: "sumo/review", baseRef: "HEAD", path: "/repo.sumo-worktrees/sumo__review" });
+		expect(task.cwd).toBe("/repo.sumo-worktrees/sumo__review");
+		expect(task.worktree).toEqual({ path: "/repo.sumo-worktrees/sumo__review", branch: "sumo/review", baseRef: "HEAD", repoRoot: "/repo" });
+		expect(openSplit.mock.calls[0]?.[2]).toContain("cd '/repo.sumo-worktrees/sumo__review'");
 		expect(JSON.parse(readFileSync(task.metaFile!, "utf8")).worktree).toEqual(task.worktree);
+	});
+
+	it("finalizes the task as failed when deferred worktree creation fails", async () => {
+		process.env.CMUX_SURFACE_ID = "surface:1";
+		const pi = buildPiStub();
+		const cmuxSplit = await import("../commands/cmux-split.js");
+		const openSplit = vi.spyOn(cmuxSplit, "openCommandInNewSplitWithRefs").mockResolvedValue({
+			ok: true,
+			workspaceRef: "workspace:1",
+			surfaceRef: "surface:2",
+		});
+		const worktree = await import("../git/worktree.js");
+		vi.spyOn(worktree, "createWorktree").mockResolvedValue({
+			ok: false,
+			error: "branch_already_exists",
+			message: "branch already exists: sumo/x",
+		});
+
+		const manager = new BackgroundTaskManager(pi as never);
+		const task = manager.spawnTask({
+			command: "review",
+			cwd: "/repo",
+			visible: true,
+			runner: "sumocode",
+			worktree: true,
+			title: "review",
+			notifyOnExit: false,
+		});
+		await vi.waitFor(() => expect(task.status).toBe("failed"));
+
+		expect(openSplit).not.toHaveBeenCalled();
+		expect(readFileSync(task.logFile, "utf8")).toContain("worktree create failed: branch already exists: sumo/x");
+		// Fix A: the speculative worktree ref must be cleared so a later prune
+		// does not try to remove a nonexistent worktree and get stuck.
+		expect(task.worktree).toBeUndefined();
+		expect(manager.clearFinishedTasks({ pruneWorktrees: true })).toBe(1);
+		expect(manager.findTask(task.id)).toBeUndefined();
 	});
 
 	it("keeps agent task running when response.md appears before real process exit", async () => {
@@ -559,6 +622,7 @@ describe("BackgroundTaskManager", () => {
 				visible: true,
 				runner: "sumocode",
 				title: "agent review",
+				notifyOnExit: true,
 			});
 
 			await vi.waitFor(() => expect(task.cmux).toBeDefined());
@@ -860,6 +924,76 @@ describe("BackgroundTaskManager", () => {
 		}
 	});
 
+	it("reaps a started agent task whose process has died without an exit marker", async () => {
+		vi.useFakeTimers();
+		const processKill = vi.spyOn(process, "kill").mockImplementation(((pid: number, signal?: string | number) => {
+			if (pid === 43210 && signal === 0) throw new Error("ESRCH");
+			return true;
+		}) as typeof process.kill);
+		try {
+			process.env.CMUX_SURFACE_ID = "surface:1";
+			const pi = buildPiStub();
+			const cmuxSplit = await import("../commands/cmux-split.js");
+			vi.spyOn(cmuxSplit, "openCommandInNewSplitWithRefs").mockResolvedValue({
+				ok: true,
+				workspaceRef: "workspace:1",
+				surfaceRef: "surface:8",
+			});
+
+			const manager = new BackgroundTaskManager(pi as never);
+			const task = manager.spawnTask({
+				command: "crashy prompt",
+				cwd: "/repo",
+				visible: true,
+				runner: "sumocode",
+				notifyOnExit: false,
+			});
+			await vi.advanceTimersByTimeAsync(50);
+			writeFileSync(task.markerFile!, "43210\n");
+
+			await vi.advanceTimersByTimeAsync(1000);
+
+			expect(task.status).toBe("failed");
+			expect(readFileSync(task.logFile, "utf8")).toContain("is gone and no exit marker");
+			manager.shutdown();
+		} finally {
+			processKill.mockRestore();
+			vi.useRealTimers();
+		}
+	});
+
+	it("keeps a started agent task running while its process is alive", async () => {
+		vi.useFakeTimers();
+		try {
+			process.env.CMUX_SURFACE_ID = "surface:1";
+			const pi = buildPiStub();
+			const cmuxSplit = await import("../commands/cmux-split.js");
+			vi.spyOn(cmuxSplit, "openCommandInNewSplitWithRefs").mockResolvedValue({
+				ok: true,
+				workspaceRef: "workspace:1",
+				surfaceRef: "surface:8",
+			});
+
+			const manager = new BackgroundTaskManager(pi as never);
+			const task = manager.spawnTask({
+				command: "long-running prompt",
+				cwd: "/repo",
+				visible: true,
+				runner: "sumocode",
+				notifyOnExit: false,
+			});
+			await vi.advanceTimersByTimeAsync(50);
+			writeFileSync(task.markerFile!, `${process.pid}\n`);
+
+			await vi.advanceTimersByTimeAsync(1000);
+
+			expect(task.status).toBe("running");
+			manager.shutdown();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
 	it("fails agent task when task-mode never writes started marker", async () => {
 		vi.useFakeTimers();
 		try {
@@ -992,7 +1126,7 @@ describe("BackgroundTaskManager", () => {
 		}
 	});
 
-	it("recovers shell tasks and reconciles exit.code after reload", () => {
+	it("recovers shell tasks and reconciles exit.code after reload without injecting a message-queue followUp", () => {
 		const root = join(baseDir, "sumocode-bg", "bg-recovered-1-1000");
 		mkdirSync(root, { recursive: true });
 		const logFile = join(root, "output.log");
@@ -1022,10 +1156,7 @@ describe("BackgroundTaskManager", () => {
 		expect(task?.status).toBe("completed");
 		expect(task?.exitCode).toBe(0);
 		expect(manager.getTaskHarvest(task!, 1000).content).toContain("done");
-		expect(pi.sendUserMessage).toHaveBeenCalledWith(
-			expect.stringContaining("background task bg-recovered-1 completed"),
-			{ deliverAs: "followUp" },
-		);
+		expect(pi.sendUserMessage).not.toHaveBeenCalled();
 	});
 
 	it("keeps new invisible shell tasks running when process identity cannot be captured", () => {
@@ -1425,7 +1556,24 @@ describe("BackgroundTaskManager", () => {
 		expect(existsSync(runningRoot)).toBe(true);
 	});
 
-	it("caps output.log size for running tasks", async () => {
+	it("caps output.log size once a task finishes", () => {
+		const child = mockLongLivedChild();
+		spawnMock.mockReturnValue(child);
+		const manager = new BackgroundTaskManager(buildPiStub() as never, { logMaxBytes: 512 });
+		const task = manager.spawnTask({ command: "watch", cwd: "/tmp", notifyOnExit: false });
+		appendFileSync(task.logFile, "x".repeat(4096));
+
+		// The cap is enforced once, when the task finalizes — i.e. after the
+		// external writer (here the mock child) has exited, never while it is
+		// still appending. Driving the child to close finalizes the task.
+		child.forceExit(0);
+
+		const finished = readFileSync(task.logFile, "utf8");
+		expect(finished.length).toBeLessThanOrEqual(512);
+		expect(finished.startsWith("[sumocode-bg] log truncated")).toBe(true);
+	});
+
+	it("bounds a running task's log writer-safely: truncates to zero, never rewrites", async () => {
 		const child = mockLongLivedChild();
 		spawnMock.mockReturnValue(child);
 		vi.useFakeTimers();
@@ -1434,10 +1582,33 @@ describe("BackgroundTaskManager", () => {
 			const task = manager.spawnTask({ command: "watch", cwd: "/tmp", notifyOnExit: false });
 			appendFileSync(task.logFile, "x".repeat(4096));
 
-			await vi.advanceTimersByTimeAsync(2_000);
+			// The running guard is writer-safe: it truncates to zero (which a live
+			// O_APPEND writer can resume past) rather than rewriting the file with a
+			// tail, which would race the tee/redirect writer and corrupt the log.
+			await vi.advanceTimersByTimeAsync(5_500);
 
-			expect(readFileSync(task.logFile, "utf8").length).toBeLessThanOrEqual(512);
-			expect(readFileSync(task.logFile, "utf8")).toContain("log truncated");
+			const running = readFileSync(task.logFile, "utf8");
+			expect(running.length).toBe(0);
+			expect(running).not.toContain("log truncated");
+			manager.shutdown();
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("leaves a running task's log untouched while it is under the cap", async () => {
+		const child = mockLongLivedChild();
+		spawnMock.mockReturnValue(child);
+		vi.useFakeTimers();
+		try {
+			const manager = new BackgroundTaskManager(buildPiStub() as never, { logMaxBytes: 4096 });
+			const task = manager.spawnTask({ command: "watch", cwd: "/tmp", notifyOnExit: false });
+			appendFileSync(task.logFile, "y".repeat(1024));
+
+			await vi.advanceTimersByTimeAsync(15_000);
+
+			expect(readFileSync(task.logFile, "utf8").length).toBe(1024);
+			manager.shutdown();
 		} finally {
 			vi.useRealTimers();
 		}

--- a/src/background-tasks/task-manager.ts
+++ b/src/background-tasks/task-manager.ts
@@ -8,6 +8,7 @@ import {
 	openSync,
 	readFileSync,
 	readSync,
+	rmSync,
 	statSync,
 	unlinkSync,
 	writeFileSync,
@@ -19,6 +20,7 @@ import {
 	openCommandInNewSplitWithRefs,
 	type SplitDirection as CmuxSplitDirection,
 } from "../commands/cmux-split.js";
+import { createWorktreeSync, removeWorktreeSync } from "../git/worktree.js";
 import {
 	BACKGROUND_TASK_META_SCHEMA_VERSION,
 	type BackgroundTask,
@@ -43,6 +45,8 @@ export const DEFAULT_SUMOCODE_AGENT_MODEL = "openai-codex/gpt-5.5";
 export const DEFAULT_SUMOCODE_AGENT_THINKING: BackgroundTaskThinking = "low";
 const AGENT_MODEL_ENV = "SUMOCODE_BG_AGENT_MODEL";
 const AGENT_THINKING_ENV = "SUMOCODE_BG_AGENT_THINKING";
+const AGENT_CAPACITY_ENV = "SUMOCODE_BG_AGENT_CAPACITY";
+export const DEFAULT_SUMOCODE_AGENT_CAPACITY = 4;
 const THINKING_LEVELS = new Set<BackgroundTaskThinking>([
 	"off",
 	"minimal",
@@ -58,11 +62,16 @@ const STOP_SIGTERM_GRACE_MS = 5_000;
 const DEFAULT_AGENT_WATCHDOG_MS = 10 * 60 * 1000; // 10 minutes
 /** Bounded tail-read for poll/harvest — avoids O(file_size) re-reads. */
 const LOG_TAIL_READ_BYTES = 16 * 1024;
+export const DEFAULT_BACKGROUND_TASK_LOG_MAX_BYTES = 2 * 1024 * 1024;
+const LOG_CAP_INTERVAL_MS = 2_000;
+const DEFAULT_FINISHED_TASK_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
+const DEFAULT_MAX_RECOVERED_FINISHED_TASKS = 100;
 
 interface InternalTask extends BackgroundTask {
 	child?: ChildProcess;
 	pollTimer?: ReturnType<typeof setInterval>;
 	responseTimer?: ReturnType<typeof setInterval>;
+	logCapTimer?: ReturnType<typeof setInterval>;
 	watchdogDeadline?: number;
 	/**
 	 * Promise that resolves once the visible-spawn coroutine finishes (success
@@ -73,6 +82,38 @@ interface InternalTask extends BackgroundTask {
 	spawnPromise?: Promise<void>;
 	stopRequested?: boolean;
 	finalized?: boolean;
+}
+
+export interface BackgroundTaskManagerOptions {
+	readonly agentCapacity?: number;
+	readonly logMaxBytes?: number;
+	readonly finishedTaskMaxAgeMs?: number;
+	readonly maxRecoveredFinishedTasks?: number;
+}
+
+export interface AgentCapacityTaskSummary {
+	readonly id: string;
+	readonly title?: string;
+	readonly status: BackgroundTask["status"];
+	readonly ageMs: number;
+}
+
+export interface AgentCapacityDetails {
+	readonly status: "at_capacity";
+	readonly capacity: number;
+	readonly runningCount: number;
+	readonly running: readonly AgentCapacityTaskSummary[];
+	readonly retryHint: string;
+}
+
+export class BackgroundTaskCapacityError extends Error {
+	public readonly details: AgentCapacityDetails;
+
+	public constructor(details: AgentCapacityDetails) {
+		super(`agent capacity reached (${details.runningCount}/${details.capacity})`);
+		this.name = "BackgroundTaskCapacityError";
+		this.details = details;
+	}
 }
 
 function getShellConfig(): { shell: string; args: string[] } {
@@ -108,8 +149,34 @@ function resolveAgentThinking(
 	return thinking ?? normalizeThinking(process.env[AGENT_THINKING_ENV]) ?? DEFAULT_SUMOCODE_AGENT_THINKING;
 }
 
-function appendLogLine(logFile: string, line: string): void {
+function resolveAgentCapacity(value: number | undefined): number {
+	if (typeof value === "number" && Number.isFinite(value) && value >= 1) return Math.floor(value);
+	const fromEnv = Number.parseInt(process.env[AGENT_CAPACITY_ENV] ?? "", 10);
+	return Number.isFinite(fromEnv) && fromEnv >= 1 ? fromEnv : DEFAULT_SUMOCODE_AGENT_CAPACITY;
+}
+
+function normalizePositiveInteger(value: number | undefined, fallback: number): number {
+	return typeof value === "number" && Number.isFinite(value) && value >= 1 ? Math.floor(value) : fallback;
+}
+
+function enforceLogSizeCap(logFile: string, maxBytes: number): void {
+	if (!existsSync(logFile)) return;
+	try {
+		const { size } = statSync(logFile);
+		if (size <= maxBytes) return;
+		const keepBytes = Math.max(0, maxBytes - 80);
+		const tail = readLogTail(logFile, keepBytes);
+		const prefix = `[sumocode-bg] log truncated to last ${keepBytes} bytes\n`;
+		const next = `${prefix}${tail}`;
+		writeFileSync(logFile, next.length <= maxBytes ? next : next.slice(-maxBytes));
+	} catch {
+		// best-effort; logging must never interrupt task lifecycle
+	}
+}
+
+function appendLogLine(logFile: string, line: string, maxBytes = DEFAULT_BACKGROUND_TASK_LOG_MAX_BYTES): void {
 	writeFileSync(logFile, line, { flag: "a" });
+	enforceLogSizeCap(logFile, maxBytes);
 }
 
 /**
@@ -283,6 +350,7 @@ function parseRecoveredTask(raw: unknown, metaFile: string): InternalTask | unde
 		model: snapshot.model,
 		thinking: snapshot.thinking,
 		cmux: snapshot.cmux,
+		worktree: snapshot.worktree,
 		notifyOnExit: snapshot.notifyOnExit !== false,
 	};
 }
@@ -290,9 +358,17 @@ function parseRecoveredTask(raw: unknown, metaFile: string): InternalTask | unde
 export class BackgroundTaskManager {
 	private tasks = new Map<string, InternalTask>();
 	private readonly pi: ExtensionAPI;
+	private readonly agentCapacity: number;
+	private readonly logMaxBytes: number;
+	private readonly finishedTaskMaxAgeMs: number;
+	private readonly maxRecoveredFinishedTasks: number;
 
-	constructor(pi: ExtensionAPI) {
+	constructor(pi: ExtensionAPI, options: BackgroundTaskManagerOptions = {}) {
 		this.pi = pi;
+		this.agentCapacity = resolveAgentCapacity(options.agentCapacity);
+		this.logMaxBytes = normalizePositiveInteger(options.logMaxBytes, DEFAULT_BACKGROUND_TASK_LOG_MAX_BYTES);
+		this.finishedTaskMaxAgeMs = normalizePositiveInteger(options.finishedTaskMaxAgeMs, DEFAULT_FINISHED_TASK_MAX_AGE_MS);
+		this.maxRecoveredFinishedTasks = normalizePositiveInteger(options.maxRecoveredFinishedTasks, DEFAULT_MAX_RECOVERED_FINISHED_TASKS);
 		this.recoverTasks();
 	}
 
@@ -311,6 +387,7 @@ export class BackgroundTaskManager {
 		} catch {
 			return;
 		}
+		const recovered: InternalTask[] = [];
 		for (const entry of entries) {
 			const metaFile = join(root, entry, "meta.json");
 			if (!existsSync(metaFile)) continue;
@@ -318,29 +395,52 @@ export class BackgroundTaskManager {
 				const task = parseRecoveredTask(JSON.parse(readFileSync(metaFile, "utf8")), metaFile);
 				if (!task || this.tasks.has(task.id)) continue;
 				this.reconcileRecoveredTask(task);
-				this.tasks.set(task.id, task);
+				recovered.push(task);
 			} catch {
 				// Ignore malformed/unknown legacy metadata; recovery is best-effort.
 			}
 		}
+		for (const task of this.pruneRecoveredFinishedTasks(recovered)) {
+			this.tasks.set(task.id, task);
+		}
+	}
+
+	private pruneRecoveredFinishedTasks(tasks: readonly InternalTask[]): InternalTask[] {
+		const now = Date.now();
+		const finished = tasks
+			.filter((task) => task.status !== "running")
+			.sort((a, b) => b.updatedAt - a.updatedAt);
+		const keepFinished = new Set(finished.slice(0, this.maxRecoveredFinishedTasks).map((task) => task.id));
+		const kept: InternalTask[] = [];
+		for (const task of tasks) {
+			if (task.status === "running") {
+				kept.push(task);
+				continue;
+			}
+			const tooOld = now - task.updatedAt > this.finishedTaskMaxAgeMs;
+			const overCount = !keepFinished.has(task.id);
+			if (tooOld || overCount) {
+				this.removeTaskArtifacts(task);
+				continue;
+			}
+			kept.push(task);
+		}
+		return kept;
 	}
 
 	private reconcileRecoveredTask(task: InternalTask): void {
 		if (task.status !== "running") {
 			task.finalized = true;
+			enforceLogSizeCap(task.logFile, this.logMaxBytes);
 			return;
 		}
+		this.armLogCap(task);
 
 		const exitCode = task.exitFile && existsSync(task.exitFile)
 			? readExitCodeFromFile(readFileSync(task.exitFile, "utf8"))
 			: null;
 		if (exitCode != null) {
 			this.finalizeTask(task, exitCode, "self-exit");
-			return;
-		}
-
-		if (task.runner === "sumocode" && task.responseFile && existsSync(task.responseFile)) {
-			this.finalizeTask(task, 0, "self-exit");
 			return;
 		}
 
@@ -384,10 +484,53 @@ export class BackgroundTaskManager {
 			.map((task) => {
 				const label = task.title ?? task.command;
 				const cmux = task.cmux ? ` · cmux ${task.cmux.surfaceRef}` : "";
+				const worktree = task.worktree ? ` · ${task.worktree.branch}` : "";
 				const pid = task.pid != null ? ` · pid ${task.pid}` : "";
-				return `${task.id} · ${summarizeStatus(task)}${pid}${cmux} · ${label}`;
+				return `${task.id} · ${summarizeStatus(task)}${pid}${cmux}${worktree} · ${label}`;
 			})
 			.join("\n");
+	}
+
+	getAgentCapacityDetails(): AgentCapacityDetails {
+		const now = Date.now();
+		const running = [...this.tasks.values()]
+			.filter((task) => task.runner === "sumocode" && task.status === "running")
+			.sort((a, b) => a.startedAt - b.startedAt)
+			.map((task) => ({
+				id: task.id,
+				title: task.title,
+				status: task.status,
+				ageMs: Math.max(0, now - task.startedAt),
+			}));
+		return {
+			status: "at_capacity",
+			capacity: this.agentCapacity,
+			runningCount: running.length,
+			running,
+			retryHint: "poll bg_task action=log on a running task until one completes, then retry this spawn; stop an unneeded task with bg_task action=stop",
+		};
+	}
+
+	private assertAgentCapacityAvailable(runner: BackgroundTask["runner"]): void {
+		if (runner !== "sumocode") return;
+		const details = this.getAgentCapacityDetails();
+		if (details.runningCount >= details.capacity) {
+			throw new BackgroundTaskCapacityError(details);
+		}
+	}
+
+	private armLogCap(task: InternalTask): void {
+		if (task.logCapTimer || task.status !== "running") return;
+		enforceLogSizeCap(task.logFile, this.logMaxBytes);
+		task.logCapTimer = setInterval(() => enforceLogSizeCap(task.logFile, this.logMaxBytes), LOG_CAP_INTERVAL_MS);
+		if (typeof task.logCapTimer.unref === "function") task.logCapTimer.unref();
+	}
+
+	private clearLogCap(task: InternalTask): void {
+		if (!task.logCapTimer) return;
+		clearInterval(task.logCapTimer);
+		task.logCapTimer = undefined;
+		enforceLogSizeCap(task.logFile, this.logMaxBytes);
 	}
 
 	spawnTask(options: SpawnBackgroundTaskOptions): BackgroundTask {
@@ -410,11 +553,30 @@ export class BackgroundTaskManager {
 		if (visible && !isInCmux()) {
 			throw new Error("visible background tasks require a cmux surface (CMUX_SURFACE_ID or CMUX_WORKSPACE_ID)");
 		}
+		this.assertAgentCapacityAvailable(runner);
 
 		let id = generateTaskId();
 		while (this.tasks.has(id)) id = generateTaskId();
 		const now = Date.now();
-		const cwd = options.cwd.trim() || process.cwd();
+		let cwd = options.cwd.trim() || process.cwd();
+		let worktree: BackgroundTask["worktree"];
+		if (options.worktree === true) {
+			const repoRoot = cwd;
+			if (runner !== "sumocode" || !visible) {
+				throw new Error("worktree=true requires runner='sumocode' and visible=true");
+			}
+			const created = createWorktreeSync({
+				repoRoot: cwd,
+				branch: options.branch,
+				baseRef: options.baseRef,
+				task: options.title ?? command,
+			});
+			if (!created.ok) {
+				throw new Error(`failed to create worktree: ${created.message}`);
+			}
+			worktree = { path: created.path, branch: created.branch, baseRef: created.baseRef, repoRoot };
+			cwd = created.path;
+		}
 		const paths = buildVisibleTaskPaths(id, now);
 		mkdirSync(dirname(paths.logFile), { recursive: true });
 		writeFileSync(paths.logFile, "");
@@ -437,11 +599,13 @@ export class BackgroundTaskManager {
 			runner,
 			model: resolveAgentModel(runner, options.model),
 			thinking: resolveAgentThinking(runner, options.thinking),
+			worktree,
 			notifyOnExit: options.notifyOnExit !== false,
 		};
 
 		this.tasks.set(id, task);
 		writeTaskMeta(task);
+		this.armLogCap(task);
 
 		if (visible) {
 			// Capture the spawn coroutine on the task so stopTask can await it.
@@ -454,7 +618,7 @@ export class BackgroundTaskManager {
 				paths,
 			).catch((error) => {
 				const message = error instanceof Error ? error.message : String(error);
-				appendLogLine(task.logFile, `\n[bg-task] visible spawn failed: ${message}\n`);
+				appendLogLine(task.logFile, `\n[bg-task] visible spawn failed: ${message}\n`, this.logMaxBytes);
 				this.finalizeTask(task, 1, "self-exit");
 			});
 		} else {
@@ -499,7 +663,7 @@ export class BackgroundTaskManager {
 			// On platforms where we kept stdio pipes (Windows), tee chunks into the
 			// log file. On detached platforms the shell does the redirection.
 			const handleChunk = (chunk: Buffer) => {
-				appendLogLine(logFile, chunk.toString());
+				appendLogLine(logFile, chunk.toString(), this.logMaxBytes);
 				task.updatedAt = Date.now();
 			};
 			child.stdout?.on("data", handleChunk);
@@ -510,12 +674,12 @@ export class BackgroundTaskManager {
 			this.finalizeTask(task, typeof code === "number" ? code : null, "self-exit");
 		});
 		child.on("error", (error) => {
-			appendLogLine(logFile, `\n[spawn error] ${error.message}\n`);
+			appendLogLine(logFile, `\n[spawn error] ${error.message}\n`, this.logMaxBytes);
 			this.finalizeTask(task, 1, "self-exit");
 		});
 
 		if (task.pid != null && !task.processStartTime) {
-			appendLogLine(logFile, "\n[bg-task] warning: failed to capture process identity; recovered stop will require identity recapture\n");
+			appendLogLine(logFile, "\n[bg-task] warning: failed to capture process identity; recovered stop will require identity recapture\n", this.logMaxBytes);
 		}
 
 		writeTaskMeta(task);
@@ -569,7 +733,7 @@ export class BackgroundTaskManager {
 
 		const splitResult = await openCommandInNewSplitWithRefs(this.pi, direction, respawnCommand);
 		if (!splitResult.ok) {
-			appendLogLine(task.logFile, `\n[cmux error] ${splitResult.error}\n`);
+			appendLogLine(task.logFile, `\n[cmux error] ${splitResult.error}\n`, this.logMaxBytes);
 			this.finalizeTask(task, 1, "self-exit");
 			return;
 		}
@@ -606,27 +770,27 @@ export class BackgroundTaskManager {
 			task.pollTimer = setInterval(() => {
 				this.pollVisibleTask(task);
 			}, POLL_INTERVAL_MS);
-		} else if (task.responseFile) {
-			// Agent runners: watch for the child to write response.md when its
-			// first agent_end fires (see src/task-mode.ts). On creation, we
-			// transition the task to "completed" and persist the updated
-			// snapshot so `bg_task list` and `bg_task log` reflect the harvest.
+		} else if (task.exitFile) {
+			// Agent runners: response.md is only the latest assistant response.
+			// Completion is keyed to the real process-exit marker written by
+			// src/task-mode.ts so multi-turn child sessions are not marked done on
+			// their first agent_end.
 			task.watchdogDeadline = Date.now() + DEFAULT_AGENT_WATCHDOG_MS;
 			this.armResponseWatcher(task);
 		}
 	}
 
 	/**
-	 * Poll for the child agent's `response.md`. Pi has no cross-process event
+	 * Poll for the child agent's real exit marker. Pi has no cross-process event
 	 * bus we could subscribe to, so a 750ms file-poll is the simplest reliable
-	 * way to detect a hand-off completion. The interval is cancelled once the
-	 * file appears, on stop/shutdown, or after the watchdog deadline (default
-	 * 10 min). Watchdog expiry covers the case where the child crashes before
-	 * `agent_end` fires — without it, the task would stay `running` forever
-	 * and the orchestrator would poll "still working" indefinitely.
+	 * way to detect hand-off completion. The interval is cancelled once the
+	 * exit marker appears, on stop/shutdown, or after the watchdog deadline
+	 * (default 10 min). Watchdog expiry covers the case where the child dies
+	 * before writing the marker — without it, the task would stay `running`
+	 * forever and the orchestrator would poll "still working" indefinitely.
 	 */
 	private armResponseWatcher(task: InternalTask): void {
-		if (!task.responseFile) return;
+		if (!task.exitFile) return;
 		if (task.responseTimer) clearInterval(task.responseTimer);
 		task.responseTimer = setInterval(() => {
 			if (task.finalized) {
@@ -634,8 +798,9 @@ export class BackgroundTaskManager {
 				task.responseTimer = undefined;
 				return;
 			}
-			if (task.responseFile && existsSync(task.responseFile)) {
-				this.finalizeTask(task, 0, "self-exit");
+			if (task.exitFile && existsSync(task.exitFile)) {
+				const exitCode = readExitCodeFromFile(readFileSync(task.exitFile, "utf8"));
+				this.finalizeTask(task, exitCode, "self-exit");
 				return;
 			}
 			if (task.watchdogDeadline && Date.now() > task.watchdogDeadline) {
@@ -643,7 +808,8 @@ export class BackgroundTaskManager {
 				task.responseTimer = undefined;
 				appendLogLine(
 					task.logFile,
-					`[bg-task] watchdog timeout: response.md not written within ${Math.round(DEFAULT_AGENT_WATCHDOG_MS / 1000)}s; marking task failed (agent may have crashed before agent_end)\n`,
+					`[bg-task] watchdog timeout: exit marker not written within ${Math.round(DEFAULT_AGENT_WATCHDOG_MS / 1000)}s; marking task failed (agent may have crashed before process exit)\n`,
+					this.logMaxBytes,
 				);
 				this.finalizeTask(task, null, "self-exit");
 			}
@@ -691,6 +857,7 @@ export class BackgroundTaskManager {
 			clearInterval(task.responseTimer);
 			task.responseTimer = undefined;
 		}
+		this.clearLogCap(task);
 
 		task.exitCode = exitCode;
 		task.updatedAt = Date.now();
@@ -929,13 +1096,37 @@ export class BackgroundTaskManager {
 		return await awaitExit(2_000);
 	}
 
-	clearFinishedTasks(): number {
+	private taskArtifactDir(task: BackgroundTask): string | undefined {
+		if (task.metaFile) return dirname(task.metaFile);
+		if (task.logFile) return dirname(task.logFile);
+		return undefined;
+	}
+
+	private removeTaskArtifacts(task: BackgroundTask): void {
+		const dir = this.taskArtifactDir(task);
+		if (!dir) return;
+		try {
+			rmSync(dir, { recursive: true, force: true });
+		} catch {
+			// best-effort cleanup; never fail clear/recovery on filesystem races
+		}
+	}
+
+	clearFinishedTasks(options: { pruneWorktrees?: boolean } = {}): number {
 		let removed = 0;
 		for (const [id, task] of this.tasks) {
 			if (task.status === "running") continue;
 			if (task.pollTimer) clearInterval(task.pollTimer);
 			if (task.responseTimer) clearInterval(task.responseTimer);
-			if (task.metaFile) removePathIfExists(task.metaFile);
+			this.clearLogCap(task);
+			if (options.pruneWorktrees && task.worktree) {
+				const pruned = removeWorktreeSync({ path: task.worktree.path, repoRoot: task.worktree.repoRoot });
+				if (!pruned.ok) {
+					appendLogLine(task.logFile, `\n[bg-task] worktree prune failed: ${pruned.message}\n`, this.logMaxBytes);
+					continue;
+				}
+			}
+			this.removeTaskArtifacts(task);
 			this.tasks.delete(id);
 			removed += 1;
 		}
@@ -943,9 +1134,10 @@ export class BackgroundTaskManager {
 	}
 
 	/**
-	 * For the sumocode runner, the harvest output lives in `response.md`
-	 * written by the child on first agent_end. For shell runners it lives in
-	 * `output.log`. This wrapper returns the right one per runner.
+	 * For the sumocode runner, the harvest output lives in `response.md`, but
+	 * that file is harvestable only after the child writes its real process-exit
+	 * marker. For shell runners output lives in `output.log`. This wrapper
+	 * returns the right one per runner.
 	 *
 	 * `ready: false` means the harvest is pending AND the task is still
 	 * running. If the task has transitioned to a terminal state (failed via
@@ -959,19 +1151,12 @@ export class BackgroundTaskManager {
 		ready: boolean;
 	} {
 		if (task.runner === "sumocode" && task.responseFile) {
-			if (existsSync(task.responseFile)) {
-				const content = readFileSync(task.responseFile, "utf8");
-				return {
-					kind: "response",
-					content: content.length <= maxChars ? content : content.slice(-maxChars),
-					ready: true,
-				};
-			}
+			const content = existsSync(task.responseFile) ? readFileSync(task.responseFile, "utf8") : "";
 			return {
 				kind: "response",
-				content: "",
-				// Terminal-state guard: don't keep telling callers "still working"
-				// once the task has failed/stopped without writing response.md.
+				content: content.length <= maxChars ? content : content.slice(-maxChars),
+				// response.md may be written before a child truly exits. Treat it as
+				// harvestable only after the real exit marker has finalized the task.
 				ready: task.status !== "running",
 			};
 		}
@@ -1002,6 +1187,7 @@ export class BackgroundTaskManager {
 			}
 			if (task.pollTimer) clearInterval(task.pollTimer);
 			if (task.responseTimer) clearInterval(task.responseTimer);
+			this.clearLogCap(task);
 		}
 	}
 }

--- a/src/background-tasks/task-manager.ts
+++ b/src/background-tasks/task-manager.ts
@@ -58,8 +58,6 @@ const THINKING_LEVELS = new Set<BackgroundTaskThinking>([
 
 /** Max grace period before stopTask escalates SIGTERM to SIGKILL. */
 const STOP_SIGTERM_GRACE_MS = 5_000;
-/** Default upper bound on agent-runner response.md harvest before failing. */
-const DEFAULT_AGENT_WATCHDOG_MS = 10 * 60 * 1000; // 10 minutes
 /** Bounded tail-read for poll/harvest — avoids O(file_size) re-reads. */
 const LOG_TAIL_READ_BYTES = 16 * 1024;
 export const DEFAULT_BACKGROUND_TASK_LOG_MAX_BYTES = 2 * 1024 * 1024;
@@ -72,7 +70,6 @@ interface InternalTask extends BackgroundTask {
 	pollTimer?: ReturnType<typeof setInterval>;
 	responseTimer?: ReturnType<typeof setInterval>;
 	logCapTimer?: ReturnType<typeof setInterval>;
-	watchdogDeadline?: number;
 	/**
 	 * Promise that resolves once the visible-spawn coroutine finishes (success
 	 * OR caught failure). `stopTask` awaits this so it can never finalize a task
@@ -455,8 +452,7 @@ export class BackgroundTaskManager {
 		if (task.runner === "shell") {
 			task.pollTimer = setInterval(() => this.pollVisibleTask(task), POLL_INTERVAL_MS);
 			if (typeof task.pollTimer.unref === "function") task.pollTimer.unref();
-		} else if (task.responseFile) {
-			task.watchdogDeadline = Date.now() + DEFAULT_AGENT_WATCHDOG_MS;
+		} else if (task.exitFile) {
 			this.armResponseWatcher(task);
 		}
 	}
@@ -775,7 +771,6 @@ export class BackgroundTaskManager {
 			// Completion is keyed to the real process-exit marker written by
 			// src/task-mode.ts so multi-turn child sessions are not marked done on
 			// their first agent_end.
-			task.watchdogDeadline = Date.now() + DEFAULT_AGENT_WATCHDOG_MS;
 			this.armResponseWatcher(task);
 		}
 	}
@@ -784,10 +779,10 @@ export class BackgroundTaskManager {
 	 * Poll for the child agent's real exit marker. Pi has no cross-process event
 	 * bus we could subscribe to, so a 750ms file-poll is the simplest reliable
 	 * way to detect hand-off completion. The interval is cancelled once the
-	 * exit marker appears, on stop/shutdown, or after the watchdog deadline
-	 * (default 10 min). Watchdog expiry covers the case where the child dies
-	 * before writing the marker — without it, the task would stay `running`
-	 * forever and the orchestrator would poll "still working" indefinitely.
+	 * exit marker appears, on explicit stop, or on manager shutdown. Absence of
+	 * the marker is deliberately non-terminal: visible child agents may run for
+	 * longer than a fixed response-era timeout, and some panes are intentionally
+	 * left open for user takeover.
 	 */
 	private armResponseWatcher(task: InternalTask): void {
 		if (!task.exitFile) return;
@@ -802,16 +797,6 @@ export class BackgroundTaskManager {
 				const exitCode = readExitCodeFromFile(readFileSync(task.exitFile, "utf8"));
 				this.finalizeTask(task, exitCode, "self-exit");
 				return;
-			}
-			if (task.watchdogDeadline && Date.now() > task.watchdogDeadline) {
-				if (task.responseTimer) clearInterval(task.responseTimer);
-				task.responseTimer = undefined;
-				appendLogLine(
-					task.logFile,
-					`[bg-task] watchdog timeout: exit marker not written within ${Math.round(DEFAULT_AGENT_WATCHDOG_MS / 1000)}s; marking task failed (agent may have crashed before process exit)\n`,
-					this.logMaxBytes,
-				);
-				this.finalizeTask(task, null, "self-exit");
 			}
 		}, RESPONSE_POLL_INTERVAL_MS);
 		if (typeof task.responseTimer.unref === "function") {
@@ -868,7 +853,6 @@ export class BackgroundTaskManager {
 			// "self-exit". Honor the original stop intent.
 			task.status = "stopped";
 		} else if (exitCode === 0) {
-			// For agent runners, exitCode=null + self-exit means watchdog timeout.
 			task.status = "completed";
 		} else if (exitCode === null) {
 			task.status = "failed";
@@ -1140,8 +1124,8 @@ export class BackgroundTaskManager {
 	 * returns the right one per runner.
 	 *
 	 * `ready: false` means the harvest is pending AND the task is still
-	 * running. If the task has transitioned to a terminal state (failed via
-	 * watchdog, stopped by user, etc.) without ever writing response.md,
+	 * running. If the task has transitioned to a terminal state (stopped by
+	 * user, crashed/nonzero exit, etc.) without ever writing response.md,
 	 * callers should NOT poll forever — we return `ready: true` with empty
 	 * content and the terminal state surfaces via task.status.
 	 */

--- a/src/background-tasks/task-manager.ts
+++ b/src/background-tasks/task-manager.ts
@@ -10,6 +10,7 @@ import {
 	readSync,
 	rmSync,
 	statSync,
+	truncateSync,
 	unlinkSync,
 	writeFileSync,
 } from "node:fs";
@@ -20,7 +21,7 @@ import {
 	openCommandInNewSplitWithRefs,
 	type SplitDirection as CmuxSplitDirection,
 } from "../commands/cmux-split.js";
-import { createWorktreeSync, removeWorktreeSync } from "../git/worktree.js";
+import { createWorktree, removeWorktreeSync, resolveCreateOptions } from "../git/worktree.js";
 import {
 	BACKGROUND_TASK_META_SCHEMA_VERSION,
 	type BackgroundTask,
@@ -40,6 +41,8 @@ import {
 
 const POLL_INTERVAL_MS = 500;
 const RESPONSE_POLL_INTERVAL_MS = 750;
+/** How often the running-task log size guard runs (writer-safe truncate). */
+const LOG_CAP_INTERVAL_MS = 5_000;
 const DEFAULT_AGENT_STARTUP_TIMEOUT_MS = 2 * 60 * 1000;
 const DEFAULT_VISIBLE_DIRECTION: CmuxSplitDirection = "right";
 export const DEFAULT_SUMOCODE_AGENT_MODEL = "openai-codex/gpt-5.5";
@@ -47,7 +50,7 @@ export const DEFAULT_SUMOCODE_AGENT_THINKING: BackgroundTaskThinking = "low";
 const AGENT_MODEL_ENV = "SUMOCODE_BG_AGENT_MODEL";
 const AGENT_THINKING_ENV = "SUMOCODE_BG_AGENT_THINKING";
 const AGENT_CAPACITY_ENV = "SUMOCODE_BG_AGENT_CAPACITY";
-export const DEFAULT_SUMOCODE_AGENT_CAPACITY = 4;
+const DEFAULT_SUMOCODE_AGENT_CAPACITY = 4;
 const THINKING_LEVELS = new Set<BackgroundTaskThinking>([
 	"off",
 	"minimal",
@@ -61,8 +64,7 @@ const THINKING_LEVELS = new Set<BackgroundTaskThinking>([
 const STOP_SIGTERM_GRACE_MS = 5_000;
 /** Bounded tail-read for poll/harvest — avoids O(file_size) re-reads. */
 const LOG_TAIL_READ_BYTES = 16 * 1024;
-export const DEFAULT_BACKGROUND_TASK_LOG_MAX_BYTES = 2 * 1024 * 1024;
-const LOG_CAP_INTERVAL_MS = 2_000;
+const DEFAULT_BACKGROUND_TASK_LOG_MAX_BYTES = 2 * 1024 * 1024;
 const DEFAULT_FINISHED_TASK_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000;
 const DEFAULT_MAX_RECOVERED_FINISHED_TASKS = 100;
 
@@ -79,6 +81,7 @@ interface InternalTask extends BackgroundTask {
 	 * stopped-then-launched race leaves a runaway pane.
 	 */
 	spawnPromise?: Promise<void>;
+	worktreePending?: boolean;
 	stopRequested?: boolean;
 	finalized?: boolean;
 }
@@ -173,9 +176,27 @@ function enforceLogSizeCap(logFile: string, maxBytes: number): void {
 	}
 }
 
-function appendLogLine(logFile: string, line: string, maxBytes = DEFAULT_BACKGROUND_TASK_LOG_MAX_BYTES): void {
+/**
+ * Writer-safe running cap. While a task is live its output.log is written by an
+ * EXTERNAL O_APPEND writer (the visible-shell `tee -a` pipeline or the detached
+ * shell's `>>` redirect). We must NOT rewrite the file from this process the way
+ * `enforceLogSizeCap` does — that races the writer and corrupts the log, which is
+ * why `enforceLogSizeCap` only runs at finalize. `truncate(0)` writes no bytes, so
+ * an O_APPEND writer simply resumes at the new EOF: it bounds disk without
+ * clobbering. History is dropped (not a tail-keep) precisely because keeping a
+ * tail would require writing bytes back into a file another process is appending.
+ */
+function truncateLogIfOverCap(logFile: string, maxBytes: number): void {
+	if (!existsSync(logFile)) return;
+	try {
+		if (statSync(logFile).size > maxBytes) truncateSync(logFile, 0);
+	} catch {
+		// best-effort; logging must never interrupt task lifecycle
+	}
+}
+
+function appendLogLine(logFile: string, line: string): void {
 	writeFileSync(logFile, line, { flag: "a" });
-	enforceLogSizeCap(logFile, maxBytes);
 }
 
 /**
@@ -260,6 +281,18 @@ function isProcessAlive(pid: number | undefined): boolean {
 		return true;
 	} catch {
 		return false;
+	}
+}
+
+function readStartedMarkerPid(markerFile: string | undefined): number | undefined {
+	if (!markerFile || !existsSync(markerFile)) return undefined;
+	try {
+		const first = readFileSync(markerFile, "utf8").trim().split("\n")[0] ?? "";
+		if (!/^\d+$/.test(first)) return undefined;
+		const pid = Number.parseInt(first, 10);
+		return Number.isFinite(pid) && pid > 0 ? pid : undefined;
+	} catch {
+		return undefined;
 	}
 }
 
@@ -351,7 +384,7 @@ function parseRecoveredTask(raw: unknown, metaFile: string): InternalTask | unde
 		thinking: snapshot.thinking,
 		cmux: snapshot.cmux,
 		worktree: snapshot.worktree,
-		notifyOnExit: snapshot.notifyOnExit !== false,
+		notifyOnExit: snapshot.notifyOnExit === true,
 	};
 }
 
@@ -362,6 +395,13 @@ export class BackgroundTaskManager {
 	private readonly logMaxBytes: number;
 	private readonly finishedTaskMaxAgeMs: number;
 	private readonly maxRecoveredFinishedTasks: number;
+	/**
+	 * True only while `recoverTasks` is reconciling persisted state on
+	 * startup/reload. Used by `finalizeTask` to suppress the message-queue
+	 * followUp injection (which would wake the agent with a turn the user never
+	 * requested) while still allowing the passive cmux desktop notify to fire.
+	 */
+	private recovering = false;
 
 	constructor(pi: ExtensionAPI, options: BackgroundTaskManagerOptions = {}) {
 		this.pi = pi;
@@ -387,21 +427,26 @@ export class BackgroundTaskManager {
 		} catch {
 			return;
 		}
-		const recovered: InternalTask[] = [];
-		for (const entry of entries) {
-			const metaFile = join(root, entry, "meta.json");
-			if (!existsSync(metaFile)) continue;
-			try {
-				const task = parseRecoveredTask(JSON.parse(readFileSync(metaFile, "utf8")), metaFile);
-				if (!task || this.tasks.has(task.id)) continue;
-				this.reconcileRecoveredTask(task);
-				recovered.push(task);
-			} catch {
-				// Ignore malformed/unknown legacy metadata; recovery is best-effort.
+		this.recovering = true;
+		try {
+			const recovered: InternalTask[] = [];
+			for (const entry of entries) {
+				const metaFile = join(root, entry, "meta.json");
+				if (!existsSync(metaFile)) continue;
+				try {
+					const task = parseRecoveredTask(JSON.parse(readFileSync(metaFile, "utf8")), metaFile);
+					if (!task || this.tasks.has(task.id)) continue;
+					this.reconcileRecoveredTask(task);
+					recovered.push(task);
+				} catch {
+					// Ignore malformed/unknown legacy metadata; recovery is best-effort.
+				}
 			}
-		}
-		for (const task of this.pruneRecoveredFinishedTasks(recovered)) {
-			this.tasks.set(task.id, task);
+			for (const task of this.pruneRecoveredFinishedTasks(recovered)) {
+				this.tasks.set(task.id, task);
+			}
+		} finally {
+			this.recovering = false;
 		}
 	}
 
@@ -434,8 +479,6 @@ export class BackgroundTaskManager {
 			enforceLogSizeCap(task.logFile, this.logMaxBytes);
 			return;
 		}
-		this.armLogCap(task);
-
 		const exitCode = task.exitFile && existsSync(task.exitFile)
 			? readExitCodeFromFile(readFileSync(task.exitFile, "utf8"))
 			: null;
@@ -451,6 +494,8 @@ export class BackgroundTaskManager {
 				return;
 			}
 		}
+
+		this.armLogCap(task);
 
 		if (task.runner === "shell") {
 			task.pollTimer = setInterval(() => this.pollVisibleTask(task), POLL_INTERVAL_MS);
@@ -519,20 +564,6 @@ export class BackgroundTaskManager {
 		}
 	}
 
-	private armLogCap(task: InternalTask): void {
-		if (task.logCapTimer || task.status !== "running") return;
-		enforceLogSizeCap(task.logFile, this.logMaxBytes);
-		task.logCapTimer = setInterval(() => enforceLogSizeCap(task.logFile, this.logMaxBytes), LOG_CAP_INTERVAL_MS);
-		if (typeof task.logCapTimer.unref === "function") task.logCapTimer.unref();
-	}
-
-	private clearLogCap(task: InternalTask): void {
-		if (!task.logCapTimer) return;
-		clearInterval(task.logCapTimer);
-		task.logCapTimer = undefined;
-		enforceLogSizeCap(task.logFile, this.logMaxBytes);
-	}
-
 	spawnTask(options: SpawnBackgroundTaskOptions): BackgroundTask {
 		const command = options.command.trim();
 		if (!command) {
@@ -560,22 +591,21 @@ export class BackgroundTaskManager {
 		const now = Date.now();
 		let cwd = options.cwd.trim() || process.cwd();
 		let worktree: BackgroundTask["worktree"];
+		let worktreePending = false;
 		if (options.worktree === true) {
-			const repoRoot = cwd;
 			if (runner !== "sumocode" || !visible) {
 				throw new Error("worktree=true requires runner='sumocode' and visible=true");
 			}
-			const created = createWorktreeSync({
-				repoRoot: cwd,
+			const repoRoot = cwd;
+			const target = resolveCreateOptions({
+				repoRoot,
 				branch: options.branch,
 				baseRef: options.baseRef,
 				task: options.title ?? command,
 			});
-			if (!created.ok) {
-				throw new Error(`failed to create worktree: ${created.message}`);
-			}
-			worktree = { path: created.path, branch: created.branch, baseRef: created.baseRef, repoRoot };
-			cwd = created.path;
+			worktree = { path: target.path, branch: target.branch, baseRef: target.baseRef, repoRoot };
+			cwd = target.path;
+			worktreePending = true;
 		}
 		const paths = buildVisibleTaskPaths(id, now);
 		mkdirSync(dirname(paths.logFile), { recursive: true });
@@ -601,7 +631,8 @@ export class BackgroundTaskManager {
 			model: resolveAgentModel(runner, options.model),
 			thinking: resolveAgentThinking(runner, options.thinking),
 			worktree,
-			notifyOnExit: options.notifyOnExit !== false,
+			worktreePending,
+			notifyOnExit: options.notifyOnExit === true,
 		};
 
 		this.tasks.set(id, task);
@@ -619,7 +650,7 @@ export class BackgroundTaskManager {
 				paths,
 			).catch((error) => {
 				const message = error instanceof Error ? error.message : String(error);
-				appendLogLine(task.logFile, `\n[bg-task] visible spawn failed: ${message}\n`, this.logMaxBytes);
+				appendLogLine(task.logFile, `\n[bg-task] visible spawn failed: ${message}\n`);
 				this.finalizeTask(task, 1, "self-exit");
 			});
 		} else {
@@ -664,7 +695,7 @@ export class BackgroundTaskManager {
 			// On platforms where we kept stdio pipes (Windows), tee chunks into the
 			// log file. On detached platforms the shell does the redirection.
 			const handleChunk = (chunk: Buffer) => {
-				appendLogLine(logFile, chunk.toString(), this.logMaxBytes);
+				appendLogLine(logFile, chunk.toString());
 				task.updatedAt = Date.now();
 			};
 			child.stdout?.on("data", handleChunk);
@@ -675,12 +706,12 @@ export class BackgroundTaskManager {
 			this.finalizeTask(task, typeof code === "number" ? code : null, "self-exit");
 		});
 		child.on("error", (error) => {
-			appendLogLine(logFile, `\n[spawn error] ${error.message}\n`, this.logMaxBytes);
+			appendLogLine(logFile, `\n[spawn error] ${error.message}\n`);
 			this.finalizeTask(task, 1, "self-exit");
 		});
 
 		if (task.pid != null && !task.processStartTime) {
-			appendLogLine(logFile, "\n[bg-task] warning: failed to capture process identity; recovered stop will require identity recapture\n", this.logMaxBytes);
+			appendLogLine(logFile, "\n[bg-task] warning: failed to capture process identity; recovered stop will require identity recapture\n");
 		}
 
 		writeTaskMeta(task);
@@ -700,6 +731,27 @@ export class BackgroundTaskManager {
 		if (task.stopRequested) {
 			this.finalizeTask(task, null, "stopped");
 			return;
+		}
+		if (task.worktreePending && task.worktree) {
+			const created = await createWorktree({
+				repoRoot: task.worktree.repoRoot,
+				branch: task.worktree.branch,
+				baseRef: task.worktree.baseRef,
+				path: task.worktree.path,
+			});
+			if (!created.ok) {
+				appendLogLine(task.logFile, `\n[bg-task] worktree create failed: ${created.message}\n`);
+				// No worktree exists on disk; drop the speculative ref so a later
+				// clearFinishedTasks({ pruneWorktrees: true }) does not try to remove
+				// a nonexistent worktree and get stuck.
+				task.worktree = undefined;
+				task.worktreePending = false;
+				this.finalizeTask(task, 1, "self-exit");
+				return;
+			}
+			task.worktreePending = false;
+			task.updatedAt = Date.now();
+			writeTaskMeta(task);
 		}
 		if (task.runner === "shell") {
 			writeFileSync(
@@ -734,7 +786,7 @@ export class BackgroundTaskManager {
 
 		const splitResult = await openCommandInNewSplitWithRefs(this.pi, direction, respawnCommand);
 		if (!splitResult.ok) {
-			appendLogLine(task.logFile, `\n[cmux error] ${splitResult.error}\n`, this.logMaxBytes);
+			appendLogLine(task.logFile, `\n[cmux error] ${splitResult.error}\n`);
 			this.finalizeTask(task, 1, "self-exit");
 			return;
 		}
@@ -817,11 +869,19 @@ export class BackgroundTaskManager {
 			}
 			if (task.markerFile && existsSync(task.markerFile)) {
 				task.startupDeadline = undefined;
+				const pid = readStartedMarkerPid(task.markerFile);
+				if (pid !== undefined && !isProcessAlive(pid)) {
+					appendLogLine(
+						task.logFile,
+						`[bg-task] agent process ${pid} is gone and no exit marker was written; marking task failed (likely SIGKILL/crash)\n`,
+					);
+					this.finalizeTask(task, null, "self-exit");
+					return;
+				}
 			} else if (task.startupDeadline && Date.now() > task.startupDeadline) {
 				appendLogLine(
 					task.logFile,
 					`[bg-task] startup timeout: task-mode started marker not written within ${Math.round(DEFAULT_AGENT_STARTUP_TIMEOUT_MS / 1000)}s; marking task failed before handoff became live\n`,
-					this.logMaxBytes,
 				);
 				this.finalizeTask(task, null, "self-exit");
 			}
@@ -857,6 +917,23 @@ export class BackgroundTaskManager {
 		}
 	}
 
+	/**
+	 * Arm a writer-safe periodic size guard for a running task so a long-lived
+	 * watcher cannot grow output.log without bound between finalizations.
+	 */
+	private armLogCap(task: InternalTask): void {
+		if (task.logCapTimer || task.status !== "running") return;
+		truncateLogIfOverCap(task.logFile, this.logMaxBytes);
+		task.logCapTimer = setInterval(() => truncateLogIfOverCap(task.logFile, this.logMaxBytes), LOG_CAP_INTERVAL_MS);
+		if (typeof task.logCapTimer.unref === "function") task.logCapTimer.unref();
+	}
+
+	private clearLogCap(task: InternalTask): void {
+		if (!task.logCapTimer) return;
+		clearInterval(task.logCapTimer);
+		task.logCapTimer = undefined;
+	}
+
 	private finalizeTask(task: InternalTask, exitCode: number | null, reason: "self-exit" | "stopped"): void {
 		if (task.finalized) return;
 		task.finalized = true;
@@ -870,6 +947,11 @@ export class BackgroundTaskManager {
 			task.responseTimer = undefined;
 		}
 		this.clearLogCap(task);
+		// Cap the log exactly once, now that the task is finalized and no external
+		// writer (the visible-shell `tee -a` pipeline / detached shell redirect) is
+		// still appending to output.log. The running guard only truncates-to-zero
+		// (writer-safe); here, with no live writer, we keep the tail.
+		enforceLogSizeCap(task.logFile, this.logMaxBytes);
 
 		task.exitCode = exitCode;
 		task.updatedAt = Date.now();
@@ -889,16 +971,27 @@ export class BackgroundTaskManager {
 
 		writeTaskMeta(task);
 
-		if (task.notifyOnExit && reason === "self-exit") {
-			const label = task.title ?? task.command;
-			const cmuxHint = task.cmux ? ` (cmux ${task.cmux.surfaceRef})` : "";
-			const message = `background task ${task.id} ${summarizeStatus(task)}: ${label}${cmuxHint}`;
-			try {
-				this.pi.sendUserMessage(message, { deliverAs: "followUp" });
-			} catch {
-				this.pi.sendUserMessage(message);
-			}
+		if (reason === "self-exit") {
+			// Passive completion signal: a cmux desktop toast that informs the user
+			// (across workspaces and reloads) WITHOUT waking the agent. Fires for every
+			// terminal self-exit, including fire-and-forget tasks and during startup
+			// recovery.
 			this.fireCmuxNotify(task);
+
+			// Active wake: inject a follow-up turn so the orchestrator agent reacts to
+			// the result (e.g. to continue chained background work). Opt-in only —
+			// notifyOnExit defaults to false — and never during startup recovery, where
+			// it would wake the agent for a task the user never started this session.
+			if (task.notifyOnExit && !this.recovering) {
+				const label = task.title ?? task.command;
+				const cmuxHint = task.cmux ? ` (cmux ${task.cmux.surfaceRef})` : "";
+				const message = `background task ${task.id} ${summarizeStatus(task)}: ${label}${cmuxHint}`;
+				try {
+					this.pi.sendUserMessage(message, { deliverAs: "followUp" });
+				} catch {
+					this.pi.sendUserMessage(message);
+				}
+			}
 		}
 	}
 
@@ -1133,7 +1226,7 @@ export class BackgroundTaskManager {
 			if (options.pruneWorktrees && task.worktree) {
 				const pruned = removeWorktreeSync({ path: task.worktree.path, repoRoot: task.worktree.repoRoot });
 				if (!pruned.ok) {
-					appendLogLine(task.logFile, `\n[bg-task] worktree prune failed: ${pruned.message}\n`, this.logMaxBytes);
+					appendLogLine(task.logFile, `\n[bg-task] worktree prune failed: ${pruned.message}\n`);
 					continue;
 				}
 			}

--- a/src/background-tasks/task-manager.ts
+++ b/src/background-tasks/task-manager.ts
@@ -40,6 +40,7 @@ import {
 
 const POLL_INTERVAL_MS = 500;
 const RESPONSE_POLL_INTERVAL_MS = 750;
+const DEFAULT_AGENT_STARTUP_TIMEOUT_MS = 2 * 60 * 1000;
 const DEFAULT_VISIBLE_DIRECTION: CmuxSplitDirection = "right";
 export const DEFAULT_SUMOCODE_AGENT_MODEL = "openai-codex/gpt-5.5";
 export const DEFAULT_SUMOCODE_AGENT_THINKING: BackgroundTaskThinking = "low";
@@ -70,6 +71,7 @@ interface InternalTask extends BackgroundTask {
 	pollTimer?: ReturnType<typeof setInterval>;
 	responseTimer?: ReturnType<typeof setInterval>;
 	logCapTimer?: ReturnType<typeof setInterval>;
+	startupDeadline?: number;
 	/**
 	 * Promise that resolves once the visible-spawn coroutine finishes (success
 	 * OR caught failure). `stopTask` awaits this so it can never finalize a task
@@ -338,6 +340,7 @@ function parseRecoveredTask(raw: unknown, metaFile: string): InternalTask | unde
 		logFile: snapshot.logFile,
 		exitFile: snapshot.exitFile,
 		metaFile,
+		markerFile: snapshot.markerFile,
 		promptFile: snapshot.promptFile,
 		responseFile: snapshot.responseFile,
 		diagFile: snapshot.diagFile,
@@ -453,6 +456,7 @@ export class BackgroundTaskManager {
 			task.pollTimer = setInterval(() => this.pollVisibleTask(task), POLL_INTERVAL_MS);
 			if (typeof task.pollTimer.unref === "function") task.pollTimer.unref();
 		} else if (task.exitFile) {
+			this.armAgentStartupDeadline(task);
 			this.armResponseWatcher(task);
 		}
 	}
@@ -588,6 +592,7 @@ export class BackgroundTaskManager {
 			logFile: paths.logFile,
 			exitFile: paths.exitFile,
 			metaFile: paths.metaFile,
+			markerFile: runner === "shell" ? undefined : paths.markerFile,
 			promptFile: runner === "shell" ? undefined : paths.promptFile,
 			responseFile: runner === "shell" ? undefined : paths.responseFile,
 			diagFile: runner === "shell" ? undefined : paths.diagFile,
@@ -771,8 +776,17 @@ export class BackgroundTaskManager {
 			// Completion is keyed to the real process-exit marker written by
 			// src/task-mode.ts so multi-turn child sessions are not marked done on
 			// their first agent_end.
+			this.armAgentStartupDeadline(task);
 			this.armResponseWatcher(task);
 		}
+	}
+
+	private armAgentStartupDeadline(task: InternalTask): void {
+		if (!task.markerFile || existsSync(task.markerFile)) {
+			task.startupDeadline = undefined;
+			return;
+		}
+		task.startupDeadline = task.startedAt + DEFAULT_AGENT_STARTUP_TIMEOUT_MS;
 	}
 
 	/**
@@ -780,9 +794,12 @@ export class BackgroundTaskManager {
 	 * bus we could subscribe to, so a 750ms file-poll is the simplest reliable
 	 * way to detect hand-off completion. The interval is cancelled once the
 	 * exit marker appears, on explicit stop, or on manager shutdown. Absence of
-	 * the marker is deliberately non-terminal: visible child agents may run for
-	 * longer than a fixed response-era timeout, and some panes are intentionally
-	 * left open for user takeover.
+	 * the exit marker is deliberately non-terminal after the child writes its
+	 * task-mode started marker: visible child agents may run for longer than a
+	 * fixed response-era timeout, and some panes are intentionally left open for
+	 * user takeover. Before that started marker appears, a bounded startup
+	 * timeout catches launcher/Pi crashes that happened before task-mode could
+	 * install the exit marker.
 	 */
 	private armResponseWatcher(task: InternalTask): void {
 		if (!task.exitFile) return;
@@ -797,6 +814,16 @@ export class BackgroundTaskManager {
 				const exitCode = readExitCodeFromFile(readFileSync(task.exitFile, "utf8"));
 				this.finalizeTask(task, exitCode, "self-exit");
 				return;
+			}
+			if (task.markerFile && existsSync(task.markerFile)) {
+				task.startupDeadline = undefined;
+			} else if (task.startupDeadline && Date.now() > task.startupDeadline) {
+				appendLogLine(
+					task.logFile,
+					`[bg-task] startup timeout: task-mode started marker not written within ${Math.round(DEFAULT_AGENT_STARTUP_TIMEOUT_MS / 1000)}s; marking task failed before handoff became live\n`,
+					this.logMaxBytes,
+				);
+				this.finalizeTask(task, null, "self-exit");
 			}
 		}, RESPONSE_POLL_INTERVAL_MS);
 		if (typeof task.responseTimer.unref === "function") {

--- a/src/background-tasks/task-types.ts
+++ b/src/background-tasks/task-types.ts
@@ -40,6 +40,7 @@ export interface BackgroundTask {
 	logFile: string;
 	exitFile?: string;
 	metaFile?: string;
+	markerFile?: string;
 	promptFile?: string;
 	responseFile?: string;
 	diagFile?: string;
@@ -84,6 +85,7 @@ export interface BackgroundTaskSnapshot {
 	logFile: string;
 	exitFile?: string;
 	metaFile?: string;
+	markerFile?: string;
 	promptFile?: string;
 	responseFile?: string;
 	diagFile?: string;
@@ -112,6 +114,7 @@ export function toBackgroundTaskSnapshot(task: BackgroundTask): BackgroundTaskSn
 		logFile: task.logFile,
 		exitFile: task.exitFile,
 		metaFile: task.metaFile,
+		markerFile: task.markerFile,
 		promptFile: task.promptFile,
 		responseFile: task.responseFile,
 		diagFile: task.diagFile,

--- a/src/background-tasks/task-types.ts
+++ b/src/background-tasks/task-types.ts
@@ -18,6 +18,13 @@ export interface BackgroundTaskCmuxRefs {
 	surfaceRef: string;
 }
 
+export interface BackgroundTaskWorktreeRef {
+	path: string;
+	branch: string;
+	baseRef: string;
+	repoRoot: string;
+}
+
 export type BackgroundTaskThinking = "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
 
 export interface BackgroundTask {
@@ -42,6 +49,7 @@ export interface BackgroundTask {
 	model?: string;
 	thinking?: BackgroundTaskThinking;
 	cmux?: BackgroundTaskCmuxRefs;
+	worktree?: BackgroundTaskWorktreeRef;
 	notifyOnExit: boolean;
 }
 
@@ -54,6 +62,9 @@ export interface SpawnBackgroundTaskOptions {
 	runner?: BackgroundTaskRunner;
 	model?: string;
 	thinking?: BackgroundTaskThinking;
+	worktree?: boolean;
+	branch?: string;
+	baseRef?: string;
 	notifyOnExit?: boolean;
 }
 
@@ -82,6 +93,7 @@ export interface BackgroundTaskSnapshot {
 	model?: string;
 	thinking?: BackgroundTaskThinking;
 	cmux?: BackgroundTaskCmuxRefs;
+	worktree?: BackgroundTaskWorktreeRef;
 	notifyOnExit?: boolean;
 }
 
@@ -109,6 +121,7 @@ export function toBackgroundTaskSnapshot(task: BackgroundTask): BackgroundTaskSn
 		model: task.model,
 		thinking: task.thinking,
 		cmux: task.cmux,
+		worktree: task.worktree,
 		notifyOnExit: task.notifyOnExit,
 	};
 }

--- a/src/background-tasks/visible-spawn.test.ts
+++ b/src/background-tasks/visible-spawn.test.ts
@@ -94,6 +94,7 @@ describe("visible-spawn", () => {
 		expect(cmd).toBe(
 			"cd '/repo with spaces' && " +
 				"SUMOCODE_TASK_RESPONSE_FILE='/tmp/test-bg/bg-4-456/response.md' " +
+				"SUMOCODE_TASK_EXIT_FILE='/tmp/test-bg/bg-4-456/exit.code' " +
 				"SUMOCODE_TASK_DIAG_FILE='/tmp/test-bg/bg-4-456/diag.jsonl' " +
 				"exec sumocode task --prompt-file '/tmp/test-bg/bg-4-456/prompt.txt'",
 		);

--- a/src/background-tasks/visible-spawn.test.ts
+++ b/src/background-tasks/visible-spawn.test.ts
@@ -15,6 +15,7 @@ describe("visible-spawn", () => {
 		expect(paths.exitFile).toBe("/tmp/test-bg/bg-1-1700000000000/exit.code");
 		expect(paths.scriptFile).toBe("/tmp/test-bg/bg-1-1700000000000/run.sh");
 		expect(paths.metaFile).toBe("/tmp/test-bg/bg-1-1700000000000/meta.json");
+		expect(paths.markerFile).toBe("/tmp/test-bg/bg-1-1700000000000/started.marker");
 		expect(paths.promptFile).toBe("/tmp/test-bg/bg-1-1700000000000/prompt.txt");
 		expect(paths.responseFile).toBe("/tmp/test-bg/bg-1-1700000000000/response.md");
 		expect(paths.diagFile).toBe("/tmp/test-bg/bg-1-1700000000000/diag.jsonl");
@@ -95,6 +96,7 @@ describe("visible-spawn", () => {
 			"cd '/repo with spaces' && " +
 				"SUMOCODE_TASK_RESPONSE_FILE='/tmp/test-bg/bg-4-456/response.md' " +
 				"SUMOCODE_TASK_EXIT_FILE='/tmp/test-bg/bg-4-456/exit.code' " +
+				"SUMOCODE_TASK_STARTED_FILE='/tmp/test-bg/bg-4-456/started.marker' " +
 				"SUMOCODE_TASK_DIAG_FILE='/tmp/test-bg/bg-4-456/diag.jsonl' " +
 				"exec sumocode task --prompt-file '/tmp/test-bg/bg-4-456/prompt.txt'",
 		);

--- a/src/background-tasks/visible-spawn.ts
+++ b/src/background-tasks/visible-spawn.ts
@@ -130,6 +130,7 @@ export function buildVisibleAgentCommand(
 	const envPrefix: string[] = [
 		`SUMOCODE_TASK_RESPONSE_FILE=${shellEscape(options.paths.responseFile)}`,
 		`SUMOCODE_TASK_EXIT_FILE=${shellEscape(options.paths.exitFile)}`,
+		`SUMOCODE_TASK_STARTED_FILE=${shellEscape(options.paths.markerFile)}`,
 		`SUMOCODE_TASK_DIAG_FILE=${shellEscape(options.paths.diagFile)}`,
 	];
 

--- a/src/background-tasks/visible-spawn.ts
+++ b/src/background-tasks/visible-spawn.ts
@@ -94,10 +94,11 @@ export function buildVisibleTaskScript(options: VisibleTaskCommandOptions): stri
  * runs via `respawn-pane --command <cmd>`:
  *
  *   1. Env-var prefix — `SUMOCODE_TASK_RESPONSE_FILE` (where the child writes
- *      its final assistant message) and `SUMOCODE_TASK_DIAG_FILE` (lifecycle
- *      diagnostics). `SUMOCODE_TASK_MODE=1` is set by the wrapper itself via
- *      the `task` subcommand. The orchestrator reads response.md to harvest
- *      the delegated work's output.
+ *      its latest assistant message), `SUMOCODE_TASK_EXIT_FILE` (real process
+ *      exit marker), and `SUMOCODE_TASK_DIAG_FILE` (lifecycle diagnostics).
+ *      `SUMOCODE_TASK_MODE=1` is set by the wrapper itself via the `task`
+ *      subcommand. The orchestrator reads response.md to harvest the delegated
+ *      work's output only after the exit marker appears.
  *   2. `cd '<cwd>'` so the child opens in the right project.
  *   3. `exec sumocode task --model X --thinking Y --prompt-file '<path>'`.
  *      `exec` ensures the wrapper shell is replaced by the sumocode process;
@@ -128,6 +129,7 @@ export function buildVisibleAgentCommand(
 
 	const envPrefix: string[] = [
 		`SUMOCODE_TASK_RESPONSE_FILE=${shellEscape(options.paths.responseFile)}`,
+		`SUMOCODE_TASK_EXIT_FILE=${shellEscape(options.paths.exitFile)}`,
 		`SUMOCODE_TASK_DIAG_FILE=${shellEscape(options.paths.diagFile)}`,
 	];
 

--- a/src/cathedral/cathedral-editor.ts
+++ b/src/cathedral/cathedral-editor.ts
@@ -41,7 +41,7 @@ import { CustomEditor } from "@earendil-works/pi-coding-agent";
 import { CURSOR_MARKER, truncateToWidth, visibleWidth, type EditorTheme, type TUI } from "@earendil-works/pi-tui";
 import { sessionHasMessages as cachedSessionHasMessages } from "../session-cache.js";
 import { activeThemeColors } from "../themes/index.js";
-import { setActiveEditorDraftController } from "./editor-draft-state.js";
+import { EditorImageDraftState, isLikelyClipboardImagePath, setActiveEditorDraftController } from "./editor-draft-state.js";
 import {
 	INPUT_FRAME_LABEL_ACTIVE,
 	INPUT_FRAME_LABEL_SPLASH,
@@ -218,6 +218,8 @@ function isPiBorderRow(row: string): boolean {
 
 class CathedralEditor extends CustomEditor {
 	private lastPrintableInputAt = 0;
+	private readonly imageDraftState = new EditorImageDraftState();
+	private submitHandler: ((text: string) => void) | undefined;
 
 	constructor(
 		private readonly cathedralTui: TUI,
@@ -226,13 +228,37 @@ class CathedralEditor extends CustomEditor {
 		private readonly isSplash: () => boolean,
 	) {
 		super(cathedralTui, theme, keybindings);
+		delete (this as { onSubmit?: unknown }).onSubmit;
+		Object.defineProperty(this, "onSubmit", {
+			configurable: true,
+			get: () => this.submitHandler,
+			set: (handler: ((text: string) => void) | undefined) => {
+				this.submitHandler = handler
+					? (text: string) => {
+						handler(this.imageDraftState.expandTokensToPaths(text));
+						this.imageDraftState.clear();
+					}
+					: undefined;
+			},
+		});
 		setActiveEditorDraftController({
 			hasDraft: () => this.getText().length > 0,
 			clearDraft: () => {
 				this.setText("");
+				this.imageDraftState.clear();
 				this.cathedralTui.requestRender();
 			},
 		});
+	}
+
+	override insertTextAtCursor(text: string): void {
+		if (isLikelyClipboardImagePath(text)) {
+			const token = this.imageDraftState.addImage(text.trim());
+			super.insertTextAtCursor(token);
+			this.cathedralTui.requestRender();
+			return;
+		}
+		super.insertTextAtCursor(text);
 	}
 
 	override handleInput(data: string): void {
@@ -245,6 +271,7 @@ class CathedralEditor extends CustomEditor {
 		const normalized = normalizeRawMultilinePasteInput(data);
 		if (/[^\x00-\x1f\x7f]/.test(normalized)) this.lastPrintableInputAt = now;
 		super.handleInput(normalized);
+		this.imageDraftState.pruneMissingTokens(this.getText());
 	}
 
 	override render(width: number): string[] {

--- a/src/cathedral/editor-draft-state.test.ts
+++ b/src/cathedral/editor-draft-state.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { EditorImageDraftState, isLikelyClipboardImagePath } from "./editor-draft-state.js";
+
+describe("EditorImageDraftState", () => {
+	it("detects Pi clipboard image temp paths", () => {
+		expect(isLikelyClipboardImagePath("/var/folders/x/pi-clipboard-abc.png")).toBe(true);
+		expect(isLikelyClipboardImagePath("/tmp/pi-clipboard-abc.jpeg")).toBe(true);
+		expect(isLikelyClipboardImagePath("/tmp/not-an-image.txt")).toBe(false);
+	});
+
+	it("allocates readable image tokens and expands them back to paths on submit", () => {
+		const state = new EditorImageDraftState();
+		const first = state.addImage("/tmp/pi-clipboard-one.png");
+		const second = state.addImage("/tmp/pi-clipboard-two.png");
+
+		expect(first).toBe("[Image 1]");
+		expect(second).toBe("[Image 2]");
+		expect(state.expandTokensToPaths("see [Image 1] and [Image 2]")).toBe("see /tmp/pi-clipboard-one.png and /tmp/pi-clipboard-two.png");
+	});
+
+	it("prunes orphan map entries when tokens are deleted", () => {
+		const state = new EditorImageDraftState();
+		state.addImage("/tmp/pi-clipboard-one.png");
+		state.addImage("/tmp/pi-clipboard-two.png");
+
+		state.pruneMissingTokens("keep [Image 2]");
+
+		expect(state.list()).toEqual([{ token: "[Image 2]", path: "/tmp/pi-clipboard-two.png" }]);
+	});
+});

--- a/src/cathedral/editor-draft-state.ts
+++ b/src/cathedral/editor-draft-state.ts
@@ -3,6 +3,7 @@ export interface ActiveEditorDraftController {
 	clearDraft(): void;
 }
 
+// Forward-looking accessor: exposed for editor-draft-state.test.ts and future attachment UI.
 export interface EditorImageAttachment {
 	readonly token: string;
 	readonly path: string;

--- a/src/cathedral/editor-draft-state.ts
+++ b/src/cathedral/editor-draft-state.ts
@@ -3,6 +3,52 @@ export interface ActiveEditorDraftController {
 	clearDraft(): void;
 }
 
+export interface EditorImageAttachment {
+	readonly token: string;
+	readonly path: string;
+}
+
+const IMAGE_PATH_PATTERN = /(?:^|\/)pi-clipboard-[\w-]+\.(?:png|jpe?g|gif|webp)$/i;
+
+export class EditorImageDraftState {
+	private nextImageIndex = 1;
+	private readonly images = new Map<string, string>();
+
+	addImage(path: string): string {
+		const token = `[Image ${this.nextImageIndex}]`;
+		this.nextImageIndex += 1;
+		this.images.set(token, path);
+		return token;
+	}
+
+	expandTokensToPaths(text: string): string {
+		let expanded = text;
+		for (const [token, path] of this.images) {
+			expanded = expanded.split(token).join(path);
+		}
+		return expanded;
+	}
+
+	pruneMissingTokens(text: string): void {
+		for (const token of this.images.keys()) {
+			if (!text.includes(token)) this.images.delete(token);
+		}
+	}
+
+	clear(): void {
+		this.images.clear();
+		this.nextImageIndex = 1;
+	}
+
+	list(): EditorImageAttachment[] {
+		return [...this.images.entries()].map(([token, path]) => ({ token, path }));
+	}
+}
+
+export function isLikelyClipboardImagePath(value: string): boolean {
+	return IMAGE_PATH_PATTERN.test(value.trim());
+}
+
 let activeController: ActiveEditorDraftController | undefined;
 
 export function setActiveEditorDraftController(controller: ActiveEditorDraftController | undefined): void {

--- a/src/commands/diff.test.ts
+++ b/src/commands/diff.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { buildHunkCommand, registerDiffCommand } from "./diff.js";
+import { buildHunkCommand, chooseDiffSplitDirection, parseDiffArgs, registerDiffCommand } from "./diff.js";
 
 afterEach(() => {
 	vi.restoreAllMocks();
@@ -30,6 +30,31 @@ describe("buildHunkCommand", () => {
 		// We only trim the outer whitespace; multi-space arg separators stay intact
 		// because hunk's own argv parser handles them.
 		expect(buildHunkCommand("show  HEAD~1")).toBe("hunk show  HEAD~1");
+	});
+});
+
+describe("parseDiffArgs", () => {
+	it("extracts split override flags without treating them as hunk args", () => {
+		expect(parseDiffArgs("--down")).toEqual({ hunkArgs: "", forcedDirection: "down" });
+		expect(parseDiffArgs("--right show HEAD~1")).toEqual({ hunkArgs: "show HEAD~1", forcedDirection: "right" });
+		expect(parseDiffArgs("show --down HEAD~1")).toEqual({ hunkArgs: "show  HEAD~1", forcedDirection: "down" });
+	});
+
+	it("uses the last split override when both are present", () => {
+		expect(parseDiffArgs("--down --right HEAD~1")).toEqual({ hunkArgs: "HEAD~1", forcedDirection: "right" });
+	});
+});
+
+describe("chooseDiffSplitDirection", () => {
+	it("uses down for portrait terminals and right for landscape or square terminals", () => {
+		expect(chooseDiffSplitDirection({ columns: 80, rows: 120 })).toBe("down");
+		expect(chooseDiffSplitDirection({ columns: 160, rows: 45 })).toBe("right");
+		expect(chooseDiffSplitDirection({ columns: 80, rows: 80 })).toBe("right");
+	});
+
+	it("lets explicit flags override terminal orientation", () => {
+		expect(chooseDiffSplitDirection({ columns: 80, rows: 120 }, "right")).toBe("right");
+		expect(chooseDiffSplitDirection({ columns: 160, rows: 45 }, "down")).toBe("down");
 	});
 });
 
@@ -129,6 +154,78 @@ describe("registerDiffCommand", () => {
 		const [message, level] = notifyMock.mock.calls[0] ?? [];
 		expect(message).toContain("boom: cmux blew up");
 		expect(level).toBe("warning");
+	});
+
+	it("opens a down split in portrait terminals", async () => {
+		const calls: Array<{ cmd: string; args: string[] }> = [];
+		const originalColumns = process.stdout.columns;
+		const originalRows = process.stdout.rows;
+		process.stdout.columns = 80;
+		process.stdout.rows = 120;
+		try {
+			const { pi, handlers } = makePi(async (cmd, args) => {
+				calls.push({ cmd, args });
+				if (cmd === "sh") return { code: 0, killed: false, stdout: "", stderr: "" };
+				if (cmd === "cmux" && args[1] === "identify") {
+					return { code: 0, killed: false, stdout: JSON.stringify({ caller: { workspace_ref: "workspace:1", surface_ref: "surface:1" } }), stderr: "" };
+				}
+				if (cmd === "cmux" && args[1] === "list-panes") {
+					return { code: 0, killed: false, stdout: JSON.stringify({ panes: [{ ref: "pane:1", selected_surface_ref: "surface:1" }] }), stderr: "" };
+				}
+				if (cmd === "cmux" && args[0] === "new-split") {
+					return { code: 0, killed: false, stdout: "OK surface:surface:2 workspace:workspace:1", stderr: "" };
+				}
+				return { code: 0, killed: false, stdout: "", stderr: "" };
+			});
+			registerDiffCommand(pi as never);
+
+			const { ctx, notifyMock } = makeCtx();
+			await handlers.get("sumo:diff")?.("HEAD~1", ctx);
+
+			const newSplitCall = calls.find((call) => call.cmd === "cmux" && call.args[0] === "new-split");
+			expect(newSplitCall?.args[1]).toBe("down");
+			expect(notifyMock).toHaveBeenCalledWith("opened hunk diff HEAD~1 in a new cmux pane", "info");
+		} finally {
+			process.stdout.columns = originalColumns;
+			process.stdout.rows = originalRows;
+		}
+	});
+
+	it("lets --right force a right split and removes the flag before building the hunk command", async () => {
+		const calls: Array<{ cmd: string; args: string[] }> = [];
+		const originalColumns = process.stdout.columns;
+		const originalRows = process.stdout.rows;
+		process.stdout.columns = 80;
+		process.stdout.rows = 120;
+		try {
+			const { pi, handlers } = makePi(async (cmd, args) => {
+				calls.push({ cmd, args });
+				if (cmd === "sh") return { code: 0, killed: false, stdout: "", stderr: "" };
+				if (cmd === "cmux" && args[1] === "identify") {
+					return { code: 0, killed: false, stdout: JSON.stringify({ caller: { workspace_ref: "workspace:1", surface_ref: "surface:1" } }), stderr: "" };
+				}
+				if (cmd === "cmux" && args[1] === "list-panes") {
+					return { code: 0, killed: false, stdout: JSON.stringify({ panes: [{ ref: "pane:1", selected_surface_ref: "surface:1" }] }), stderr: "" };
+				}
+				if (cmd === "cmux" && args[0] === "new-split") {
+					return { code: 0, killed: false, stdout: "OK surface:surface:2 workspace:workspace:1", stderr: "" };
+				}
+				return { code: 0, killed: false, stdout: "", stderr: "" };
+			});
+			registerDiffCommand(pi as never);
+
+			const { ctx } = makeCtx();
+			await handlers.get("sumo:diff")?.("--right --watch", ctx);
+
+			const newSplitCall = calls.find((call) => call.cmd === "cmux" && call.args[0] === "new-split");
+			const respawnCall = calls.find((call) => call.cmd === "cmux" && call.args[0] === "respawn-pane");
+			expect(newSplitCall?.args[1]).toBe("right");
+			expect(respawnCall?.args.at(-1)).toContain("hunk diff --watch");
+			expect(respawnCall?.args.at(-1)).not.toContain("--right");
+		} finally {
+			process.stdout.columns = originalColumns;
+			process.stdout.rows = originalRows;
+		}
 	});
 
 	it("notifies with cmux error when not inside a cmux surface", async () => {

--- a/src/commands/diff.ts
+++ b/src/commands/diff.ts
@@ -15,13 +15,47 @@ import { buildShellCommand, openCommandInNewSplit, type SplitDirection } from ".
  * `npm i -g hunkdiff` or `brew install modem-dev/tap/hunk`). When either is
  * missing, the command notifies and exits without side effects.
  *
- * Split direction is `right` so the diff lands next to the active SUMO
- * session. Users who prefer a downward split can use pi-cmux's `/cmoh hunk
- * diff` instead.
+ * Split direction follows terminal orientation: portrait terminals split
+ * down to preserve diff width; landscape/square terminals split right.
+ * `/sumo:diff --down` and `/sumo:diff --right` force a direction.
  */
 
 /** First-token subcommands hunk supports as documented in its README. */
 const HUNK_SUBCOMMANDS: ReadonlySet<string> = new Set(["diff", "show", "patch", "pager"]);
+const SPLIT_FLAG_PATTERN = /(^|\s)(--down|--right)(?=\s|$)/g;
+
+export interface TerminalSize {
+	readonly columns?: number;
+	readonly rows?: number;
+}
+
+export interface ParsedDiffArgs {
+	readonly hunkArgs: string;
+	readonly forcedDirection?: SplitDirection;
+}
+
+export function parseDiffArgs(rawArgs: string): ParsedDiffArgs {
+	let forcedDirection: SplitDirection | undefined;
+	for (const match of rawArgs.matchAll(SPLIT_FLAG_PATTERN)) {
+		forcedDirection = match[2] === "--down" ? "down" : "right";
+	}
+	const hunkArgs = rawArgs.replace(SPLIT_FLAG_PATTERN, " ").trim();
+	return { hunkArgs, forcedDirection };
+}
+
+export function chooseDiffSplitDirection(size: TerminalSize, forcedDirection?: SplitDirection): SplitDirection {
+	if (forcedDirection) return forcedDirection;
+	const columns = size.columns ?? 0;
+	const rows = size.rows ?? 0;
+	return rows > columns ? "down" : "right";
+}
+
+function getTerminalSize(): TerminalSize {
+	return {
+		columns: process.stdout.columns,
+		rows: process.stdout.rows,
+	};
+}
 
 export function buildHunkCommand(rawArgs: string): string {
 	const trimmed = rawArgs.trim();
@@ -51,7 +85,7 @@ async function isHunkInstalled(pi: ExtensionAPI): Promise<boolean> {
 
 export function registerDiffCommand(pi: ExtensionAPI): void {
 	pi.registerCommand("sumo:diff", {
-		description: "Open hunk diff in a new cmux split (right) for quick review",
+		description: "Open hunk diff in an orientation-aware cmux split for quick review",
 		handler: async (args: string | undefined, ctx: ExtensionContext) => {
 			// All failure paths must go through `ctx.ui.notify` per the
 			// SumoCode slash-command contract — no exception should ever
@@ -72,9 +106,10 @@ export function registerDiffCommand(pi: ExtensionAPI): void {
 					return;
 				}
 
-				const hunkCmd = buildHunkCommand(args ?? "");
+				const { hunkArgs, forcedDirection } = parseDiffArgs(args ?? "");
+				const hunkCmd = buildHunkCommand(hunkArgs);
 				const shellCmd = buildShellCommand(ctx.cwd, hunkCmd);
-				const direction: SplitDirection = "right";
+				const direction = chooseDiffSplitDirection(getTerminalSize(), forcedDirection);
 
 				const result = await openCommandInNewSplit(pi, direction, shellCmd);
 				if (result.ok) {

--- a/src/commands/review.test.ts
+++ b/src/commands/review.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { buildReviewPrompt, DEFAULT_REVIEW_MODEL, extractModelAlias, MODEL_ALIASES, parseReviewScope, registerReviewCommand, resolveReviewModel } from "./review.js";
+import { buildReviewPrompt, DEFAULT_REVIEW_MODEL, extractModelAlias, MODEL_ALIASES, parseReviewScope, registerReviewCommand, resolveReviewModel, reviewScopeLabel } from "./review.js";
 
 describe("/sumo:review", () => {
 	describe("resolveReviewModel", () => {
@@ -60,6 +60,14 @@ describe("/sumo:review", () => {
 		});
 	});
 
+	describe("reviewScopeLabel", () => {
+		it("formats user-facing scope labels", () => {
+			expect(reviewScopeLabel({ kind: "working-tree" })).toBe("branch diff");
+			expect(reviewScopeLabel({ kind: "pr", number: "42" })).toBe("PR #42");
+			expect(reviewScopeLabel({ kind: "explicit", raw: "src/foo.ts" })).toBe("src/foo.ts");
+		});
+	});
+
 	describe("buildReviewPrompt", () => {
 		it("working-tree: instructs scribe to fall back to branch diff when working tree is empty", () => {
 			const prompt = buildReviewPrompt("", "deepseek/deepseek-v4-pro");
@@ -81,11 +89,13 @@ describe("/sumo:review", () => {
 			expect(prompt).toContain("git diff main...HEAD");
 		});
 
-		it("includes relentless review loop, model, and xhigh thinking", () => {
+		it("is direct reviewer guidance for a tracked background task", () => {
 			const prompt = buildReviewPrompt("", "deepseek/deepseek-v4-pro");
-			expect(prompt).toContain("model deepseek/deepseek-v4-pro");
-			expect(prompt).toContain('thinking="xhigh"');
-			expect(prompt).toContain("Relentlessly repeat review -> fix -> review until the scribe returns a GREEN signal");
+			expect(prompt).toContain("tracked SumoCode background task with model deepseek/deepseek-v4-pro");
+			expect(prompt).toContain("Review only");
+			expect(prompt).not.toContain("Main-agent protocol");
+			expect(prompt).not.toContain("Use task type");
+			expect(prompt).not.toContain("Relentlessly repeat review -> fix -> review");
 		});
 
 		it("includes P0/P1/P2 severity rubric", () => {
@@ -95,10 +105,12 @@ describe("/sumo:review", () => {
 			expect(prompt).toContain("P2: should fix before merge");
 		});
 
-		it("prohibits the scribe from delegating via task tool", () => {
+		it("prohibits delegation and no longer instructs task-tool use", () => {
 			const prompt = buildReviewPrompt("", "deepseek/deepseek-v4-pro");
 			expect(prompt).toContain("Do NOT use the task tool");
 			expect(prompt).toContain("Perform the entire review yourself");
+			expect(prompt).not.toContain("Invoke the task tool");
+			expect(prompt).not.toContain("Use task type=\"single\"");
 		});
 
 		it("includes DO NOT flag list to suppress noise", () => {
@@ -144,51 +156,90 @@ describe("/sumo:review", () => {
 	});
 
 	describe("registerReviewCommand", () => {
-		it("registers a command that queues the review prompt as a follow-up", async () => {
-			let handler: ((args: string, ctx: { hasUI: boolean; ui: { notify: ReturnType<typeof vi.fn> } }) => Promise<void>) | undefined;
+		function setup(taskSpawner = { spawnTask: vi.fn(() => ({ id: "bg-42", cmux: { surfaceRef: "surface:2", workspaceRef: "workspace:1" } })) }) {
+			let handler: ((args: string, ctx: { hasUI: boolean; cwd: string; ui: { notify: ReturnType<typeof vi.fn> } }) => Promise<void>) | undefined;
 			const sendUserMessage = vi.fn();
 			const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
 				handler = options.handler;
 			});
 			const notify = vi.fn();
+			registerReviewCommand({ registerCommand, sendUserMessage } as never, {
+				taskSpawner,
+				terminalSize: () => ({ columns: 80, rows: 120 }),
+			});
+			const ctx = { hasUI: true, cwd: "/tmp/sumo-fixture", ui: { notify } };
+			return { handler, registerCommand, sendUserMessage, notify, taskSpawner, ctx };
+		}
 
-			registerReviewCommand({ registerCommand, sendUserMessage } as never);
-			await handler?.("src/foo.ts", { hasUI: true, ui: { notify } });
+		it("registers a command that spawns a tracked visible bg_task review", async () => {
+			const { handler, registerCommand, sendUserMessage, notify, taskSpawner, ctx } = setup();
+
+			await handler?.("src/foo.ts", ctx);
 
 			expect(registerCommand).toHaveBeenCalledWith("sumo:review", expect.objectContaining({ description: expect.any(String) }));
-			expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("git diff src/foo.ts"), { deliverAs: "followUp" });
-			expect(notify).toHaveBeenCalledWith(expect.stringContaining("openai-codex/gpt-5.3-codex"), "info");
+			expect(sendUserMessage).not.toHaveBeenCalled();
+			expect(taskSpawner.spawnTask).toHaveBeenCalledWith(expect.objectContaining({
+				command: expect.stringContaining("git diff src/foo.ts"),
+				cwd: "/tmp/sumo-fixture",
+				title: "review: src/foo.ts · openai-codex/gpt-5.3-codex",
+				visible: true,
+				direction: "down",
+				runner: "sumocode",
+				model: "openai-codex/gpt-5.3-codex",
+				thinking: "xhigh",
+				notifyOnExit: true,
+			}));
+			expect(notify).toHaveBeenCalledWith(expect.stringContaining("review started: bg-42"), "info");
+			expect(notify).toHaveBeenCalledWith(expect.stringContaining("bg_task action=log id=bg-42"), "info");
 		});
 
-		it("includes scope label in notify for PR args", async () => {
-			let handler: ((args: string, ctx: { hasUI: boolean; ui: { notify: ReturnType<typeof vi.fn> } }) => Promise<void>) | undefined;
-			const sendUserMessage = vi.fn();
-			const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
-				handler = options.handler;
-			});
-			const notify = vi.fn();
+		it("includes scope label in bg_task title and notify for PR args", async () => {
+			const { handler, notify, taskSpawner, ctx } = setup();
 
-			registerReviewCommand({ registerCommand, sendUserMessage } as never);
-			await handler?.("#42", { hasUI: true, ui: { notify } });
+			await handler?.("#42", ctx);
 
-			expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("gh pr diff 42"), { deliverAs: "followUp" });
+			expect(taskSpawner.spawnTask).toHaveBeenCalledWith(expect.objectContaining({
+				command: expect.stringContaining("gh pr diff 42"),
+				title: "review: PR #42 · openai-codex/gpt-5.3-codex",
+			}));
 			expect(notify).toHaveBeenCalledWith(expect.stringContaining("PR #42"), "info");
 		});
 
 		it("uses alias model when provided as first arg", async () => {
-			let handler: ((args: string, ctx: { hasUI: boolean; ui: { notify: ReturnType<typeof vi.fn> } }) => Promise<void>) | undefined;
+			const { handler, notify, taskSpawner, ctx } = setup();
+
+			await handler?.("opus #42", ctx);
+
+			expect(taskSpawner.spawnTask).toHaveBeenCalledWith(expect.objectContaining({
+				command: expect.stringContaining("anthropic/claude-opus-4.6"),
+				model: "anthropic/claude-opus-4.6",
+				title: "review: PR #42 · anthropic/claude-opus-4.6",
+			}));
+			expect(notify).toHaveBeenCalledWith(expect.stringContaining("anthropic/claude-opus-4.6"), "info");
+		});
+
+		it("reports a clear warning if bg_task spawn fails", async () => {
+			const failingSpawner = { spawnTask: vi.fn(() => { throw new Error("cmux unavailable"); }) };
+			const { handler, notify, ctx } = setup(failingSpawner);
+
+			await handler?.("", ctx);
+
+			expect(notify).toHaveBeenCalledWith("/sumo:review failed to start bg_task: cmux unavailable", "warning");
+		});
+
+		it("does not fall back to queuing a main-agent prompt when bg_task is unavailable", async () => {
+			let handler: ((args: string, ctx: { hasUI: boolean; cwd: string; ui: { notify: ReturnType<typeof vi.fn> } }) => Promise<void>) | undefined;
 			const sendUserMessage = vi.fn();
 			const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
 				handler = options.handler;
 			});
 			const notify = vi.fn();
-
 			registerReviewCommand({ registerCommand, sendUserMessage } as never);
-			await handler?.("opus #42", { hasUI: true, ui: { notify } });
 
-			expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("anthropic/claude-opus-4.6"), { deliverAs: "followUp" });
-			expect(sendUserMessage).toHaveBeenCalledWith(expect.stringContaining("gh pr diff 42"), { deliverAs: "followUp" });
-			expect(notify).toHaveBeenCalledWith(expect.stringContaining("anthropic/claude-opus-4.6"), "info");
+			await handler?.("", { hasUI: true, cwd: "/tmp/sumo-fixture", ui: { notify } });
+
+			expect(sendUserMessage).not.toHaveBeenCalled();
+			expect(notify).toHaveBeenCalledWith("/sumo:review cannot start: bg_task manager is not available", "warning");
 		});
 	});
 });

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { chooseDiffSplitDirection, type TerminalSize } from "./diff.js";
 
 export const DEFAULT_REVIEW_MODEL = "openai-codex/gpt-5.3-codex";
 
@@ -9,6 +10,42 @@ export const MODEL_ALIASES: Record<string, string> = {
 	sonnet: "anthropic/claude-sonnet-4.6",
 	deepseek: "deepseek/deepseek-v4-pro",
 };
+
+export interface ReviewTaskSpawnOptions {
+	readonly command: string;
+	readonly cwd: string;
+	readonly title?: string;
+	readonly visible?: boolean;
+	readonly direction?: "right" | "down";
+	readonly runner?: "shell" | "sumocode";
+	readonly model?: string;
+	readonly thinking?: "off" | "minimal" | "low" | "medium" | "high" | "xhigh";
+	readonly notifyOnExit?: boolean;
+}
+
+export interface ReviewTaskHandle {
+	readonly id: string;
+	readonly cmux?: {
+		readonly surfaceRef: string;
+		readonly workspaceRef: string;
+	};
+}
+
+export interface ReviewTaskSpawner {
+	spawnTask(options: ReviewTaskSpawnOptions): ReviewTaskHandle;
+}
+
+export interface RegisterReviewCommandOptions {
+	readonly taskSpawner?: ReviewTaskSpawner;
+	readonly terminalSize?: () => TerminalSize;
+}
+
+function getTerminalSize(): TerminalSize {
+	return {
+		columns: process.stdout.columns,
+		rows: process.stdout.rows,
+	};
+}
 
 export function resolveReviewModel(env: NodeJS.ProcessEnv = process.env): string {
 	return env.SUMOCODE_REVIEW_MODEL?.trim() || DEFAULT_REVIEW_MODEL;
@@ -63,6 +100,12 @@ function scopeDescription(scope: ReviewScope): string {
 	return scope.raw;
 }
 
+export function reviewScopeLabel(scope: ReviewScope): string {
+	if (scope.kind === "working-tree") return "branch diff";
+	if (scope.kind === "pr") return `PR #${scope.number}`;
+	return scope.raw;
+}
+
 function inspectInstructions(scope: ReviewScope): string {
 	if (scope.kind === "pr") {
 		return `\
@@ -103,17 +146,8 @@ export function buildReviewPrompt(args: string, model = DEFAULT_REVIEW_MODEL): s
 
 	return `Run SumoCode diff review for ${description}.
 
-Main-agent protocol:
-- Do not perform the final review yourself. Invoke the task tool as a scroll/scribe reviewer with model ${model}.
-- Use task type="single" with one task. Pass model="${model}" and thinking="xhigh".
-- The scribe must inspect the requested scope directly with git commands and file reads.
-- If the scribe returns P0, P1, or P2 findings, fix the issues or ask me before making product-risk changes, then call the review task again.
-- Relentlessly repeat review -> fix -> review until the scribe returns a GREEN signal.
-- Stop only when there is a GREEN signal or when blocked by missing requirements/permissions.
-
----
-
-Scribe instructions — read carefully before reviewing:
+You are the reviewer running in your own tracked SumoCode background task with model ${model}.
+Review only: inspect the requested scope directly, report findings precisely, and stop after one complete review pass. Do not fix code in this child task unless the parent explicitly asks in a later turn.
 
 Project context:
 - Language: TypeScript (strict, no emit — jiti runs TS directly)
@@ -185,21 +219,41 @@ function notify(ctx: ExtensionContext, message: string, type: "info" | "warning"
 	process.stdout.write(`${message}\n`);
 }
 
-export function registerReviewCommand(pi: ExtensionAPI): void {
+export function registerReviewCommand(pi: ExtensionAPI, options: RegisterReviewCommandOptions = {}): void {
+	const terminalSize = options.terminalSize ?? getTerminalSize;
 	pi.registerCommand("sumo:review", {
-		description: `Run scroll/scribe diff review until GREEN. Args: [${Object.keys(MODEL_ALIASES).join("|")}] [scope]. Scope: empty=branch diff, #51=PR, or git range/path`,
+		description: `Run a tracked bg_task diff review. Args: [${Object.keys(MODEL_ALIASES).join("|")}] [scope]. Scope: empty=branch diff, #51=PR, or git range/path`,
 		handler: async (args, ctx) => {
-			const { model: aliasModel, scopeArgs } = extractModelAlias(args);
+			const taskSpawner = options.taskSpawner;
+			if (!taskSpawner) {
+				notify(ctx, "/sumo:review cannot start: bg_task manager is not available", "warning");
+				return;
+			}
+
+			const { model: aliasModel, scopeArgs } = extractModelAlias(args ?? "");
 			const model = aliasModel ?? resolveReviewModel();
 			const prompt = buildReviewPrompt(scopeArgs, model);
 			const scope = parseReviewScope(scopeArgs);
-			const label = scope.kind === "pr" ? `PR #${scope.number}` : scope.kind === "explicit" ? scope.raw : "branch diff";
+			const label = reviewScopeLabel(scope);
+			const direction = chooseDiffSplitDirection(terminalSize());
 			try {
-				pi.sendUserMessage(prompt, { deliverAs: "followUp" });
-			} catch {
-				pi.sendUserMessage(prompt);
+				const task = taskSpawner.spawnTask({
+					command: prompt,
+					cwd: ctx.cwd,
+					title: `review: ${label} · ${model}`,
+					visible: true,
+					direction: direction as "right" | "down",
+					runner: "sumocode",
+					model,
+					thinking: "xhigh",
+					notifyOnExit: true,
+				});
+				const paneHint = task.cmux ? ` · ${task.cmux.surfaceRef}` : "";
+				notify(ctx, `review started: ${task.id}${paneHint} · ${model} · ${label}. read: bg_task action=log id=${task.id}; stop: bg_task action=stop id=${task.id}`);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				notify(ctx, `/sumo:review failed to start bg_task: ${message}`, "warning");
 			}
-			notify(ctx, `review queued: ${model} · ${label}`);
 		},
 	});
 }

--- a/src/commands/ship.test.ts
+++ b/src/commands/ship.test.ts
@@ -26,22 +26,22 @@ describe("/sumo:ship", () => {
 		const calls: Array<{ cmd: string; args: string[] }> = [];
 		const { handler, ask, notify, ctx } = setup(async (cmd, args) => {
 			calls.push({ cmd, args });
-			if (cmd === "git" && args[0] === "status") return { code: 0, stdout: " M src/a.ts\n?? src/b.ts\n", stderr: "", killed: false };
+			if (cmd === "git" && args[0] === "status") return { code: 0, stdout: " M src/a.ts\0?? src/b.ts\0", stderr: "", killed: false };
 			if (cmd === "git" && args[0] === "branch") return { code: 0, stdout: "sumo/worktree-fanout\n", stderr: "", killed: false };
 			return { code: 0, stdout: "", stderr: "", killed: false };
-		}, ["Push", "Open PR"]);
+		}, ["Commit", "Push", "Open PR"]);
 
 		await handler?.("", ctx);
 
 		expect(calls.map((call) => `${call.cmd} ${call.args.join(" ")}`)).toEqual([
-			"git status --porcelain",
+			"git status --porcelain -z",
 			"git branch --show-current",
 			"git add -A",
 			"git commit -m chore(worktree-fanout): update 2 files",
 			"git push -u origin HEAD",
 			"gh pr create --fill",
 		]);
-		expect(ask).toHaveBeenCalledTimes(2);
+		expect(ask).toHaveBeenCalledTimes(3);
 		expect(notify).toHaveBeenCalledWith(expect.stringContaining("committed locally"), "info");
 		expect(notify).toHaveBeenCalledWith("PR opened for sumo/worktree-fanout", "info");
 	});
@@ -50,16 +50,16 @@ describe("/sumo:ship", () => {
 		const calls: Array<{ cmd: string; args: string[] }> = [];
 		const { handler, ask, notify, ctx } = setup(async (cmd, args) => {
 			calls.push({ cmd, args });
-			if (cmd === "git" && args[0] === "status") return { code: 0, stdout: " M src/a.ts\n", stderr: "", killed: false };
+			if (cmd === "git" && args[0] === "status") return { code: 0, stdout: " M src/a.ts\0", stderr: "", killed: false };
 			if (cmd === "git" && args[0] === "branch") return { code: 0, stdout: "sumo/no-push\n", stderr: "", killed: false };
 			return { code: 0, stdout: "", stderr: "", killed: false };
-		}, ["Cancel"]);
+		}, ["Commit", "Cancel"]);
 
 		await handler?.("", ctx);
 
 		expect(calls.some((call) => call.cmd === "git" && call.args[0] === "push")).toBe(false);
 		expect(calls.some((call) => call.cmd === "gh")).toBe(false);
-		expect(ask).toHaveBeenCalledTimes(1);
+		expect(ask).toHaveBeenCalledTimes(2);
 		expect(notify).toHaveBeenCalledWith("/sumo:ship stopped before push", "info");
 	});
 
@@ -67,10 +67,10 @@ describe("/sumo:ship", () => {
 		const calls: Array<{ cmd: string; args: string[] }> = [];
 		const { handler, notify, ctx } = setup(async (cmd, args) => {
 			calls.push({ cmd, args });
-			if (cmd === "git" && args[0] === "status") return { code: 0, stdout: " M src/a.ts\n", stderr: "", killed: false };
+			if (cmd === "git" && args[0] === "status") return { code: 0, stdout: " M src/a.ts\0", stderr: "", killed: false };
 			if (cmd === "git" && args[0] === "branch") return { code: 0, stdout: "sumo/no-pr\n", stderr: "", killed: false };
 			return { code: 0, stdout: "", stderr: "", killed: false };
-		}, ["Push", "Cancel"]);
+		}, ["Commit", "Push", "Cancel"]);
 
 		await handler?.("", ctx);
 
@@ -79,13 +79,46 @@ describe("/sumo:ship", () => {
 		expect(notify).toHaveBeenCalledWith("/sumo:ship stopped before PR creation", "info");
 	});
 
+	it("stops before commit when commit confirmation is declined", async () => {
+		const calls: Array<{ cmd: string; args: string[] }> = [];
+		const { handler, notify, ctx } = setup(async (cmd, args) => {
+			calls.push({ cmd, args });
+			if (cmd === "git" && args[0] === "status") return { code: 0, stdout: " M src/a.ts\0", stderr: "", killed: false };
+			if (cmd === "git" && args[0] === "branch") return { code: 0, stdout: "sumo/no-commit\n", stderr: "", killed: false };
+			return { code: 0, stdout: "", stderr: "", killed: false };
+		}, ["Cancel"]);
+
+		await handler?.("", ctx);
+
+		expect(calls.some((call) => call.cmd === "git" && call.args[0] === "add")).toBe(false);
+		expect(calls.some((call) => call.cmd === "git" && call.args[0] === "commit")).toBe(false);
+		expect(calls.some((call) => call.cmd === "git" && call.args[0] === "push")).toBe(false);
+		expect(calls.some((call) => call.cmd === "gh")).toBe(false);
+		expect(notify).toHaveBeenCalledWith("/sumo:ship stopped before commit", "info");
+	});
+
+	it("counts rename records as one changed file", async () => {
+		const calls: Array<{ cmd: string; args: string[] }> = [];
+		const { handler, notify, ctx } = setup(async (cmd, args) => {
+			calls.push({ cmd, args });
+			if (cmd === "git" && args[0] === "status") return { code: 0, stdout: "R  new name.ts\0old name.ts\0 M src/b.ts\0", stderr: "", killed: false };
+			if (cmd === "git" && args[0] === "branch") return { code: 0, stdout: "sumo/rename\n", stderr: "", killed: false };
+			return { code: 0, stdout: "", stderr: "", killed: false };
+		}, ["Commit", "Cancel"]);
+
+		await handler?.("", ctx);
+
+		expect(calls.map((call) => `${call.cmd} ${call.args.join(" ")}`)).toContain("git commit -m chore(rename): update 2 files");
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("committed locally: chore(rename): update 2 files · new name.ts, src/b.ts"), "info");
+	});
+
 	it("reports gh failures clearly", async () => {
 		const { handler, notify, ctx } = setup(async (cmd, args) => {
-			if (cmd === "git" && args[0] === "status") return { code: 0, stdout: " M src/a.ts\n", stderr: "", killed: false };
+			if (cmd === "git" && args[0] === "status") return { code: 0, stdout: " M src/a.ts\0", stderr: "", killed: false };
 			if (cmd === "git" && args[0] === "branch") return { code: 0, stdout: "sumo/ship\n", stderr: "", killed: false };
 			if (cmd === "gh") return { code: 127, stdout: "", stderr: "gh: command not found", killed: false };
 			return { code: 0, stdout: "", stderr: "", killed: false };
-		}, ["Push", "Open PR"]);
+		}, ["Commit", "Push", "Open PR"]);
 
 		await handler?.("", ctx);
 

--- a/src/commands/ship.test.ts
+++ b/src/commands/ship.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { draftCommitMessage, registerShipCommand } from "./ship.js";
+
+function setup(execImpl: (cmd: string, args: string[]) => Promise<{ code: number; stdout: string; stderr: string; killed: boolean }>, choices: string[] = []) {
+	let handler: ((args: string | undefined, ctx: { hasUI: boolean; cwd: string; ui: { notify: ReturnType<typeof vi.fn> } }) => Promise<void>) | undefined;
+	const pi = {
+		registerCommand: vi.fn((_name: string, options: { handler: typeof handler }) => {
+			handler = options.handler;
+		}),
+		exec: vi.fn(async (cmd: string, args: string[]) => execImpl(cmd, args)),
+	};
+	const ask = vi.fn(async () => choices.shift() ?? "Cancel");
+	registerShipCommand(pi as never, { ask: ask as never });
+	const notify = vi.fn();
+	const ctx = { hasUI: true, cwd: "/repo", ui: { notify } };
+	return { pi, handler, ask, notify, ctx };
+}
+
+describe("/sumo:ship", () => {
+	it("drafts a conventional commit message from branch and file summary", () => {
+		expect(draftCommitMessage("sumo/worktree-fanout", ["a.ts", "b.ts"])).toBe("chore(worktree-fanout): update 2 files");
+		expect(draftCommitMessage("main", ["a.ts"])).toBe("chore(main): update 1 file");
+	});
+
+	it("commits locally, then gates push and PR creation", async () => {
+		const calls: Array<{ cmd: string; args: string[] }> = [];
+		const { handler, ask, notify, ctx } = setup(async (cmd, args) => {
+			calls.push({ cmd, args });
+			if (cmd === "git" && args[0] === "status") return { code: 0, stdout: " M src/a.ts\n?? src/b.ts\n", stderr: "", killed: false };
+			if (cmd === "git" && args[0] === "branch") return { code: 0, stdout: "sumo/worktree-fanout\n", stderr: "", killed: false };
+			return { code: 0, stdout: "", stderr: "", killed: false };
+		}, ["Push", "Open PR"]);
+
+		await handler?.("", ctx);
+
+		expect(calls.map((call) => `${call.cmd} ${call.args.join(" ")}`)).toEqual([
+			"git status --porcelain",
+			"git branch --show-current",
+			"git add -A",
+			"git commit -m chore(worktree-fanout): update 2 files",
+			"git push -u origin HEAD",
+			"gh pr create --fill",
+		]);
+		expect(ask).toHaveBeenCalledTimes(2);
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("committed locally"), "info");
+		expect(notify).toHaveBeenCalledWith("PR opened for sumo/worktree-fanout", "info");
+	});
+
+	it("never pushes when push confirmation is declined", async () => {
+		const calls: Array<{ cmd: string; args: string[] }> = [];
+		const { handler, ask, notify, ctx } = setup(async (cmd, args) => {
+			calls.push({ cmd, args });
+			if (cmd === "git" && args[0] === "status") return { code: 0, stdout: " M src/a.ts\n", stderr: "", killed: false };
+			if (cmd === "git" && args[0] === "branch") return { code: 0, stdout: "sumo/no-push\n", stderr: "", killed: false };
+			return { code: 0, stdout: "", stderr: "", killed: false };
+		}, ["Cancel"]);
+
+		await handler?.("", ctx);
+
+		expect(calls.some((call) => call.cmd === "git" && call.args[0] === "push")).toBe(false);
+		expect(calls.some((call) => call.cmd === "gh")).toBe(false);
+		expect(ask).toHaveBeenCalledTimes(1);
+		expect(notify).toHaveBeenCalledWith("/sumo:ship stopped before push", "info");
+	});
+
+	it("pushes but never creates PR when PR confirmation is declined", async () => {
+		const calls: Array<{ cmd: string; args: string[] }> = [];
+		const { handler, notify, ctx } = setup(async (cmd, args) => {
+			calls.push({ cmd, args });
+			if (cmd === "git" && args[0] === "status") return { code: 0, stdout: " M src/a.ts\n", stderr: "", killed: false };
+			if (cmd === "git" && args[0] === "branch") return { code: 0, stdout: "sumo/no-pr\n", stderr: "", killed: false };
+			return { code: 0, stdout: "", stderr: "", killed: false };
+		}, ["Push", "Cancel"]);
+
+		await handler?.("", ctx);
+
+		expect(calls.some((call) => call.cmd === "git" && call.args[0] === "push")).toBe(true);
+		expect(calls.some((call) => call.cmd === "gh")).toBe(false);
+		expect(notify).toHaveBeenCalledWith("/sumo:ship stopped before PR creation", "info");
+	});
+
+	it("reports gh failures clearly", async () => {
+		const { handler, notify, ctx } = setup(async (cmd, args) => {
+			if (cmd === "git" && args[0] === "status") return { code: 0, stdout: " M src/a.ts\n", stderr: "", killed: false };
+			if (cmd === "git" && args[0] === "branch") return { code: 0, stdout: "sumo/ship\n", stderr: "", killed: false };
+			if (cmd === "gh") return { code: 127, stdout: "", stderr: "gh: command not found", killed: false };
+			return { code: 0, stdout: "", stderr: "", killed: false };
+		}, ["Push", "Open PR"]);
+
+		await handler?.("", ctx);
+
+		expect(notify).toHaveBeenCalledWith("/sumo:ship: gh pr create failed: gh: command not found", "warning");
+	});
+});

--- a/src/commands/ship.ts
+++ b/src/commands/ship.ts
@@ -1,0 +1,94 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { showDivineQuery } from "../divine-query.js";
+
+export interface ShipCommandOptions {
+	readonly ask?: (ctx: ExtensionContext, title: string, options: readonly string[]) => Promise<string | null>;
+}
+
+interface ExecResult {
+	readonly code: number;
+	readonly stdout: string;
+	readonly stderr: string;
+	readonly killed: boolean;
+}
+
+function notify(ctx: ExtensionContext, message: string, type: "info" | "warning" = "info"): void {
+	if (ctx.hasUI) {
+		ctx.ui.notify(message, type);
+		return;
+	}
+	process.stdout.write(`${message}\n`);
+}
+
+function changedFiles(statusPorcelain: string): string[] {
+	return statusPorcelain
+		.split("\n")
+		.map((line) => line.slice(3).trim())
+		.filter(Boolean);
+}
+
+export function draftCommitMessage(branch: string, files: readonly string[]): string {
+	const branchSlug = branch.replace(/^sumo\//, "").replace(/[^a-zA-Z0-9]+/g, "-").replace(/^-+|-+$/g, "").toLowerCase();
+	const scope = branchSlug || "changes";
+	const noun = files.length === 1 ? "file" : "files";
+	return `chore(${scope}): update ${files.length} ${noun}`;
+}
+
+async function exec(pi: ExtensionAPI, cmd: string, args: readonly string[], cwd: string): Promise<ExecResult> {
+	return pi.exec(cmd, [...args], { cwd, timeout: 30_000 }) as Promise<ExecResult>;
+}
+
+async function ensureOk(result: ExecResult, label: string): Promise<void> {
+	if (result.code === 0 && !result.killed) return;
+	throw new Error(`${label} failed: ${result.stderr.trim() || result.stdout.trim() || `exit ${result.code}`}`);
+}
+
+export function registerShipCommand(pi: ExtensionAPI, options: ShipCommandOptions = {}): void {
+	const ask = options.ask ?? ((ctx, title, choices) => showDivineQuery(ctx, title, choices));
+	pi.registerCommand("sumo:ship", {
+		description: "Commit locally, then human-gate push and PR creation",
+		handler: async (_args, ctx) => {
+			try {
+				const status = await exec(pi, "git", ["status", "--porcelain"], ctx.cwd);
+				await ensureOk(status, "git status");
+				const files = changedFiles(status.stdout);
+				if (files.length === 0) {
+					notify(ctx, "/sumo:ship: no working-tree changes to commit", "warning");
+					return;
+				}
+				const branchResult = await exec(pi, "git", ["branch", "--show-current"], ctx.cwd);
+				await ensureOk(branchResult, "git branch");
+				const branch = branchResult.stdout.trim() || "HEAD";
+				const message = draftCommitMessage(branch, files);
+				const summary = files.slice(0, 8).join(", ") + (files.length > 8 ? `, +${files.length - 8} more` : "");
+
+				await ensureOk(await exec(pi, "git", ["add", "-A"], ctx.cwd), "git add");
+				await ensureOk(await exec(pi, "git", ["commit", "-m", message], ctx.cwd), "git commit");
+				notify(ctx, `committed locally: ${message} · ${summary}`);
+
+				if (!ctx.hasUI) {
+					notify(ctx, "/sumo:ship stopped before push: interactive confirmation required", "warning");
+					return;
+				}
+				const pushChoice = await ask(ctx, `Push branch ${branch}?\nCommit: ${message}\nFiles: ${summary}`, ["Push", "Cancel"]);
+				if (pushChoice !== "Push") {
+					notify(ctx, "/sumo:ship stopped before push");
+					return;
+				}
+				await ensureOk(await exec(pi, "git", ["push", "-u", "origin", "HEAD"], ctx.cwd), "git push");
+				notify(ctx, `pushed ${branch}`);
+
+				const prChoice = await ask(ctx, `Open PR for ${branch}?\nTitle: ${message}`, ["Open PR", "Cancel"]);
+				if (prChoice !== "Open PR") {
+					notify(ctx, "/sumo:ship stopped before PR creation");
+					return;
+				}
+				await ensureOk(await exec(pi, "gh", ["pr", "create", "--fill"], ctx.cwd), "gh pr create");
+				notify(ctx, `PR opened for ${branch}`);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				notify(ctx, `/sumo:ship: ${message}`, "warning");
+			}
+		},
+	});
+}

--- a/src/commands/ship.ts
+++ b/src/commands/ship.ts
@@ -20,11 +20,23 @@ function notify(ctx: ExtensionContext, message: string, type: "info" | "warning"
 	process.stdout.write(`${message}\n`);
 }
 
-function changedFiles(statusPorcelain: string): string[] {
-	return statusPorcelain
-		.split("\n")
-		.map((line) => line.slice(3).trim())
-		.filter(Boolean);
+function changedFiles(statusPorcelainZ: string): string[] {
+	const out: string[] = [];
+	const records = statusPorcelainZ.split("\0");
+	for (let i = 0; i < records.length; i += 1) {
+		const record = records[i];
+		if (!record) continue;
+		const xy = record.slice(0, 2);
+		let path = record.slice(3);
+		// Renames/copies (R/C) emit the destination path, then the source path
+		// as the NEXT NUL-separated field. Consume it and keep the destination.
+		if (xy[0] === "R" || xy[0] === "C") {
+			i += 1;
+		}
+		path = path.trim();
+		if (path) out.push(path);
+	}
+	return out;
 }
 
 export function draftCommitMessage(branch: string, files: readonly string[]): string {
@@ -49,7 +61,7 @@ export function registerShipCommand(pi: ExtensionAPI, options: ShipCommandOption
 		description: "Commit locally, then human-gate push and PR creation",
 		handler: async (_args, ctx) => {
 			try {
-				const status = await exec(pi, "git", ["status", "--porcelain"], ctx.cwd);
+				const status = await exec(pi, "git", ["status", "--porcelain", "-z"], ctx.cwd);
 				await ensureOk(status, "git status");
 				const files = changedFiles(status.stdout);
 				if (files.length === 0) {
@@ -61,6 +73,14 @@ export function registerShipCommand(pi: ExtensionAPI, options: ShipCommandOption
 				const branch = branchResult.stdout.trim() || "HEAD";
 				const message = draftCommitMessage(branch, files);
 				const summary = files.slice(0, 8).join(", ") + (files.length > 8 ? `, +${files.length - 8} more` : "");
+
+				if (ctx.hasUI) {
+					const commitChoice = await ask(ctx, `Commit ${files.length} change(s) on ${branch}?\nMessage: ${message}\nFiles: ${summary}`, ["Commit", "Cancel"]);
+					if (commitChoice !== "Commit") {
+						notify(ctx, "/sumo:ship stopped before commit");
+						return;
+					}
+				}
 
 				await ensureOk(await exec(pi, "git", ["add", "-A"], ctx.cwd), "git add");
 				await ensureOk(await exec(pi, "git", ["commit", "-m", message], ctx.cwd), "git commit");

--- a/src/commands/worktree.test.ts
+++ b/src/commands/worktree.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseWorktreeArgs, registerWorktreeCommand } from "./worktree.js";
+
+function makePi() {
+	let handler: ((args: string | undefined, ctx: { hasUI: boolean; cwd: string; ui: { notify: ReturnType<typeof vi.fn> } }) => Promise<void>) | undefined;
+	const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
+		handler = options.handler;
+	});
+	return { pi: { registerCommand }, handler: () => handler, registerCommand };
+}
+
+describe("/sumo:worktree", () => {
+	it("parses open and prune modes", () => {
+		expect(parseWorktreeArgs("build the thing")).toEqual({ mode: "open", task: "build the thing" });
+		expect(parseWorktreeArgs("prune")).toEqual({ mode: "prune", task: "" });
+		expect(parseWorktreeArgs("prune sumo/foo")).toEqual({ mode: "prune", task: "sumo/foo" });
+	});
+
+	it("creates a named worktree and opens an interactive sumocode pane with setup", async () => {
+		const { pi, handler, registerCommand } = makePi();
+		const create = vi.fn(async () => ({ ok: true as const, path: "/repo.wt/sumo__task", branch: "sumo/task", baseRef: "HEAD" }));
+		const openSplit = vi.fn(async () => ({ ok: true as const }));
+		const notify = vi.fn();
+		registerWorktreeCommand(pi as never, {
+			create,
+			openSplit,
+			isInCmux: () => true,
+			terminalSize: () => ({ columns: 80, rows: 120 }),
+			setupAction: "pnpm install",
+		});
+
+		await handler()?.("ship v0.4", { hasUI: true, cwd: "/repo", ui: { notify } });
+
+		expect(registerCommand).toHaveBeenCalledWith("sumo:worktree", expect.objectContaining({ description: expect.any(String) }));
+		expect(create).toHaveBeenCalledWith({ repoRoot: "/repo", task: "ship v0.4", baseRef: "HEAD" });
+		expect(openSplit).toHaveBeenCalledWith(pi, "down", expect.stringContaining("cd '/repo.wt/sumo__task'"));
+		const openedCommand = (openSplit.mock.calls[0] as unknown[] | undefined)?.[2] as string;
+		expect(openedCommand).toContain("pnpm install && exec sumocode task");
+		expect(openedCommand).toContain("ship v0.4");
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("opened sumo/task in down split"), "info");
+	});
+
+	it("guards non-cmux and missing task before creating worktrees", async () => {
+		const { pi, handler } = makePi();
+		const create = vi.fn();
+		const notify = vi.fn();
+		registerWorktreeCommand(pi as never, { create: create as never, isInCmux: () => false });
+
+		await handler()?.("do work", { hasUI: true, cwd: "/repo", ui: { notify } });
+
+		expect(create).not.toHaveBeenCalled();
+		expect(notify).toHaveBeenCalledWith("/sumo:worktree requires a cmux surface", "warning");
+	});
+
+	it("lists sumo worktrees when prune has no target", async () => {
+		const { pi, handler } = makePi();
+		const notify = vi.fn();
+		registerWorktreeCommand(pi as never, {
+			list: vi.fn(async () => ({
+				ok: true as const,
+				worktrees: [{ path: "/repo.wt/sumo__one", branch: "sumo/one", head: "abc", detached: false }],
+			})),
+		});
+
+		await handler()?.("prune", { hasUI: true, cwd: "/repo", ui: { notify } });
+
+		expect(notify).toHaveBeenCalledWith(expect.stringContaining("sumo/one"), "info");
+	});
+
+	it("removes an explicit sumo worktree on prune", async () => {
+		const { pi, handler } = makePi();
+		const remove = vi.fn(async () => ({ ok: true as const }));
+		const notify = vi.fn();
+		registerWorktreeCommand(pi as never, {
+			list: vi.fn(async () => ({
+				ok: true as const,
+				worktrees: [{ path: "/repo.wt/sumo__one", branch: "sumo/one", head: "abc", detached: false }],
+			})),
+			remove,
+		});
+
+		await handler()?.("prune sumo/one", { hasUI: true, cwd: "/repo", ui: { notify } });
+
+		expect(remove).toHaveBeenCalledWith({ repoRoot: "/repo", path: "/repo.wt/sumo__one" });
+		expect(notify).toHaveBeenCalledWith("removed worktree sumo/one", "info");
+	});
+});

--- a/src/commands/worktree.test.ts
+++ b/src/commands/worktree.test.ts
@@ -35,7 +35,7 @@ describe("/sumo:worktree", () => {
 		expect(create).toHaveBeenCalledWith({ repoRoot: "/repo", task: "ship v0.4", baseRef: "HEAD" });
 		expect(openSplit).toHaveBeenCalledWith(pi, "down", expect.stringContaining("cd '/repo.wt/sumo__task'"));
 		const openedCommand = (openSplit.mock.calls[0] as unknown[] | undefined)?.[2] as string;
-		expect(openedCommand).toContain("pnpm install && exec sumocode task");
+		expect(openedCommand).toContain("pnpm install && SUMOCODE_TASK_KEEP_OPEN=1 exec sumocode task");
 		expect(openedCommand).toContain("ship v0.4");
 		expect(notify).toHaveBeenCalledWith(expect.stringContaining("opened sumo/task in down split"), "info");
 	});

--- a/src/commands/worktree.test.ts
+++ b/src/commands/worktree.test.ts
@@ -6,7 +6,8 @@ function makePi() {
 	const registerCommand = vi.fn((_name: string, options: { handler: typeof handler }) => {
 		handler = options.handler;
 	});
-	return { pi: { registerCommand }, handler: () => handler, registerCommand };
+	const sendMessage = vi.fn();
+	return { pi: { registerCommand, sendMessage }, handler: () => handler, registerCommand, sendMessage };
 }
 
 describe("/sumo:worktree", () => {
@@ -17,7 +18,7 @@ describe("/sumo:worktree", () => {
 	});
 
 	it("creates a named worktree and opens an interactive sumocode pane with setup", async () => {
-		const { pi, handler, registerCommand } = makePi();
+		const { pi, handler, registerCommand, sendMessage } = makePi();
 		const create = vi.fn(async () => ({ ok: true as const, path: "/repo.wt/sumo__task", branch: "sumo/task", baseRef: "HEAD" }));
 		const openSplit = vi.fn(async () => ({ ok: true as const }));
 		const notify = vi.fn();
@@ -37,6 +38,10 @@ describe("/sumo:worktree", () => {
 		const openedCommand = (openSplit.mock.calls[0] as unknown[] | undefined)?.[2] as string;
 		expect(openedCommand).toContain("pnpm install && SUMOCODE_TASK_KEEP_OPEN=1 exec sumocode task");
 		expect(openedCommand).toContain("ship v0.4");
+		expect(sendMessage).toHaveBeenCalledWith(
+			expect.objectContaining({ customType: "sumo:worktree", content: expect.stringContaining("opened sumo/task in down split"), display: true }),
+			{ triggerTurn: false },
+		);
 		expect(notify).toHaveBeenCalledWith(expect.stringContaining("opened sumo/task in down split"), "info");
 	});
 

--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -1,0 +1,136 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { buildShellCommand, isInCmux, openCommandInNewSplit, shellEscape, type SplitDirection } from "./cmux-split.js";
+import { chooseDiffSplitDirection, type TerminalSize } from "./diff.js";
+import { createWorktree, listWorktrees, removeWorktree, type CreateWorktreeResult, type ListWorktreesResult, type RemoveWorktreeResult } from "../git/worktree.js";
+
+const DEFAULT_SETUP_ACTION = "pnpm install";
+
+export interface WorktreeCommandOptions {
+	readonly create?: typeof createWorktree;
+	readonly list?: typeof listWorktrees;
+	readonly remove?: typeof removeWorktree;
+	readonly openSplit?: typeof openCommandInNewSplit;
+	readonly isInCmux?: typeof isInCmux;
+	readonly terminalSize?: () => TerminalSize;
+	readonly setupAction?: string;
+}
+
+export interface ParsedWorktreeArgs {
+	readonly mode: "open" | "prune";
+	readonly task: string;
+}
+
+function terminalSize(): TerminalSize {
+	return { columns: process.stdout.columns, rows: process.stdout.rows };
+}
+
+export function parseWorktreeArgs(args: string): ParsedWorktreeArgs {
+	const trimmed = args.trim();
+	if (trimmed === "prune" || trimmed.startsWith("prune ")) {
+		return { mode: "prune", task: trimmed.slice("prune".length).trim() };
+	}
+	return { mode: "open", task: trimmed };
+}
+
+function notify(ctx: ExtensionContext, message: string, type: "info" | "warning" = "info"): void {
+	if (ctx.hasUI) {
+		ctx.ui.notify(message, type);
+		return;
+	}
+	process.stdout.write(`${message}\n`);
+}
+
+function commandForWorktree(task: string, setupAction: string): string {
+	const setup = setupAction.trim();
+	const setupPrefix = setup ? `${setup} && ` : "";
+	return `${setupPrefix}exec sumocode task ${shellEscape(task)}`;
+}
+
+async function handlePrune(
+	ctx: ExtensionContext,
+	target: string,
+	list: typeof listWorktrees,
+	remove: typeof removeWorktree,
+): Promise<void> {
+	const listed = await list(ctx.cwd);
+	if (!listed.ok) {
+		notify(ctx, `/sumo:worktree prune: ${listed.message}`, "warning");
+		return;
+	}
+	const sumoWorktrees = listed.worktrees.filter((worktree) => worktree.branch?.startsWith("sumo/"));
+	if (!target) {
+		if (sumoWorktrees.length === 0) {
+			notify(ctx, "no sumo worktrees found");
+			return;
+		}
+		const lines = sumoWorktrees.map((worktree) => `${worktree.branch ?? "detached"} · ${worktree.path}`);
+		notify(ctx, `sumo worktrees:\n${lines.join("\n")}\nrun /sumo:worktree prune <branch-or-path> to remove one`);
+		return;
+	}
+	const match = sumoWorktrees.find((worktree) => worktree.path === target || worktree.branch === target);
+	if (!match) {
+		notify(ctx, `/sumo:worktree prune: no tracked sumo worktree matched ${target}`, "warning");
+		return;
+	}
+	const removed = await remove({ repoRoot: ctx.cwd, path: match.path });
+	if (!removed.ok) {
+		notify(ctx, `/sumo:worktree prune: ${removed.message}`, "warning");
+		return;
+	}
+	notify(ctx, `removed worktree ${match.branch ?? match.path}`);
+}
+
+export function registerWorktreeCommand(pi: ExtensionAPI, options: WorktreeCommandOptions = {}): void {
+	const create = options.create ?? createWorktree;
+	const list = options.list ?? listWorktrees;
+	const remove = options.remove ?? removeWorktree;
+	const openSplit = options.openSplit ?? openCommandInNewSplit;
+	const isInsideCmux = options.isInCmux ?? isInCmux;
+	const getTerminalSize = options.terminalSize ?? terminalSize;
+	const setupAction = options.setupAction ?? process.env.SUMOCODE_WORKTREE_SETUP ?? DEFAULT_SETUP_ACTION;
+
+	pi.registerCommand("sumo:worktree", {
+		description: "Create a named git worktree and open an interactive SumoCode pane, or prune explicit sumo worktrees",
+		handler: async (args, ctx) => {
+			try {
+				const parsed = parseWorktreeArgs(args ?? "");
+				if (parsed.mode === "prune") {
+					await handlePrune(ctx, parsed.task, list, remove);
+					return;
+				}
+				if (!ctx.hasUI) {
+					notify(ctx, "/sumo:worktree requires interactive UI", "warning");
+					return;
+				}
+				if (!isInsideCmux()) {
+					notify(ctx, "/sumo:worktree requires a cmux surface", "warning");
+					return;
+				}
+				if (!parsed.task) {
+					notify(ctx, "Usage: /sumo:worktree <task> or /sumo:worktree prune <branch-or-path>", "warning");
+					return;
+				}
+
+				const created: CreateWorktreeResult = await create({ repoRoot: ctx.cwd, task: parsed.task, baseRef: "HEAD" });
+				if (!created.ok) {
+					notify(ctx, `/sumo:worktree: ${created.message}`, "warning");
+					return;
+				}
+
+				const direction: SplitDirection = chooseDiffSplitDirection(getTerminalSize());
+				const command = buildShellCommand(created.path, commandForWorktree(parsed.task, setupAction));
+				const opened = await openSplit(pi, direction, command);
+				if (!opened.ok) {
+					notify(ctx, `/sumo:worktree: ${opened.error}`, "warning");
+					return;
+				}
+				notify(ctx, `opened ${created.branch} in ${direction} split · setup: ${setupAction || "none"}`);
+			} catch (error) {
+				const message = error instanceof Error ? error.message : String(error);
+				notify(ctx, `/sumo:worktree: ${message}`, "warning");
+			}
+		},
+	});
+}
+
+export type { ListWorktreesResult, RemoveWorktreeResult };

--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -43,7 +43,7 @@ function notify(ctx: ExtensionContext, message: string, type: "info" | "warning"
 function commandForWorktree(task: string, setupAction: string): string {
 	const setup = setupAction.trim();
 	const setupPrefix = setup ? `${setup} && ` : "";
-	return `${setupPrefix}exec sumocode task ${shellEscape(task)}`;
+	return `${setupPrefix}SUMOCODE_TASK_KEEP_OPEN=1 exec sumocode task ${shellEscape(task)}`;
 }
 
 async function handlePrune(

--- a/src/commands/worktree.ts
+++ b/src/commands/worktree.ts
@@ -2,6 +2,7 @@ import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-a
 import { buildShellCommand, isInCmux, openCommandInNewSplit, shellEscape, type SplitDirection } from "./cmux-split.js";
 import { chooseDiffSplitDirection, type TerminalSize } from "./diff.js";
 import { createWorktree, listWorktrees, removeWorktree, type CreateWorktreeResult, type ListWorktreesResult, type RemoveWorktreeResult } from "../git/worktree.js";
+import { getActiveSumoRuntime } from "../sumo-tui/pi-compat/sumo-interactive-mode.js";
 
 const DEFAULT_SETUP_ACTION = "pnpm install";
 
@@ -32,8 +33,18 @@ export function parseWorktreeArgs(args: string): ParsedWorktreeArgs {
 	return { mode: "open", task: trimmed };
 }
 
-function notify(ctx: ExtensionContext, message: string, type: "info" | "warning" = "info"): void {
+function notify(pi: Pick<ExtensionAPI, "sendMessage">, ctx: ExtensionContext, message: string, type: "info" | "warning" = "info"): void {
 	if (ctx.hasUI) {
+		getActiveSumoRuntime()?.showNotice(message, type);
+		pi.sendMessage(
+			{
+				customType: "sumo:worktree",
+				content: message,
+				display: true,
+				details: { type, message },
+			},
+			{ triggerTurn: false },
+		);
 		ctx.ui.notify(message, type);
 		return;
 	}
@@ -47,6 +58,7 @@ function commandForWorktree(task: string, setupAction: string): string {
 }
 
 async function handlePrune(
+	pi: Pick<ExtensionAPI, "sendMessage">,
 	ctx: ExtensionContext,
 	target: string,
 	list: typeof listWorktrees,
@@ -54,30 +66,30 @@ async function handlePrune(
 ): Promise<void> {
 	const listed = await list(ctx.cwd);
 	if (!listed.ok) {
-		notify(ctx, `/sumo:worktree prune: ${listed.message}`, "warning");
+		notify(pi, ctx, `/sumo:worktree prune: ${listed.message}`, "warning");
 		return;
 	}
 	const sumoWorktrees = listed.worktrees.filter((worktree) => worktree.branch?.startsWith("sumo/"));
 	if (!target) {
 		if (sumoWorktrees.length === 0) {
-			notify(ctx, "no sumo worktrees found");
+			notify(pi, ctx, "no sumo worktrees found");
 			return;
 		}
 		const lines = sumoWorktrees.map((worktree) => `${worktree.branch ?? "detached"} · ${worktree.path}`);
-		notify(ctx, `sumo worktrees:\n${lines.join("\n")}\nrun /sumo:worktree prune <branch-or-path> to remove one`);
+		notify(pi, ctx, `sumo worktrees:\n${lines.join("\n")}\nrun /sumo:worktree prune <branch-or-path> to remove one`);
 		return;
 	}
 	const match = sumoWorktrees.find((worktree) => worktree.path === target || worktree.branch === target);
 	if (!match) {
-		notify(ctx, `/sumo:worktree prune: no tracked sumo worktree matched ${target}`, "warning");
+		notify(pi, ctx, `/sumo:worktree prune: no tracked sumo worktree matched ${target}`, "warning");
 		return;
 	}
 	const removed = await remove({ repoRoot: ctx.cwd, path: match.path });
 	if (!removed.ok) {
-		notify(ctx, `/sumo:worktree prune: ${removed.message}`, "warning");
+		notify(pi, ctx, `/sumo:worktree prune: ${removed.message}`, "warning");
 		return;
 	}
-	notify(ctx, `removed worktree ${match.branch ?? match.path}`);
+	notify(pi, ctx, `removed worktree ${match.branch ?? match.path}`);
 }
 
 export function registerWorktreeCommand(pi: ExtensionAPI, options: WorktreeCommandOptions = {}): void {
@@ -95,25 +107,25 @@ export function registerWorktreeCommand(pi: ExtensionAPI, options: WorktreeComma
 			try {
 				const parsed = parseWorktreeArgs(args ?? "");
 				if (parsed.mode === "prune") {
-					await handlePrune(ctx, parsed.task, list, remove);
+					await handlePrune(pi, ctx, parsed.task, list, remove);
 					return;
 				}
 				if (!ctx.hasUI) {
-					notify(ctx, "/sumo:worktree requires interactive UI", "warning");
+					notify(pi, ctx, "/sumo:worktree requires interactive UI", "warning");
 					return;
 				}
 				if (!isInsideCmux()) {
-					notify(ctx, "/sumo:worktree requires a cmux surface", "warning");
+					notify(pi, ctx, "/sumo:worktree requires a cmux surface", "warning");
 					return;
 				}
 				if (!parsed.task) {
-					notify(ctx, "Usage: /sumo:worktree <task> or /sumo:worktree prune <branch-or-path>", "warning");
+					notify(pi, ctx, "Usage: /sumo:worktree <task> or /sumo:worktree prune <branch-or-path>", "warning");
 					return;
 				}
 
 				const created: CreateWorktreeResult = await create({ repoRoot: ctx.cwd, task: parsed.task, baseRef: "HEAD" });
 				if (!created.ok) {
-					notify(ctx, `/sumo:worktree: ${created.message}`, "warning");
+					notify(pi, ctx, `/sumo:worktree: ${created.message}`, "warning");
 					return;
 				}
 
@@ -121,13 +133,13 @@ export function registerWorktreeCommand(pi: ExtensionAPI, options: WorktreeComma
 				const command = buildShellCommand(created.path, commandForWorktree(parsed.task, setupAction));
 				const opened = await openSplit(pi, direction, command);
 				if (!opened.ok) {
-					notify(ctx, `/sumo:worktree: ${opened.error}`, "warning");
+					notify(pi, ctx, `/sumo:worktree: ${opened.error}`, "warning");
 					return;
 				}
-				notify(ctx, `opened ${created.branch} in ${direction} split · setup: ${setupAction || "none"}`);
+				notify(pi, ctx, `opened ${created.branch} in ${direction} split · setup: ${setupAction || "none"}`);
 			} catch (error) {
 				const message = error instanceof Error ? error.message : String(error);
-				notify(ctx, `/sumo:worktree: ${message}`, "warning");
+				notify(pi, ctx, `/sumo:worktree: ${message}`, "warning");
 			}
 		},
 	});

--- a/src/extension.test.ts
+++ b/src/extension.test.ts
@@ -177,6 +177,17 @@ describe("sumocode extension", () => {
 		}
 	});
 
+	it("registers the v0.4 slash commands during full extension install", () => {
+		const { pi } = buildPiStub();
+
+		sumocode(pi as never);
+
+		const commandNames = pi.registerCommand.mock.calls.map((call) => call[0]);
+		expect(commandNames).toContain("sumo:review");
+		expect(commandNames).toContain("sumo:ship");
+		expect(commandNames).toContain("sumo:worktree");
+	});
+
 	it("does not push a 'SumoCode loaded' notification on session_start", () => {
 		const { pi, handlers } = buildPiStub();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import { installCompactionIndicator } from "./compaction-indicator.js";
 import { installFastMode } from "./fast-mode.js";
 import { installBackgroundTasks } from "./background-tasks/index.js";
 import { installTaskModeAutoExit } from "./task-mode.js";
+import { logDiagnostic } from "./sumo-tui/runtime/diagnostics.js";
 
 const SUMOCODE_PACKAGE_NAME = "@dhruvkelawala/sumocode";
 const LEGACY_TASK_TOOL_EXTENSION_PATH = join(".pi", "agent", "extensions", "task-tool", "index.ts");
@@ -157,6 +158,11 @@ export function isTaskMode(options: TaskModeOptions = {}): boolean {
  * so ownership and startup conflict diagnostics have one registry seam.
  */
 export default function sumocode(pi: ExtensionAPI): void {
+	logDiagnostic("extension_activate_begin", {
+		taskMode: isTaskMode(),
+		sumoTui: process.env.SUMO_TUI ?? null,
+		launcher: process.env.SUMOCODE_LAUNCHER ?? null,
+	});
 	if (shouldNoopHelperSubprocess()) {
 		// Helper subprocesses (pi-cmux session naming, SumoCode bg_task shell
 		// wrappers, etc.) signal themselves via PI_CMUX_CHILD / SUMOCODE_BG_CHILD.
@@ -233,4 +239,9 @@ export default function sumocode(pi: ExtensionAPI): void {
 	installCompactionIndicator(pi);
 	registerSumoReloadCommand(pi);
 	installSumoInteractions(pi, { backgroundTaskManager });
+	logDiagnostic("extension_activate_end", {
+		taskMode: isTaskMode(),
+		nativeTaskInstalled: shouldInstallNativeTaskTool({ force: process.env.SUMOCODE_NATIVE_TASK }),
+		hasBackgroundTasks: backgroundTaskManager !== undefined,
+	});
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -226,11 +226,11 @@ export default function sumocode(pi: ExtensionAPI): void {
 	}
 	installQuestionTool(pi);
 	installAnswerTool(pi);
-	installBackgroundTasks(pi);
+	const backgroundTaskManager = installBackgroundTasks(pi);
 	installTaskModeAutoExit(pi);
 
 	installWorkingIndicator(pi);
 	installCompactionIndicator(pi);
 	registerSumoReloadCommand(pi);
-	installSumoInteractions(pi);
+	installSumoInteractions(pi, { backgroundTaskManager });
 }

--- a/src/git/worktree.test.ts
+++ b/src/git/worktree.test.ts
@@ -1,0 +1,98 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+	createWorktree,
+	headAdvanced,
+	isClean,
+	listWorktrees,
+	parseWorktreePorcelain,
+	removeWorktree,
+	slugifyBranch,
+	worktreeRoot,
+} from "./worktree.js";
+
+function git(cwd: string, args: readonly string[]): string {
+	return execFileSync("git", [...args], { cwd, encoding: "utf8" });
+}
+
+describe("git/worktree", () => {
+	let root: string;
+	let repo: string;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "sumocode-worktree-test-"));
+		repo = join(root, "repo with spaces");
+		mkdirSync(repo, { recursive: true });
+		git(repo, ["init"]);
+		git(repo, ["config", "user.email", "sumocode@example.test"]);
+		git(repo, ["config", "user.name", "SumoCode Test"]);
+		writeFileSync(join(repo, "README.md"), "hello\n");
+		git(repo, ["add", "README.md"]);
+		git(repo, ["commit", "-m", "initial"]);
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	it("slugifies task text for named sumo branches", () => {
+		expect(slugifyBranch("Add bg_task worktree fan-out!")).toBe("add-bg-task-worktree-fan-out");
+		expect(slugifyBranch("---")).toBe("task");
+	});
+
+	it("uses a sibling worktree root so the repo stays clean", () => {
+		expect(worktreeRoot(repo)).toBe(join(dirname(repo), `${basename(repo)}.sumo-worktrees`));
+	});
+
+	it("parses git worktree porcelain output", () => {
+		expect(parseWorktreePorcelain("worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /tmp/wt\nHEAD def456\ndetached\n")).toEqual([
+			{ path: "/repo", head: "abc123", branch: "main", detached: false },
+			{ path: "/tmp/wt", head: "def456", detached: true },
+		]);
+	});
+
+	it("creates, lists, checks, advances, and removes a named-branch worktree", async () => {
+		const created = await createWorktree({ repoRoot: repo, task: "Implement worktree fanout", baseRef: "HEAD" });
+		expect(created.ok).toBe(true);
+		if (!created.ok) return;
+		expect(created.branch).toBe("sumo/implement-worktree-fanout");
+		expect(existsSync(created.path)).toBe(true);
+
+		const listed = await listWorktrees(repo);
+		expect(listed.ok).toBe(true);
+		if (!listed.ok) return;
+		expect(listed.worktrees.some((worktree) => realpathSync(worktree.path) === realpathSync(created.path) && worktree.branch === created.branch)).toBe(true);
+
+		expect(await isClean(created.path)).toMatchObject({ ok: true, clean: true });
+		expect(await headAdvanced(created.path, "HEAD~0")).toMatchObject({ ok: true, advanced: false });
+		const baseBranch = git(repo, ["branch", "--show-current"]).trim();
+
+		writeFileSync(join(created.path, "feature.txt"), "feature\n");
+		expect(await isClean(created.path)).toMatchObject({ ok: true, clean: false });
+		git(created.path, ["add", "feature.txt"]);
+		git(created.path, ["commit", "-m", "feature"]);
+		expect(await headAdvanced(created.path, baseBranch)).toMatchObject({ ok: true, advanced: true });
+
+		const removed = await removeWorktree({ repoRoot: repo, path: created.path, force: true });
+		expect(removed).toEqual({ ok: true });
+		expect(existsSync(created.path)).toBe(false);
+	});
+
+	it("surfaces branch and path collisions as typed errors", async () => {
+		git(repo, ["branch", "sumo/existing"]);
+		expect(await createWorktree({ repoRoot: repo, branch: "sumo/existing" })).toMatchObject({
+			ok: false,
+			error: "branch_already_exists",
+		});
+
+		const collisionPath = join(root, "already here");
+		mkdirSync(collisionPath);
+		expect(await createWorktree({ repoRoot: repo, branch: "sumo/new", path: collisionPath })).toMatchObject({
+			ok: false,
+			error: "path_already_exists",
+		});
+	});
+});

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -132,7 +132,7 @@ function branchExistsSync(repoRoot: string, branch: string): boolean {
 	return gitOkSync(repoRoot, ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`]);
 }
 
-function resolveCreateOptions(options: CreateWorktreeOptions): { branch: string; baseRef: string; path: string } {
+export function resolveCreateOptions(options: CreateWorktreeOptions): { branch: string; baseRef: string; path: string } {
 	const baseRef = options.baseRef ?? "HEAD";
 	const branch = options.branch ?? `sumo/${slugifyBranch(options.task ?? "task")}`;
 	const path = options.path ?? join(worktreeRoot(options.repoRoot), pathSegmentForBranch(branch));
@@ -233,6 +233,7 @@ export async function removeWorktree(options: RemoveWorktreeOptions): Promise<Re
 	}
 }
 
+// Forward-looking: worktree reconcile/ship loop helpers; currently covered by worktree.test.ts only.
 export async function isClean(path: string): Promise<CleanResult> {
 	try {
 		const { stdout } = await git(path, ["status", "--porcelain"]);
@@ -242,6 +243,7 @@ export async function isClean(path: string): Promise<CleanResult> {
 	}
 }
 
+// Forward-looking: worktree reconcile/ship loop helpers; currently covered by worktree.test.ts only.
 export async function headAdvanced(path: string, baseRef: string): Promise<HeadAdvancedResult> {
 	try {
 		const head = (await git(path, ["rev-parse", "HEAD"])).stdout.trim();

--- a/src/git/worktree.ts
+++ b/src/git/worktree.ts
@@ -1,0 +1,255 @@
+import { execFile, execFileSync } from "node:child_process";
+import { existsSync, mkdirSync } from "node:fs";
+import { basename, dirname, join } from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_GIT_TIMEOUT_MS = 15_000;
+
+export type WorktreeErrorCode =
+	| "branch_already_exists"
+	| "path_already_exists"
+	| "git_failed"
+	| "parse_failed";
+
+export interface WorktreeFailure {
+	readonly ok: false;
+	readonly error: WorktreeErrorCode;
+	readonly message: string;
+	readonly stderr?: string;
+	readonly stdout?: string;
+}
+
+export interface CreateWorktreeOptions {
+	readonly repoRoot: string;
+	readonly branch?: string;
+	readonly baseRef?: string;
+	readonly task?: string;
+	readonly path?: string;
+}
+
+export type CreateWorktreeResult =
+	| { readonly ok: true; readonly path: string; readonly branch: string; readonly baseRef: string }
+	| WorktreeFailure;
+
+export interface WorktreeInfo {
+	readonly path: string;
+	readonly head?: string;
+	readonly branch?: string;
+	readonly detached: boolean;
+}
+
+export type ListWorktreesResult = { readonly ok: true; readonly worktrees: readonly WorktreeInfo[] } | WorktreeFailure;
+
+export interface RemoveWorktreeOptions {
+	readonly path: string;
+	readonly repoRoot?: string;
+	readonly force?: boolean;
+}
+
+export type RemoveWorktreeResult = { readonly ok: true } | WorktreeFailure;
+export type CleanResult = { readonly ok: true; readonly clean: boolean } | WorktreeFailure;
+export type HeadAdvancedResult = { readonly ok: true; readonly advanced: boolean } | WorktreeFailure;
+
+interface GitResult {
+	readonly stdout: string;
+	readonly stderr: string;
+}
+
+function failure(error: WorktreeErrorCode, message: string, output: Partial<GitResult> = {}): WorktreeFailure {
+	return { ok: false, error, message, stdout: output.stdout, stderr: output.stderr };
+}
+
+async function git(repoRoot: string, args: readonly string[]): Promise<GitResult> {
+	const { stdout, stderr } = await execFileAsync("git", ["-C", repoRoot, ...args], {
+		encoding: "utf8",
+		timeout: DEFAULT_GIT_TIMEOUT_MS,
+		maxBuffer: 10 * 1024 * 1024,
+	});
+	return { stdout, stderr };
+}
+
+async function gitOk(repoRoot: string, args: readonly string[]): Promise<boolean> {
+	try {
+		await git(repoRoot, args);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function gitSync(repoRoot: string, args: readonly string[]): GitResult {
+	const stdout = execFileSync("git", ["-C", repoRoot, ...args], {
+		encoding: "utf8",
+		timeout: DEFAULT_GIT_TIMEOUT_MS,
+		maxBuffer: 10 * 1024 * 1024,
+	});
+	return { stdout, stderr: "" };
+}
+
+function gitOkSync(repoRoot: string, args: readonly string[]): boolean {
+	try {
+		gitSync(repoRoot, args);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function gitFailure(error: unknown): WorktreeFailure {
+	const maybe = error as { message?: unknown; stdout?: unknown; stderr?: unknown };
+	const stdout = typeof maybe.stdout === "string" ? maybe.stdout : undefined;
+	const stderr = typeof maybe.stderr === "string" ? maybe.stderr : undefined;
+	const message = stderr?.trim() || (typeof maybe.message === "string" ? maybe.message : "git command failed");
+	return failure("git_failed", message, { stdout, stderr });
+}
+
+export function slugifyBranch(task: string): string {
+	const slug = task
+		.toLowerCase()
+		.normalize("NFKD")
+		.replace(/[\u0300-\u036f]/g, "")
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 48)
+		.replace(/-+$/g, "");
+	return slug || "task";
+}
+
+export function worktreeRoot(repoRoot = process.cwd()): string {
+	return join(dirname(repoRoot), `${basename(repoRoot)}.sumo-worktrees`);
+}
+
+function pathSegmentForBranch(branch: string): string {
+	return branch.replace(/[^a-zA-Z0-9._-]+/g, "__");
+}
+
+async function branchExists(repoRoot: string, branch: string): Promise<boolean> {
+	return gitOk(repoRoot, ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`]);
+}
+
+function branchExistsSync(repoRoot: string, branch: string): boolean {
+	return gitOkSync(repoRoot, ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`]);
+}
+
+function resolveCreateOptions(options: CreateWorktreeOptions): { branch: string; baseRef: string; path: string } {
+	const baseRef = options.baseRef ?? "HEAD";
+	const branch = options.branch ?? `sumo/${slugifyBranch(options.task ?? "task")}`;
+	const path = options.path ?? join(worktreeRoot(options.repoRoot), pathSegmentForBranch(branch));
+	return { branch, baseRef, path };
+}
+
+export function createWorktreeSync(options: CreateWorktreeOptions): CreateWorktreeResult {
+	const { branch, baseRef, path } = resolveCreateOptions(options);
+	if (branchExistsSync(options.repoRoot, branch)) {
+		return failure("branch_already_exists", `branch already exists: ${branch}`);
+	}
+	if (existsSync(path)) {
+		return failure("path_already_exists", `worktree path already exists: ${path}`);
+	}
+	try {
+		mkdirSync(dirname(path), { recursive: true });
+		gitSync(options.repoRoot, ["worktree", "add", "-b", branch, path, baseRef]);
+		return { ok: true, path, branch, baseRef };
+	} catch (error) {
+		return gitFailure(error);
+	}
+}
+
+export async function createWorktree(options: CreateWorktreeOptions): Promise<CreateWorktreeResult> {
+	const { branch, baseRef, path } = resolveCreateOptions(options);
+
+	if (await branchExists(options.repoRoot, branch)) {
+		return failure("branch_already_exists", `branch already exists: ${branch}`);
+	}
+	if (existsSync(path)) {
+		return failure("path_already_exists", `worktree path already exists: ${path}`);
+	}
+
+	try {
+		mkdirSync(dirname(path), { recursive: true });
+		await git(options.repoRoot, ["worktree", "add", "-b", branch, path, baseRef]);
+		return { ok: true, path, branch, baseRef };
+	} catch (error) {
+		return gitFailure(error);
+	}
+}
+
+export function parseWorktreePorcelain(output: string): WorktreeInfo[] {
+	const records = output.trim().split(/\n\s*\n/).filter(Boolean);
+	return records.map((record) => {
+		const info: { path?: string; head?: string; branch?: string; detached?: boolean } = {};
+		for (const line of record.split("\n")) {
+			const [key, ...rest] = line.split(" ");
+			const value = rest.join(" ");
+			if (key === "worktree") info.path = value;
+			else if (key === "HEAD") info.head = value;
+			else if (key === "branch") info.branch = value.replace(/^refs\/heads\//, "");
+			else if (key === "detached") info.detached = true;
+		}
+		if (!info.path) {
+			throw new Error(`missing worktree path in porcelain record: ${record}`);
+		}
+		return {
+			path: info.path,
+			head: info.head,
+			branch: info.branch,
+			detached: info.detached ?? !info.branch,
+		};
+	});
+}
+
+export async function listWorktrees(repoRoot: string): Promise<ListWorktreesResult> {
+	try {
+		const { stdout } = await git(repoRoot, ["worktree", "list", "--porcelain"]);
+		return { ok: true, worktrees: parseWorktreePorcelain(stdout) };
+	} catch (error) {
+		if (error instanceof Error && error.message.includes("missing worktree path")) {
+			return failure("parse_failed", error.message);
+		}
+		return gitFailure(error);
+	}
+}
+
+export function removeWorktreeSync(options: RemoveWorktreeOptions): RemoveWorktreeResult {
+	const repoRoot = options.repoRoot ?? options.path;
+	const args = ["worktree", "remove", ...(options.force ? ["--force"] : []), options.path];
+	try {
+		gitSync(repoRoot, args);
+		return { ok: true };
+	} catch (error) {
+		return gitFailure(error);
+	}
+}
+
+export async function removeWorktree(options: RemoveWorktreeOptions): Promise<RemoveWorktreeResult> {
+	const repoRoot = options.repoRoot ?? options.path;
+	const args = ["worktree", "remove", ...(options.force ? ["--force"] : []), options.path];
+	try {
+		await git(repoRoot, args);
+		return { ok: true };
+	} catch (error) {
+		return gitFailure(error);
+	}
+}
+
+export async function isClean(path: string): Promise<CleanResult> {
+	try {
+		const { stdout } = await git(path, ["status", "--porcelain"]);
+		return { ok: true, clean: stdout.trim().length === 0 };
+	} catch (error) {
+		return gitFailure(error);
+	}
+}
+
+export async function headAdvanced(path: string, baseRef: string): Promise<HeadAdvancedResult> {
+	try {
+		const head = (await git(path, ["rev-parse", "HEAD"])).stdout.trim();
+		const base = (await git(path, ["rev-parse", baseRef])).stdout.trim();
+		if (head === base) return { ok: true, advanced: false };
+		const isAncestor = await gitOk(path, ["merge-base", "--is-ancestor", baseRef, "HEAD"]);
+		return { ok: true, advanced: isAncestor };
+	} catch (error) {
+		return gitFailure(error);
+	}
+}

--- a/src/interaction-registry.test.ts
+++ b/src/interaction-registry.test.ts
@@ -84,14 +84,16 @@ describe("InteractionRegistry", () => {
 			"sumo:persona",
 			"sumo:query",
 			"sumo:review",
+			"sumo:ship",
 			"sumo:spinner",
 			"sumo:sync",
 			"sumo:tabs",
 			"sumo:theme",
 			"sumo:theme-check",
+			"sumo:worktree",
 		]);
 		expect(snapshot.shortcuts.map(([id]) => id).sort()).toEqual(["alt+t", "ctrl+/", "ctrl+1", "ctrl+2", "ctrl+shift+t"]);
-		expect(pi.registerCommand).toHaveBeenCalledTimes(15);
+		expect(pi.registerCommand).toHaveBeenCalledTimes(17);
 		expect(pi.registerShortcut).toHaveBeenCalledTimes(5);
 	});
 });

--- a/src/interaction-registry.ts
+++ b/src/interaction-registry.ts
@@ -1,4 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import type { BackgroundTaskManager } from "./background-tasks/task-manager.js";
 import { installCommandPalette } from "./command-palette.js";
 import { registerApprovalCommand } from "./commands/approval.js";
 import { registerCursorCommand } from "./commands/cursor.js";
@@ -6,6 +7,7 @@ import { registerDiffCommand } from "./commands/diff.js";
 import { registerDivineQueryCommand } from "./commands/divine-query.js";
 import { registerExitCommand } from "./commands/exit.js";
 import { registerSlateCommand } from "./commands/slate.js";
+import { registerShipCommand } from "./commands/ship.js";
 import { registerPersonaCommand } from "./commands/persona.js";
 import { registerReviewCommand } from "./commands/review.js";
 import { registerSpinnerCommand } from "./commands/spinner.js";
@@ -13,6 +15,7 @@ import { registerSumoSyncCommand } from "./commands/sync.js";
 import { registerTabsCommand } from "./commands/tabs.js";
 import { registerThemeCommand } from "./commands/theme.js";
 import { registerThemeCheckCommand } from "./commands/theme-check.js";
+import { registerWorktreeCommand } from "./commands/worktree.js";
 import { registerMemoryCommand } from "./memory-editor.js";
 import { installSidebar } from "./sidebar.js";
 
@@ -119,6 +122,7 @@ export class InteractionRegistry {
 
 export interface InstallSumoInteractionsOptions {
 	readonly reporter?: InteractionDiagnosticReporter;
+	readonly backgroundTaskManager?: BackgroundTaskManager;
 }
 
 export function createInteractionRegistry(pi: ExtensionAPI, reporter?: InteractionDiagnosticReporter): InteractionRegistry {
@@ -136,12 +140,14 @@ export function installSumoInteractions(pi: ExtensionAPI, options: InstallSumoIn
 	registry.install("commands.exit", registerExitCommand);
 	registry.install("commands.slate", registerSlateCommand);
 	registry.install("commands.persona", registerPersonaCommand);
-	registry.install("commands.review", registerReviewCommand);
+	registry.install("commands.review", (targetPi) => registerReviewCommand(targetPi, { taskSpawner: options.backgroundTaskManager }));
+	registry.install("commands.ship", registerShipCommand);
 	registry.install("commands.spinner", registerSpinnerCommand);
 	registry.install("commands.sync", registerSumoSyncCommand);
 	registry.install("commands.tabs", registerTabsCommand);
 	registry.install("commands.theme", registerThemeCommand);
 	registry.install("commands.theme-check", registerThemeCheckCommand);
+	registry.install("commands.worktree", registerWorktreeCommand);
 	registry.install("commands.memory", registerMemoryCommand);
 	registry.flushDiagnostics();
 	return registry.getSnapshot();

--- a/src/sumo-tui/pi-compat/extension-ui-adapter.ts
+++ b/src/sumo-tui/pi-compat/extension-ui-adapter.ts
@@ -147,11 +147,15 @@ export class SumoExtensionUIAdapter implements ExtensionUIContext {
 		this.onWorkingIndicator = options.setWorkingIndicator;
 		this.onHiddenThinkingLabel = options.setHiddenThinkingLabel;
 		this.requestRender = options.onRenderRequest ?? (() => this.tui.requestRender?.());
-		this.regionRegistry.mountOverlay("__notifications", this.notifications, {
+		const notificationOverlayOptions: OverlayOptions = {
 			anchor: "top-right",
 			width: "45%",
 			maxHeight: 6,
-		});
+			nonCapturing: true,
+			visible: () => this.notifications.getToasts().length > 0,
+		};
+		this.tui.showOverlay?.(this.notifications, notificationOverlayOptions);
+		this.regionRegistry.mountOverlay("__notifications", this.notifications, notificationOverlayOptions);
 		if (this.modals instanceof ModalLayer) {
 			this.regionRegistry.mountOverlay("__modal", this.modals, {
 				row: 0,

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.test.ts
@@ -104,6 +104,24 @@ describe("sumo interactive Pi noise filtering", () => {
 		runtime.stop();
 	});
 
+	it("emits a boot_screen_frame diagnostic when the eager splash paints", async () => {
+		const previousDiagFile = process.env.SUMO_TUI_DIAG_FILE;
+		const diagFile = join(mkdtempSync(join(tmpdir(), "sumocode-boot-diag-")), "diag.jsonl");
+		process.env.SUMO_TUI_DIAG_FILE = diagFile;
+		const runtime = new SumoInteractiveRuntime({ isTTY: true, columns: 100, rows: 30, write: vi.fn() });
+		try {
+			await runtime.start();
+			const events = readFileSync(diagFile, "utf8").split("\n").filter(Boolean).map((line) => JSON.parse(line) as Record<string, unknown>);
+			expect(events).toEqual(expect.arrayContaining([
+				expect.objectContaining({ event: "boot_screen_frame", surface: "retained_splash", width: 100, height: 30 }),
+			]));
+		} finally {
+			runtime.stop();
+			if (previousDiagFile === undefined) delete process.env.SUMO_TUI_DIAG_FILE;
+			else process.env.SUMO_TUI_DIAG_FILE = previousDiagFile;
+		}
+	});
+
 	it("shares the terminal owner with lifecycle startup without duplicate mode writes", async () => {
 		const write = vi.fn();
 		const output = { isTTY: true, columns: 100, rows: 30, write };

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -322,6 +322,12 @@ export class SumoInteractiveRuntime {
 		return this.selection;
 	}
 
+	public showNotice(message: string, type: "info" | "warning" = "info"): void {
+		const text = type === "warning" ? `Warning: ${message}` : message;
+		this.chat?.addMessage("system", text, new Date());
+		this.requestRender();
+	}
+
 	public setSelectionFrameSource(source: (() => CellBuffer | undefined) | undefined): void {
 		this.selectionFrameSource = source;
 	}

--- a/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
+++ b/src/sumo-tui/pi-compat/sumo-interactive-mode.ts
@@ -522,7 +522,10 @@ export class SumoInteractiveRuntime {
 		this.renderedVersion = this.frameVersion;
 		this.renderedWidth = width;
 		this.renderedHeight = height;
-		logDiagnostic("eager_splash_paint", { width, height, patchCount: patches.length, layoutMs: Math.round(layoutMs * 100) / 100, compositeMs: Math.round(compositeMs * 100) / 100 });
+		const layoutRoundedMs = Math.round(layoutMs * 100) / 100;
+		const compositeRoundedMs = Math.round(compositeMs * 100) / 100;
+		logDiagnostic("eager_splash_paint", { width, height, patchCount: patches.length, layoutMs: layoutRoundedMs, compositeMs: compositeRoundedMs });
+		logDiagnostic("boot_screen_frame", { width, height, patchCount: patches.length, layoutMs: layoutRoundedMs, compositeMs: compositeRoundedMs, surface: "retained_splash" });
 	}
 
 	private emptyChatQuoteSnapshot(): EmptyChatQuoteSnapshot {
@@ -825,7 +828,12 @@ export class SumoInteractiveMode {
 		process.nextTick(() => {
 			logDiagnostic("owned_shell_initial_render_start");
 			this.ownedShell?.render();
-			logDiagnostic("owned_shell_initial_render_end");
+			const cols = dimensions.columns ?? null;
+			const rows = dimensions.rows ?? null;
+			logDiagnostic("owned_shell_initial_render_end", { cols, rows });
+			logDiagnostic("stable_chrome_ready", { cols, rows, surface: "owned_shell" });
+			logDiagnostic("app_ready", { cols, rows, surface: "owned_shell" });
+			logDiagnostic("input_ready", { cols, rows, surface: "owned_shell" });
 		});
 
 		logDiagnostic("owned_shell_installed", {

--- a/src/sumo-tui/transcript/view-model.test.ts
+++ b/src/sumo-tui/transcript/view-model.test.ts
@@ -257,6 +257,19 @@ describe("structured transcript view model", () => {
 		});
 	});
 
+	it("maps image content parts instead of dropping them", () => {
+		const message = chatMessageViewModelFromPiMessage({
+			role: "assistant",
+			content: [
+				{ type: "text", text: "before" },
+				{ type: "image", data: "iVBORw0KGgo=", mimeType: "image/png", filename: "one.png" },
+			],
+		});
+
+		expect(message?.blocks).toContainEqual({ type: "image", data: "iVBORw0KGgo=", mime: "image/png", filename: "one.png" });
+		expect(message ? chatMessageViewModelToPlainText(message) : "").toContain("[image] image/png");
+	});
+
 	it("maps skill blocks", () => {
 		const message = chatMessageViewModelFromPiMessage({
 			role: "assistant",

--- a/src/sumo-tui/transcript/view-model.ts
+++ b/src/sumo-tui/transcript/view-model.ts
@@ -45,6 +45,7 @@ export type ChatBlock =
 	| { readonly type: "markdown"; readonly text: string }
 	| { readonly type: "thinking"; readonly text: string; readonly hidden?: boolean }
 	| { readonly type: "code"; readonly lang: string; readonly source: string; readonly collapsed?: boolean }
+	| { readonly type: "image"; readonly data: string; readonly mime: string; readonly filename?: string }
 	| { readonly type: "tool"; readonly tool: ToolCallViewModel }
 	| { readonly type: "skill"; readonly name: string; readonly expanded: boolean }
 	| { readonly type: "question"; readonly question: QuestionViewModel }
@@ -198,6 +199,14 @@ function skillBlockFromRecord(record: Record<string, unknown>): ChatBlock {
 		name: firstString(record.name, record.skill, record.skillName) ?? "unknown-skill",
 		expanded: asBoolean(record.expanded) ?? false,
 	};
+}
+
+function imageBlockFromRecord(record: Record<string, unknown>): ChatBlock[] {
+	const source = asRecord(record.source);
+	const data = firstString(record.data, record.base64, record.base64Data, source?.data, source?.base64, source?.base64Data);
+	const mime = firstString(record.mime, record.mimeType, record.mediaType, record.media_type, source?.mime, source?.mimeType, source?.mediaType, source?.media_type);
+	if (!data || !mime) return [];
+	return [{ type: "image", data, mime, filename: firstString(record.filename, record.name, source?.filename) }];
 }
 
 function questionBlockFromRecord(record: Record<string, unknown>): ChatBlock {
@@ -585,6 +594,9 @@ function blocksFromContentPart(part: unknown): ChatBlock[] {
 		case "thinking_delta":
 		case "reasoning_delta":
 			return thinkingBlockFromRecord(record);
+		case "image":
+		case "input_image":
+			return imageBlockFromRecord(record);
 		case "toolCall":
 		case "tool_call":
 		case "tool":
@@ -701,6 +713,8 @@ export function chatMessageViewModelToPlainText(message: ChatMessageViewModel): 
 					return block.hidden ? "Thinking..." : block.text;
 				case "code":
 					return `\`\`\`${block.lang}\n${block.source}\n\`\`\``;
+				case "image":
+					return `[image] ${block.mime}`;
 				case "tool":
 					return renderCompactToolPill(block.tool);
 				case "skill":

--- a/src/sumo-tui/widgets/chat-message.ts
+++ b/src/sumo-tui/widgets/chat-message.ts
@@ -1,4 +1,4 @@
-import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { Image, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
 import { DEFAULT_SUMOCODE_CONFIG } from "../../config/sumocode-config.js";
 import { activeThemeChrome, activeThemeColors } from "../../themes/index.js";
 import { fgHex, RESET } from "../cathedral/ansi.js";
@@ -240,6 +240,16 @@ function renderQuestionRows(block: Extract<ChatBlock, { type: "question" }>): st
 	return [`[question] ${block.question.prompt}`, ...block.question.choices.map((choice) => `- ${choice}`)];
 }
 
+function renderImageRows(block: Extract<ChatBlock, { type: "image" }>, width: number): string[] {
+	const image = new Image(
+		block.data,
+		block.mime,
+		{ fallbackColor: (value) => `${fgHex(activeThemeColors().foregroundDim)}${value}${RESET}` },
+		{ maxWidthCells: Math.max(1, width), maxHeightCells: 24, filename: block.filename },
+	);
+	return image.render(width).map((row) => visibleWidth(row) > width ? truncateToWidth(row, width, "") : row);
+}
+
 function renderDelegationRows(block: Extract<ChatBlock, { type: "delegation" }>, width: number): string[] {
 	return renderScrollBlock(block.delegation, width);
 }
@@ -261,6 +271,9 @@ function renderBlockRows(blocks: readonly ChatBlock[], width: number): string[] 
 				break;
 			case "code":
 				rows.push(...renderCodeRows(block, width));
+				break;
+			case "image":
+				rows.push(...renderImageRows(block, width));
 				break;
 			case "tool":
 				rows.push(...renderToolBlockRows(block.tool, width));

--- a/src/task-mode.test.ts
+++ b/src/task-mode.test.ts
@@ -7,6 +7,7 @@ import {
 	installTaskModeAutoExit,
 	shouldInstallTaskModeAutoExit,
 	writeTaskExitMarker,
+	writeTaskStartedMarker,
 } from "./task-mode.js";
 
 type Handler = (...args: unknown[]) => unknown;
@@ -119,6 +120,7 @@ describe("installTaskModeAutoExit", () => {
 	let originalSurfaceId: string | undefined;
 	let originalResponseFile: string | undefined;
 	let originalExitFile: string | undefined;
+	let originalStartedFile: string | undefined;
 	let workDir: string | undefined;
 
 	beforeEach(() => {
@@ -127,8 +129,10 @@ describe("installTaskModeAutoExit", () => {
 		process.env.CMUX_SURFACE_ID = "surface:test";
 		originalResponseFile = process.env.SUMOCODE_TASK_RESPONSE_FILE;
 		originalExitFile = process.env.SUMOCODE_TASK_EXIT_FILE;
+		originalStartedFile = process.env.SUMOCODE_TASK_STARTED_FILE;
 		delete process.env.SUMOCODE_TASK_RESPONSE_FILE;
 		delete process.env.SUMOCODE_TASK_EXIT_FILE;
+		delete process.env.SUMOCODE_TASK_STARTED_FILE;
 		workDir = undefined;
 	});
 
@@ -140,6 +144,8 @@ describe("installTaskModeAutoExit", () => {
 		else process.env.SUMOCODE_TASK_RESPONSE_FILE = originalResponseFile;
 		if (originalExitFile === undefined) delete process.env.SUMOCODE_TASK_EXIT_FILE;
 		else process.env.SUMOCODE_TASK_EXIT_FILE = originalExitFile;
+		if (originalStartedFile === undefined) delete process.env.SUMOCODE_TASK_STARTED_FILE;
+		else process.env.SUMOCODE_TASK_STARTED_FILE = originalStartedFile;
 		if (workDir) rmSync(workDir, { recursive: true, force: true });
 	});
 
@@ -296,6 +302,27 @@ describe("installTaskModeAutoExit", () => {
 
 		expect(readFileSync(responseFile, "utf8").trim()).toBe("second");
 		expect(ctx.ui.setStatus).toHaveBeenCalledTimes(1);
+	});
+
+	it("writes a task-started marker for manager startup liveness", () => {
+		workDir = mkdtempSync(join(tmpdir(), "sumocode-task-mode-test-"));
+		const startedFile = join(workDir, "started.marker");
+		writeTaskStartedMarker({ SUMOCODE_TASK_STARTED_FILE: startedFile } as NodeJS.ProcessEnv);
+
+		expect(readFileSync(startedFile, "utf8").trim()).toBe(String(process.pid));
+	});
+
+	it("writes a task-started marker during task-mode install", () => {
+		workDir = mkdtempSync(join(tmpdir(), "sumocode-task-mode-test-"));
+		const startedFile = join(workDir, "started.marker");
+		const { pi } = buildPiStub();
+
+		installTaskModeAutoExit(pi as never, {
+			env: { SUMOCODE_TASK_MODE: "1", SUMOCODE_TASK_STARTED_FILE: startedFile },
+			graceMs: 10_000,
+		});
+
+		expect(readFileSync(startedFile, "utf8").trim()).toBe(String(process.pid));
 	});
 
 	it("writes a real-exit marker for the manager to harvest", () => {

--- a/src/task-mode.test.ts
+++ b/src/task-mode.test.ts
@@ -6,6 +6,7 @@ import {
 	extractFinalAssistantText,
 	installTaskModeAutoExit,
 	shouldInstallTaskModeAutoExit,
+	writeTaskExitMarker,
 } from "./task-mode.js";
 
 type Handler = (...args: unknown[]) => unknown;
@@ -117,6 +118,7 @@ describe("shouldInstallTaskModeAutoExit", () => {
 describe("installTaskModeAutoExit", () => {
 	let originalSurfaceId: string | undefined;
 	let originalResponseFile: string | undefined;
+	let originalExitFile: string | undefined;
 	let workDir: string | undefined;
 
 	beforeEach(() => {
@@ -124,7 +126,9 @@ describe("installTaskModeAutoExit", () => {
 		originalSurfaceId = process.env.CMUX_SURFACE_ID;
 		process.env.CMUX_SURFACE_ID = "surface:test";
 		originalResponseFile = process.env.SUMOCODE_TASK_RESPONSE_FILE;
+		originalExitFile = process.env.SUMOCODE_TASK_EXIT_FILE;
 		delete process.env.SUMOCODE_TASK_RESPONSE_FILE;
+		delete process.env.SUMOCODE_TASK_EXIT_FILE;
 		workDir = undefined;
 	});
 
@@ -134,6 +138,8 @@ describe("installTaskModeAutoExit", () => {
 		else process.env.CMUX_SURFACE_ID = originalSurfaceId;
 		if (originalResponseFile === undefined) delete process.env.SUMOCODE_TASK_RESPONSE_FILE;
 		else process.env.SUMOCODE_TASK_RESPONSE_FILE = originalResponseFile;
+		if (originalExitFile === undefined) delete process.env.SUMOCODE_TASK_EXIT_FILE;
+		else process.env.SUMOCODE_TASK_EXIT_FILE = originalExitFile;
 		if (workDir) rmSync(workDir, { recursive: true, force: true });
 	});
 
@@ -151,7 +157,7 @@ describe("installTaskModeAutoExit", () => {
 		expect(pi.on).not.toHaveBeenCalled();
 	});
 
-	it("schedules cmux close-surface after the grace period on first agent_end", async () => {
+	it("schedules process shutdown after the grace period on first agent_end", async () => {
 		const { pi, handlers } = buildPiStub();
 		installTaskModeAutoExit(pi as never, { env: { SUMOCODE_TASK_MODE: "1" }, graceMs: 10_000 });
 
@@ -164,7 +170,7 @@ describe("installTaskModeAutoExit", () => {
 		// status is set immediately with full grace countdown
 		expect(ctx.ui.setStatus).toHaveBeenCalledWith(
 			"sumocode-task-auto-exit",
-			expect.stringContaining("auto-closing in 10s"),
+			expect.stringContaining("exiting in 10s"),
 		);
 
 		// nothing has fired yet
@@ -176,8 +182,8 @@ describe("installTaskModeAutoExit", () => {
 		vi.advanceTimersByTime(1);
 		// Let the floated promise inside the timer callback settle
 		await Promise.resolve();
-		expect(pi.exec).toHaveBeenCalledWith("cmux", ["close-surface"], { timeout: 5000 });
-		expect(ctx.shutdown).not.toHaveBeenCalled();
+		expect(pi.exec).not.toHaveBeenCalled();
+		expect(ctx.shutdown).toHaveBeenCalledTimes(1);
 	});
 
 	it("cancels auto-exit when the user types interactively during the grace period", () => {
@@ -212,7 +218,8 @@ describe("installTaskModeAutoExit", () => {
 
 		vi.advanceTimersByTime(10_000);
 		await Promise.resolve();
-		expect(pi.exec).toHaveBeenCalledWith("cmux", ["close-surface"], { timeout: 5000 });
+		expect(pi.exec).not.toHaveBeenCalled();
+		expect(ctx.shutdown).toHaveBeenCalledTimes(1);
 	});
 
 	it("cancels auto-exit when the user types AFTER the first agent_end (real follow-up)", () => {
@@ -272,6 +279,31 @@ describe("installTaskModeAutoExit", () => {
 
 		expect(existsSync(responseFile)).toBe(true);
 		expect(readFileSync(responseFile, "utf8").trim()).toBe("done x");
+	});
+
+	it("updates response.md on later agent_end events without re-arming shutdown", () => {
+		workDir = mkdtempSync(join(tmpdir(), "sumocode-task-mode-test-"));
+		const responseFile = join(workDir, "response.md");
+		process.env.SUMOCODE_TASK_RESPONSE_FILE = responseFile;
+
+		const { pi, handlers } = buildPiStub();
+		installTaskModeAutoExit(pi as never, { env: { SUMOCODE_TASK_MODE: "1" }, graceMs: 10_000 });
+
+		const ctx = buildCtxStub();
+		const onAgentEnd = handlers.get("agent_end")?.[0];
+		onAgentEnd?.({ messages: [{ role: "assistant", content: [{ type: "text", text: "first" }] }] }, ctx);
+		onAgentEnd?.({ messages: [{ role: "assistant", content: [{ type: "text", text: "second" }] }] }, ctx);
+
+		expect(readFileSync(responseFile, "utf8").trim()).toBe("second");
+		expect(ctx.ui.setStatus).toHaveBeenCalledTimes(1);
+	});
+
+	it("writes a real-exit marker for the manager to harvest", () => {
+		workDir = mkdtempSync(join(tmpdir(), "sumocode-task-mode-test-"));
+		const exitFile = join(workDir, "exit.code");
+		writeTaskExitMarker(0, { SUMOCODE_TASK_EXIT_FILE: exitFile } as NodeJS.ProcessEnv);
+
+		expect(readFileSync(exitFile, "utf8").trim()).toBe("0");
 	});
 
 	it("does not write response.md when env var is unset", () => {

--- a/src/task-mode.ts
+++ b/src/task-mode.ts
@@ -3,31 +3,28 @@
  *
  * When SumoCode launches via `sumocode task "<prompt>"` (i.e.
  * `SUMOCODE_TASK_MODE=1`), the session is a hand-off from an orchestrator:
- * do one delegated turn, then close. This module wires the lifecycle that
- * makes the pane close itself after the agent finishes — without leaving
- * the user staring at an idle editor in a child pane they probably don't
- * want to interact with.
+ * do one delegated turn, then shut down the child process. This module wires
+ * the lifecycle that exits the agent while leaving the cmux pane itself as a
+ * preserved viewport the orchestrator/human can inspect.
  *
  * Behavior:
  *
- * - On the first `agent_end` after launch, schedule a close after a grace
- *   period (default 10s) so the user has time to read the response.
+ * - On each `agent_end`, write the latest assistant response for the parent.
+ * - On the first `agent_end` after launch, schedule process shutdown after a
+ *   grace period (default 10s) so the user has time to read the response.
  * - During the grace period, a status entry in the footer counts down
- *   ("auto-closing in 9s · type to cancel").
+ *   ("exiting in 9s · type to cancel").
  * - If the user types anything in the editor (source=interactive), cancel
  *   the auto-exit permanently for this session. User has taken over.
  * - Opt out entirely with `SUMOCODE_TASK_KEEP_OPEN=1`.
  *
- * Closing the pane uses `cmux close-surface` (no args; cmux defaults to
- * `$CMUX_SURFACE_ID` which is auto-set in every cmux terminal). This is
- * cmux's documented "close this pane" method and bypasses Pi's deferred
- * `ctx.shutdown()` semantics, which in practice do not reliably terminate
- * Pi from inside an extension handler.
+ * Shutdown uses Pi's `ctx.shutdown()` instead of `cmux close-surface`: task
+ * completion belongs to the child process lifecycle, while pane close is an
+ * explicit orchestrator/user decision (`bg_task stop`).
  */
 
 import { appendFileSync, writeFileSync } from "node:fs";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { isInCmux } from "./commands/cmux-split.js";
 
 /**
  * Env-gated diagnostic logging. Set `SUMOCODE_TASK_DIAG_FILE=/tmp/xxx.jsonl`
@@ -102,6 +99,24 @@ function persistResponse(messages: unknown[]): void {
 	}
 }
 
+export function writeTaskExitMarker(code: number, env: NodeJS.ProcessEnv = process.env): void {
+	const file = env.SUMOCODE_TASK_EXIT_FILE;
+	if (!file) return;
+	try {
+		writeFileSync(file, `${code}\n`);
+		diagLog("exit_marker_written", { file, code });
+	} catch (error) {
+		diagLog("exit_marker_write_failed", {
+			message: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
+function installTaskExitMarker(env: NodeJS.ProcessEnv = process.env): void {
+	if (!env.SUMOCODE_TASK_EXIT_FILE) return;
+	process.once("exit", (code) => writeTaskExitMarker(typeof code === "number" ? code : 0, env));
+}
+
 const STATUS_KEY = "sumocode-task-auto-exit";
 const DEFAULT_GRACE_MS = 10_000;
 const TICK_MS = 1_000;
@@ -145,9 +160,9 @@ export function installTaskModeAutoExit(pi: ExtensionAPI, options: TaskModeAutoE
 	let pending: { tick: ReturnType<typeof setInterval>; shutdown: ReturnType<typeof setTimeout> } | undefined;
 	let armed = false;
 
+	installTaskExitMarker(options.env ?? process.env);
 	diagLog("install", {
 		graceMs,
-		inCmux: isInCmux(),
 		cmuxSurfaceId: process.env.CMUX_SURFACE_ID,
 		cmuxWorkspaceId: process.env.CMUX_WORKSPACE_ID,
 	});
@@ -160,25 +175,6 @@ export function installTaskModeAutoExit(pi: ExtensionAPI, options: TaskModeAutoE
 		ctx.ui.setStatus(STATUS_KEY, undefined);
 		if (reason === "user") {
 			userTookOver = true;
-		}
-	};
-
-	const closeOwnSurface = async (): Promise<void> => {
-		// `cmux close-surface` with no args defaults to $CMUX_SURFACE_ID, which
-		// is auto-set in every cmux terminal. From inside the child pane this
-		// is the documented way to ask cmux to tear down the surface we are
-		// running in. cmux then signals the pane's leading process; the bash
-		// wrapper and pi both exit cleanly without any process.exit() hack.
-		if (!isInCmux()) {
-			diagLog("close_skipped", { reason: "not_in_cmux" });
-			return;
-		}
-		diagLog("close_invoking", { surface: process.env.CMUX_SURFACE_ID });
-		try {
-			const result = await pi.exec("cmux", ["close-surface"], { timeout: 5000 });
-			diagLog("close_result", { code: result.code, stdout: result.stdout?.slice(0, 200), stderr: result.stderr?.slice(0, 200), killed: result.killed });
-		} catch (error) {
-			diagLog("close_threw", { message: error instanceof Error ? error.message : String(error) });
 		}
 	};
 
@@ -201,6 +197,10 @@ export function installTaskModeAutoExit(pi: ExtensionAPI, options: TaskModeAutoE
 
 	pi.on("agent_end", (event, ctx) => {
 		diagLog("agent_end", { userTookOver, armed });
+		// Always persist the latest completed turn. Completion is keyed off the
+		// real process-exit marker, so response.md can be overwritten safely if a
+		// human takes over and sends follow-up turns before shutdown.
+		persistResponse((event as { messages?: unknown[] }).messages ?? []);
 		if (userTookOver) return;
 		// Only auto-exit on the FIRST agent_end after launch. Subsequent
 		// agent_end events fire because the user typed follow-up prompts
@@ -208,26 +208,21 @@ export function installTaskModeAutoExit(pi: ExtensionAPI, options: TaskModeAutoE
 		if (armed) return;
 		armed = true;
 
-		// Persist the final assistant text to disk so the orchestrator can
-		// harvest the delegated work's output. Best-effort — if SUMOCODE_TASK_RESPONSE_FILE
-		// isn't set (running outside the bg_task pipeline), this no-ops.
-		persistResponse((event as { messages?: unknown[] }).messages ?? []);
-
 		let remaining = Math.ceil(graceMs / 1000);
-		ctx.ui.setStatus(STATUS_KEY, `task done · auto-closing in ${remaining}s · type to cancel`);
+		ctx.ui.setStatus(STATUS_KEY, `task done · exiting in ${remaining}s · type to cancel`);
 		diagLog("timer_armed", { graceMs, remaining });
 
 		const tick = setInterval(() => {
 			remaining -= 1;
 			if (remaining > 0) {
-				ctx.ui.setStatus(STATUS_KEY, `task done · auto-closing in ${remaining}s · type to cancel`);
+				ctx.ui.setStatus(STATUS_KEY, `task done · exiting in ${remaining}s · type to cancel`);
 			}
 		}, TICK_MS);
 
 		const shutdown = setTimeout(() => {
 			diagLog("timer_fired");
 			cancelPending(ctx, "fired");
-			void closeOwnSurface();
+			ctx.shutdown();
 		}, graceMs);
 
 		pending = { tick, shutdown };

--- a/src/task-mode.ts
+++ b/src/task-mode.ts
@@ -112,6 +112,19 @@ export function writeTaskExitMarker(code: number, env: NodeJS.ProcessEnv = proce
 	}
 }
 
+export function writeTaskStartedMarker(env: NodeJS.ProcessEnv = process.env): void {
+	const file = env.SUMOCODE_TASK_STARTED_FILE;
+	if (!file) return;
+	try {
+		writeFileSync(file, `${process.pid}\n`);
+		diagLog("started_marker_written", { file });
+	} catch (error) {
+		diagLog("started_marker_write_failed", {
+			message: error instanceof Error ? error.message : String(error),
+		});
+	}
+}
+
 function installTaskExitMarker(env: NodeJS.ProcessEnv = process.env): void {
 	if (!env.SUMOCODE_TASK_EXIT_FILE) return;
 	process.once("exit", (code) => writeTaskExitMarker(typeof code === "number" ? code : 0, env));
@@ -147,10 +160,16 @@ export function shouldInstallTaskModeAutoExit(options: TaskModeAutoExitOptions =
  * grace-period cycle handles the close.
  */
 export function installTaskModeAutoExit(pi: ExtensionAPI, options: TaskModeAutoExitOptions = {}): void {
+	const env = options.env ?? process.env;
+	if (isActive(env)) {
+		writeTaskStartedMarker(env);
+		installTaskExitMarker(env);
+	}
+
 	if (!shouldInstallTaskModeAutoExit(options)) {
 		diagLog("install_skipped", {
-			taskMode: process.env.SUMOCODE_TASK_MODE,
-			keepOpen: process.env.SUMOCODE_TASK_KEEP_OPEN,
+			taskMode: env.SUMOCODE_TASK_MODE,
+			keepOpen: env.SUMOCODE_TASK_KEEP_OPEN,
 		});
 		return;
 	}
@@ -159,8 +178,6 @@ export function installTaskModeAutoExit(pi: ExtensionAPI, options: TaskModeAutoE
 	let userTookOver = false;
 	let pending: { tick: ReturnType<typeof setInterval>; shutdown: ReturnType<typeof setTimeout> } | undefined;
 	let armed = false;
-
-	installTaskExitMarker(options.env ?? process.env);
 	diagLog("install", {
 		graceMs,
 		cmuxSurfaceId: process.env.CMUX_SURFACE_ID,

--- a/test/integration/session-switch-retained-lifecycle.test.ts
+++ b/test/integration/session-switch-retained-lifecycle.test.ts
@@ -54,7 +54,7 @@ describe("retained lifecycle across session switches", () => {
 		expect(stableChromeIndex).toBeGreaterThan(bootIndex);
 		expect(appReadyIndex).toBeGreaterThanOrEqual(stableChromeIndex);
 		expect(inputReadyIndex).toBeGreaterThanOrEqual(appReadyIndex);
-	});
+	}, 15_000);
 
 	it("does not leave altscreen during /new", async () => {
 		app = spawnPiPty({
@@ -79,5 +79,5 @@ describe("retained lifecycle across session switches", () => {
 		const output = app.getOutput();
 		expect(countOccurrences(output, "\x1b[?1049h")).toBe(1);
 		expect(countOccurrences(output, "\x1b[?1049l")).toBe(0);
-	});
+	}, 15_000);
 });

--- a/test/integration/session-switch-retained-lifecycle.test.ts
+++ b/test/integration/session-switch-retained-lifecycle.test.ts
@@ -32,6 +32,30 @@ describe("retained lifecycle across session switches", () => {
 		app = undefined;
 	});
 
+	it("emits boot and app-ready diagnostics in order on startup", async () => {
+		app = spawnPiPty({
+			args: ["--offline", "--no-extensions", "-e", "./src/extension.ts", "--no-session"],
+			env: retainedModeEnv(),
+		});
+		await app.waitForOutput(/DIVINE INVOCATION/, 12_000);
+		await new Promise((resolve) => setTimeout(resolve, 300));
+
+		const events = readFileSync(retainedModeEnv().SUMO_TUI_DIAG_FILE, "utf8")
+			.split("\n")
+			.filter(Boolean)
+			.map((line) => JSON.parse(line) as { event?: string });
+		const names = events.map((event) => event.event).filter((event): event is string => typeof event === "string");
+		const bootIndex = names.indexOf("boot_screen_frame");
+		const appReadyIndex = names.indexOf("app_ready");
+		const stableChromeIndex = names.indexOf("stable_chrome_ready");
+		const inputReadyIndex = names.indexOf("input_ready");
+
+		expect(bootIndex).toBeGreaterThanOrEqual(0);
+		expect(stableChromeIndex).toBeGreaterThan(bootIndex);
+		expect(appReadyIndex).toBeGreaterThanOrEqual(stableChromeIndex);
+		expect(inputReadyIndex).toBeGreaterThanOrEqual(appReadyIndex);
+	});
+
 	it("does not leave altscreen during /new", async () => {
 		app = spawnPiPty({
 			args: ["--offline", "--no-extensions", "-e", "./src/extension.ts", "--no-session"],

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -72,12 +72,18 @@ describe("Phase 4 slash command pipe", () => {
 			args: ["--offline", "--no-extensions", "-e", "./src/extension.ts", "--no-session"],
 			env: retainedModeEnv(),
 		});
-		await app.waitForOutput(/DIVINE INVOCATION/, 12_000);
+		await app.waitForOutput(/DIVINE INVOCATION/, 20_000);
 
 		app.sendInput("/sumo:worktree build thing");
-		await new Promise((resolve) => setTimeout(resolve, 75));
+		// Wait for the editor to render the full command before submitting, then
+		// clear the 50ms raw-paste CR window (RAW_PASTE_CR_WINDOW_MS in
+		// cathedral-editor.ts) with ample margin. A separate "\r" that lands within
+		// that window is treated as pasted text, not Enter — under CI load the old
+		// fixed 75ms delay was too tight and the command never submitted.
+		await app.waitForOutput(/\/sumo:worktree build thing/, 20_000);
+		await new Promise((resolve) => setTimeout(resolve, 200));
 		app.sendInput("\r");
 
-		await app.waitForOutput(/\/sumo:worktree requires a cmux surface/, 12_000);
-	}, 25_000);
+		await app.waitForOutput(/\/sumo:worktree requires a cmux surface/, 20_000);
+	}, 45_000);
 });

--- a/test/integration/slash-commands.test.ts
+++ b/test/integration/slash-commands.test.ts
@@ -1,5 +1,7 @@
 import type { ExtensionAPI, RegisteredCommand } from "@earendil-works/pi-coding-agent";
-import { describe, expect, it } from "vitest";
+import { pathToFileURL } from "node:url";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { installCommandPalette } from "../../src/command-palette.js";
 import { registerMemoryCommand } from "../../src/memory-editor.js";
 import { registerPersonaCommand } from "../../src/commands/persona.js";
@@ -7,6 +9,7 @@ import { registerSpinnerCommand } from "../../src/commands/spinner.js";
 import { registerTabsCommand } from "../../src/commands/tabs.js";
 import { registerThemeCommand } from "../../src/commands/theme.js";
 import { registerThemeCheckCommand } from "../../src/commands/theme-check.js";
+import { spawnPiPty, type SpawnedPiPty } from "./spawn-pi-pty.js";
 
 function commandRegistry(): { pi: ExtensionAPI; commands: Map<string, Omit<RegisteredCommand, "name" | "sourceInfo">> } {
 	const commands = new Map<string, Omit<RegisteredCommand, "name" | "sourceInfo">>();
@@ -22,7 +25,21 @@ function commandRegistry(): { pi: ExtensionAPI; commands: Map<string, Omit<Regis
 	return { pi, commands };
 }
 
+function retainedModeEnv(): Record<string, string> {
+	return {
+		SUMO_TUI: "1",
+		SUMO_TUI_MODULE: pathToFileURL(resolve(process.cwd(), "sumo-interactive-mode.js")).href,
+		CMUX_WORKSPACE_ID: "",
+		CMUX_SURFACE_ID: "",
+	};
+}
+
 describe("Phase 4 slash command pipe", () => {
+	let app: SpawnedPiPty | undefined;
+	afterEach(() => {
+		app?.cleanup();
+		app = undefined;
+	});
 	it("surfaces all /sumo:* commands for autocomplete providers", () => {
 		const { pi, commands } = commandRegistry();
 
@@ -49,4 +66,18 @@ describe("Phase 4 slash command pipe", () => {
 			"sumo:theme-check",
 		]);
 	});
+
+	it("dispatches /sumo:worktree from the retained editor", async () => {
+		app = spawnPiPty({
+			args: ["--offline", "--no-extensions", "-e", "./src/extension.ts", "--no-session"],
+			env: retainedModeEnv(),
+		});
+		await app.waitForOutput(/DIVINE INVOCATION/, 12_000);
+
+		app.sendInput("/sumo:worktree build thing");
+		await new Promise((resolve) => setTimeout(resolve, 75));
+		app.sendInput("\r");
+
+		await app.waitForOutput(/\/sumo:worktree requires a cmux surface/, 12_000);
+	}, 25_000);
 });


### PR DESCRIPTION
## Summary

- ship the v0.4 worktree fan-out loop in one branch: bg_task hardening, worktree spawn, `/sumo:worktree`, `/sumo:review`, and `/sumo:ship`
- add the v0.4 startup readiness slice: boot/app-ready/stable-chrome/input-ready diagnostics, launcher startup improvements, and a refreshed startup perf snapshot
- add v0.4 docs for fan-out coexistence and pi-cmux command boundary
- bump package version/changelog to 0.4.0 and add image transcript/editor plumbing

## Milestone issue coverage

Closes #267
Closes #268
Closes #269
Closes #270
Closes #271
Closes #272
Closes #273
Closes #274
Closes #275
Closes #276
Closes #277
Closes #278
Closes #279
Closes #280
Closes #282
Closes #286

Already closed milestone issue: #281 was superseded by #282 and is covered by the startup readiness implementation.

Implementation map:

- #267 orientation-aware `/sumo:diff`
- #268/#270 agent success notify gap + real-exit liveness + orchestrator-owned pane lifecycle
- #269 durable bg_task registry + recovery across reload
- #271 agent concurrency cap/backpressure
- #272 bg_task GC + log cap
- #273 shared git worktree module
- #274 `bg_task worktree=true`
- #275 `/sumo:worktree` interactive pane + prune; worktree panes keep task kickoff but disable auto-exit so they remain interactive
- #276 `/sumo:ship` staged commit → push → PR, human-gated
- #277 retained transcript image block plumbing
- #278 editor `[Image N]` paste tokens
- #279 fan-out coexistence decision doc
- #280 pi-cmux compatibility decision doc
- #282 startup boot/readiness metrics and diagnostics
- #286 `/sumo:review` as tracked bg_task

## Verification

Latest local harness on `release/v0.4-milestone`:

- `pnpm test` — 109 files / 1015 tests passed
- `pnpm exec tsc --noEmit && pnpm build` — passed
- `pnpm test:integration` — 19 files / 33 tests passed
- `pnpm visual:ci` — completed; required pass scenarios passed, review-pack scenarios generated at `docs/visual/out/parity/index.html`
- `pnpm render:bible` — 93 mockups rendered successfully
- `node scripts/perf-startup.mjs` — refreshed `docs/perf/startup.md` / `docs/perf/startup.json` with `first-frame`, `boot-screen-frame`, `app-ready`, `stable-chrome`, and `input-ready`
- autoreview: `/Users/dhruvkelawala/.pi/agent/skills/autoreview/scripts/autoreview --mode branch --base origin/main` — clean, no accepted/actionable findings
- GitHub PR checks on `facf9ea` — typecheck/unit, integration, perf, visual-bible, visual-v2, and dead-code report all passed

## Notes

- `visual:ci` still reports several review-compatible visual scenarios as `review`, matching the existing parity workflow; required pass scenarios remain passing.
- Startup perf metrics are report-only, not CI gates.

